### PR TITLE
feat: default edge middleware to on

### DIFF
--- a/demos/middleware/netlify.toml
+++ b/demos/middleware/netlify.toml
@@ -3,9 +3,6 @@ command = "npm run build"
 publish = ".next"
 ignore = "if [ $CACHED_COMMIT_REF == $COMMIT_REF ]; then (exit 1); else git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ../..; fi;"
 
-[build.environment]
-NEXT_USE_NETLIFY_EDGE = "true"
-
 [[plugins]]
 package = "../plugin-wrapper/"
 

--- a/demos/server-components/netlify.toml
+++ b/demos/server-components/netlify.toml
@@ -3,9 +3,6 @@ command = "npm run build"
 publish = ".next"
 ignore = "if [ $CACHED_COMMIT_REF == $COMMIT_REF ]; then (exit 1); else git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ../..; fi;"
 
-[build.environment]
-NEXT_USE_NETLIFY_EDGE = "true"
-
 [[plugins]]
 package = "../plugin-wrapper/"
 

--- a/packages/runtime/src/helpers/edge.ts
+++ b/packages/runtime/src/helpers/edge.ts
@@ -182,7 +182,7 @@ export const writeEdgeFunctions = async (netlifyConfig: NetlifyConfig) => {
   await writeJson(join(edgeFunctionRoot, 'manifest.json'), manifest)
 }
 
-export const updateConfig = async (publish: string) => {
+export const enableEdgeInNextConfig = async (publish: string) => {
   const configFile = join(publish, 'required-server-files.json')
   const config = await readJSON(configFile)
   // This is for runtime in Next.js, rather than a build plugin setting

--- a/packages/runtime/src/helpers/edge.ts
+++ b/packages/runtime/src/helpers/edge.ts
@@ -135,11 +135,9 @@ export const writeEdgeFunctions = async (netlifyConfig: NetlifyConfig) => {
   await emptyDir(edgeFunctionRoot)
 
   if (!process.env.NEXT_DISABLE_EDGE_IMAGES) {
-    if (!process.env.NEXT_USE_NETLIFY_EDGE) {
-      console.log(
-        'Using Netlify Edge Functions for image format detection. Set env var "NEXT_DISABLE_EDGE_IMAGES=true" to disable.',
-      )
-    }
+    console.log(
+      'Using Netlify Edge Functions for image format detection. Set env var "NEXT_DISABLE_EDGE_IMAGES=true" to disable.',
+    )
     const edgeFunctionDir = join(edgeFunctionRoot, 'ipx')
     await ensureDir(edgeFunctionDir)
     await copyEdgeSourceFile({ edgeFunctionDir, file: 'ipx.ts', target: 'index.ts' })
@@ -152,7 +150,7 @@ export const writeEdgeFunctions = async (netlifyConfig: NetlifyConfig) => {
       path: '/_next/image*',
     })
   }
-  if (process.env.NEXT_USE_NETLIFY_EDGE) {
+  if (!process.env.NEXT_DISABLE_NETLIFY_EDGE) {
     const middlewareManifest = await loadMiddlewareManifest(netlifyConfig)
     if (!middlewareManifest) {
       console.error("Couldn't find the middleware manifest")
@@ -187,6 +185,7 @@ export const writeEdgeFunctions = async (netlifyConfig: NetlifyConfig) => {
 export const updateConfig = async (publish: string) => {
   const configFile = join(publish, 'required-server-files.json')
   const config = await readJSON(configFile)
+  // This is for runtime in Next.js, rather than a build plugin setting
   config.config.env.NEXT_USE_NETLIFY_EDGE = 'true'
   await writeJSON(configFile, config)
 }

--- a/packages/runtime/src/helpers/files.ts
+++ b/packages/runtime/src/helpers/files.ts
@@ -60,7 +60,7 @@ export const matchesRewrite = (file: string, rewrites: Rewrites): boolean => {
 }
 
 export const getMiddleware = async (publish: string): Promise<Array<string>> => {
-  if (process.env.NEXT_USE_NETLIFY_EDGE) {
+  if (!process.env.NEXT_DISABLE_NETLIFY_EDGE) {
     return []
   }
   const manifestPath = join(publish, 'server', 'middleware-manifest.json')

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -2,7 +2,7 @@
 import { join, relative } from 'path'
 
 import type { NetlifyPlugin } from '@netlify/build'
-import { greenBright, yellowBright, bold } from 'chalk'
+import { greenBright, bold, redBright } from 'chalk'
 import { existsSync, readFileSync } from 'fs-extra'
 import { outdent } from 'outdent'
 
@@ -15,7 +15,7 @@ import {
   configureHandlerFunctions,
   generateCustomHeaders,
 } from './helpers/config'
-import { updateConfig, writeEdgeFunctions, loadMiddlewareManifest } from './helpers/edge'
+import { enableEdgeInNextConfig, writeEdgeFunctions, loadMiddlewareManifest } from './helpers/edge'
 import { moveStaticPages, movePublicFiles, patchNextFiles } from './helpers/files'
 import { generateFunctions, setupImageFunction, generatePagesResolver } from './helpers/functions'
 import { generateRedirects, generateStaticRedirects } from './helpers/redirects'
@@ -80,6 +80,34 @@ const plugin: NetlifyPlugin = {
       },
     )
 
+    const middlewareManifest = await loadMiddlewareManifest(netlifyConfig)
+
+    let usingEdge = false
+
+    if (Object.keys(middlewareManifest?.functions).length !== 0) {
+      usingEdge = true
+      if (process.env.NEXT_DISABLE_NETLIFY_EDGE) {
+        failBuild(outdent`
+          You are using Next.js experimental edge runtime, but have set NEXT_DISABLE_NETLIFY_EDGE to true. This is not supported.
+          To use edge runtime, remove the env var ${bold`NEXT_DISABLE_NETLIFY_EDGE`}.
+        `)
+      }
+    }
+
+    if (Object.keys(middlewareManifest?.middleware).length !== 0) {
+      usingEdge = true
+      if (process.env.NEXT_DISABLE_NETLIFY_EDGE) {
+        console.log(
+          redBright(outdent`
+            You are using Next.js Middleware without Netlify Edge Functions.
+            This is deprecated because it negatively affects performance and will disable ISR and static rendering.
+            It also disables advanced middleware features from @netlify/next
+            To get the best performance and use Netlify Edge Functions, remove the env var ${bold`NEXT_DISABLE_NETLIFY_EDGE`}.
+          `),
+        )
+      }
+    }
+
     if (experimental.images) {
       experimentalRemotePatterns = experimental.images.remotePatterns || []
     }
@@ -138,32 +166,15 @@ const plugin: NetlifyPlugin = {
       buildId,
     })
 
-    if (!process.env.NEXT_DISABLE_NETLIFY_EDGE) {
+    if (usingEdge) {
       await writeEdgeFunctions(netlifyConfig)
 
-      await updateConfig(publish)
-    }
+      await enableEdgeInNextConfig(publish)
 
-    const middlewareManifest = await loadMiddlewareManifest(netlifyConfig)
-    if (
-      Object.keys(middlewareManifest?.middleware).length !== 0 ||
-      Object.keys(middlewareManifest?.functions).length !== 0
-    ) {
-      if (process.env.NEXT_DISABLE_NETLIFY_EDGE) {
-        console.log(
-          yellowBright(outdent`
-            You are using Next.js Middleware without Netlify Edge Functions.
-            This is deprecated because it negatively affects performance and will disable ISR and static rendering.
-            It also disables advanced middleware features from @netlify/next
-            To get the best performance and use Netlify Edge Functions, remove the env var ${bold`NEXT_DISABLE_NETLIFY_EDGE`}.
-          `),
-        )
-      } else {
-        console.log(outdent`
-          ✨ Deploying middleware and functions to ${greenBright`Netlify Edge Functions`} ✨
-          This feature is in beta. Please share your feedback here: https://ntl.fyi/next-netlify-edge
-        `)
-      }
+      console.log(outdent`
+        ✨ Deploying middleware and functions to ${greenBright`Netlify Edge Functions`} ✨
+        This feature is in beta. Please share your feedback here: https://ntl.fyi/next-netlify-edge
+      `)
     }
   },
 


### PR DESCRIPTION
<!--Please tag yourself as the Assignee and netlify/frameworks as the Reviewer -->

### Summary

Change edge function to opt-out instead of opt-in. To disable it, they must set NEXT_DISABLE_NETLIFY_EDGE to true. If this is set and the site has middleware it will give a warning saying this is deprecated but won;t fail the build. However if the site has edge functions (i.e. edge runtime) then it will fail the build.

I am asking to merge this before I've written the full tests and updated the docs so that we can get a tagged release out asap. I will follow up with tests. Issue here: https://github.com/netlify/next-runtime/issues/1552

### Test plan

1. Visit the middleware and server components deploy previews

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

Fixes #1431

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
