### PR TITLE
chore: retain patched server files

### DIFF
--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -16,7 +16,7 @@ import {
   generateCustomHeaders,
 } from './helpers/config'
 import { updateConfig, writeEdgeFunctions, loadMiddlewareManifest } from './helpers/edge'
-import { moveStaticPages, movePublicFiles, patchNextFiles, unpatchNextFiles } from './helpers/files'
+import { moveStaticPages, movePublicFiles, patchNextFiles } from './helpers/files'
 import { generateFunctions, setupImageFunction, generatePagesResolver } from './helpers/functions'
 import { generateRedirects, generateStaticRedirects } from './helpers/redirects'
 import { shouldSkip, isNextAuthInstalled, getCustomImageResponseHeaders } from './helpers/utils'
@@ -200,7 +200,6 @@ const plugin: NetlifyPlugin = {
 
     warnForProblematicUserRewrites({ basePath, redirects })
     warnForRootRedirects({ appDir })
-    await unpatchNextFiles(basePath)
   },
 }
 module.exports = plugin


### PR DESCRIPTION
<!--Please tag yourself as the Assignee and netlify/frameworks as the Reviewer -->

### Summary

As part of the build process, we patch the next server files to enable certain features. Currently we unpatch the files after the build, to keep things clean. However this means they're not patched when running `ntl dev`. This is a problem if we want to run middleware, which needs the patch to be enabled.

This PR changes it so that the files aren't unpatched. Instead we ensure that if the file has been patched that we use the unpatched version when applying the patch again.

### Test plan

1. Ensure the site builds and that middleware works

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal
![image](https://user-images.githubusercontent.com/213306/184632799-53f5f810-1333-473c-9a67-e8c300409948.png)

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
