### PR TITLE
feat(graph): populate graph token for ISR

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4130,9 +4130,9 @@
       }
     },
     "node_modules/@netlify/functions": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@netlify/functions/-/functions-1.0.0.tgz",
-      "integrity": "sha512-7fnJv3vr8uyyyOYPChwoec6MjzsCw1CoRUO2DhQ1BD6bOyJRlD4DUaOOGlMILB2LCT8P24p5LexEGx8AJb7xdA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@netlify/functions/-/functions-1.1.0.tgz",
+      "integrity": "sha512-XUFC5nt4iLMrDK+6WjYrDOW9h6XGIQlEk3o++xglFbDKc6dsP+k6rjfz3vl0w8S9Oiosxj3uLaPW18szJc1UgA==",
       "dependencies": {
         "is-promise": "^4.0.0"
       },
@@ -22768,10 +22768,10 @@
     },
     "packages/runtime": {
       "name": "@netlify/plugin-nextjs",
-      "version": "4.14.2",
+      "version": "4.15.0",
       "license": "MIT",
       "dependencies": {
-        "@netlify/functions": "^1.0.0",
+        "@netlify/functions": "^1.1.0",
         "@netlify/ipx": "^1.2.0",
         "@vercel/node-bridge": "^2.1.0",
         "chalk": "^4.1.2",
@@ -25595,9 +25595,9 @@
       }
     },
     "@netlify/functions": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@netlify/functions/-/functions-1.0.0.tgz",
-      "integrity": "sha512-7fnJv3vr8uyyyOYPChwoec6MjzsCw1CoRUO2DhQ1BD6bOyJRlD4DUaOOGlMILB2LCT8P24p5LexEGx8AJb7xdA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@netlify/functions/-/functions-1.1.0.tgz",
+      "integrity": "sha512-XUFC5nt4iLMrDK+6WjYrDOW9h6XGIQlEk3o++xglFbDKc6dsP+k6rjfz3vl0w8S9Oiosxj3uLaPW18szJc1UgA==",
       "requires": {
         "is-promise": "^4.0.0"
       }
@@ -25670,7 +25670,7 @@
       "requires": {
         "@delucis/if-env": "^1.1.2",
         "@netlify/build": "^27.11.4",
-        "@netlify/functions": "^1.0.0",
+        "@netlify/functions": "^1.1.0",
         "@netlify/ipx": "^1.2.0",
         "@types/fs-extra": "^9.0.13",
         "@types/jest": "^27.4.1",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -9,7 +9,7 @@
     "manifest.yml"
   ],
   "dependencies": {
-    "@netlify/functions": "^1.0.0",
+    "@netlify/functions": "^1.1.0",
     "@netlify/ipx": "^1.2.0",
     "@vercel/node-bridge": "^2.1.0",
     "chalk": "^4.1.2",

--- a/packages/runtime/src/templates/getHandler.ts
+++ b/packages/runtime/src/templates/getHandler.ts
@@ -132,15 +132,11 @@ const makeHandler = (conf: NextConfig, app, pageRoot, staticManifest: Array<[str
     )
 
     const graphToken = event.netlifyGraphToken
-    if (graphToken) {
-      if (requestMode === 'ssr') {
-        multiValueHeaders['X-Netlify-Graph-Token'] = [graphToken]
-      } else {
-        // Prefix with underscore to help us determine the origin of the token
-        // allows us to write better error messages
-        // eslint-disable-next-line no-underscore-dangle
-        process.env._NETLIFY_GRAPH_TOKEN = graphToken
-      }
+    if (graphToken && requestMode !== 'ssr') {
+      // Prefix with underscore to help us determine the origin of the token
+      // allows us to write better error messages
+      // eslint-disable-next-line no-underscore-dangle
+      process.env._NETLIFY_GRAPH_TOKEN = graphToken
     }
 
     return {

--- a/packages/runtime/src/templates/getHandler.ts
+++ b/packages/runtime/src/templates/getHandler.ts
@@ -130,6 +130,19 @@ const makeHandler = (conf: NextConfig, app, pageRoot, staticManifest: Array<[str
     console.log(
       `[${event.httpMethod}] ${event.path} (${requestMode?.toUpperCase()}${result.ttl > 0 ? ` ${result.ttl}s` : ''})`,
     )
+
+    const graphToken = event.netlifyGraphToken
+    if (graphToken) {
+      if (requestMode === 'ssr') {
+        multiValueHeaders['X-Netlify-Graph-Token'] = [graphToken]
+      } else {
+        // Prefix with underscore to help us determine the origin of the token
+        // allows us to write better error messages
+        // eslint-disable-next-line no-underscore-dangle
+        process.env._NETLIFY_GRAPH_TOKEN = graphToken
+      }
+    }
+
     return {
       ...result,
       multiValueHeaders,

--- a/packages/runtime/src/templates/getHandler.ts
+++ b/packages/runtime/src/templates/getHandler.ts
@@ -138,7 +138,6 @@ const makeHandler = (conf: NextConfig, app, pageRoot, staticManifest: Array<[str
     console.log(
       `[${event.httpMethod}] ${event.path} (${requestMode?.toUpperCase()}${result.ttl > 0 ? ` ${result.ttl}s` : ''})`,
     )
-
     return {
       ...result,
       multiValueHeaders,

--- a/packages/runtime/src/templates/getHandler.ts
+++ b/packages/runtime/src/templates/getHandler.ts
@@ -101,6 +101,14 @@ const makeHandler = (conf: NextConfig, app, pageRoot, staticManifest: Array<[str
     const query = new URLSearchParams(event.queryStringParameters).toString()
     event.path = query ? `${event.path}?${query}` : event.path
 
+    const graphToken = event.netlifyGraphToken
+    if (graphToken && requestMode !== 'ssr') {
+      // Prefix with underscore to help us determine the origin of the token
+      // allows us to write better error messages
+      // eslint-disable-next-line no-underscore-dangle
+      process.env._NETLIFY_GRAPH_TOKEN = graphToken
+    }
+
     const { headers, ...result } = await getBridge(event).launcher(event, context)
 
     // Convert all headers to multiValueHeaders
@@ -130,14 +138,6 @@ const makeHandler = (conf: NextConfig, app, pageRoot, staticManifest: Array<[str
     console.log(
       `[${event.httpMethod}] ${event.path} (${requestMode?.toUpperCase()}${result.ttl > 0 ? ` ${result.ttl}s` : ''})`,
     )
-
-    const graphToken = event.netlifyGraphToken
-    if (graphToken && requestMode !== 'ssr') {
-      // Prefix with underscore to help us determine the origin of the token
-      // allows us to write better error messages
-      // eslint-disable-next-line no-underscore-dangle
-      process.env._NETLIFY_GRAPH_TOKEN = graphToken
-    }
 
     return {
       ...result,


### PR DESCRIPTION
<!--Please tag yourself as the Assignee and netlify/frameworks as the Reviewer -->

### Summary

Allows the `getSecretsForBuild` and `getNetlifyGraphTokenForBuild` functionality to work with ISR in next.js.

Populates an environment variable that graph helpers exported from `@netlify/functions` will be able to read.

### Test plan

Here is an example of it in action: https://bucolic-torte-c9a71a.netlify.app/posts/15
Corresponding code: https://github.com/dwwoelfel/nextjs-blog-theme-9/blob/main/pages/posts/%5Bslug%5D.js#L17

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
