### PR TITLE
chore: revert skipping runtime, revert package name to plugin-nextjs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4266,6 +4266,10 @@
       "integrity": "sha512-ni6R1xdR8EtH0iB8ixGt9ocuboW+Q8eN4ilTX8lfNHS6Y6Q2S+O/aB2n1BnAgv39wopeQsQ2meL9vfEePURl7w==",
       "dev": true
     },
+    "node_modules/@netlify/plugin-nextjs": {
+      "resolved": "packages/runtime",
+      "link": true
+    },
     "node_modules/@netlify/plugins-list": {
       "version": "6.36.0",
       "resolved": "https://registry.npmjs.org/@netlify/plugins-list/-/plugins-list-6.36.0.tgz",
@@ -22954,7 +22958,7 @@
       }
     },
     "packages/runtime": {
-      "name": "@netlify/next-runtime",
+      "name": "@netlify/plugin-nextjs",
       "version": "4.17.0",
       "license": "MIT",
       "dependencies": {
@@ -25850,6 +25854,45 @@
       "resolved": "https://registry.npmjs.org/@netlify/open-api/-/open-api-2.11.0.tgz",
       "integrity": "sha512-ni6R1xdR8EtH0iB8ixGt9ocuboW+Q8eN4ilTX8lfNHS6Y6Q2S+O/aB2n1BnAgv39wopeQsQ2meL9vfEePURl7w==",
       "dev": true
+    },
+    "@netlify/plugin-nextjs": {
+      "version": "file:packages/runtime",
+      "requires": {
+        "@delucis/if-env": "^1.1.2",
+        "@netlify/build": "^27.14.0",
+        "@netlify/functions": "^1.2.0",
+        "@netlify/ipx": "^1.2.2",
+        "@types/fs-extra": "^9.0.13",
+        "@types/jest": "^27.4.1",
+        "@types/node": "^17.0.25",
+        "@vercel/node-bridge": "^2.1.0",
+        "chalk": "^4.1.2",
+        "fs-extra": "^10.0.0",
+        "globby": "^11.0.4",
+        "moize": "^6.1.0",
+        "next": "^12.2.0",
+        "node-fetch": "^2.6.6",
+        "node-stream-zip": "^1.15.0",
+        "npm-run-all": "^4.1.5",
+        "outdent": "^0.8.0",
+        "p-limit": "^3.1.0",
+        "pathe": "^0.2.0",
+        "pretty-bytes": "^5.6.0",
+        "semver": "^7.3.5",
+        "slash": "^3.0.0",
+        "tiny-glob": "^0.2.9",
+        "typescript": "^4.6.3"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
     },
     "@netlify/plugins-list": {
       "version": "6.36.0",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@netlify/next-runtime",
+  "name": "@netlify/plugin-nextjs",
   "version": "4.17.0",
   "description": "Run Next.js seamlessly on Netlify",
   "main": "lib/index.js",

--- a/packages/runtime/src/helpers/utils.ts
+++ b/packages/runtime/src/helpers/utils.ts
@@ -179,19 +179,8 @@ export const findModuleFromBase = ({ paths, candidates }): string | null => {
 
 export const isNextAuthInstalled = (): boolean => {
   try {
-    // eslint-disable-next-line import/no-unassigned-import, n/no-extraneous-require, import/no-extraneous-dependencies
+    // eslint-disable-next-line import/no-unassigned-import
     require('next-auth')
-    return true
-  } catch {
-    // Ignore the MODULE_NOT_FOUND error
-    return false
-  }
-}
-
-export const isOldPluginInstalled = (): boolean => {
-  try {
-    // eslint-disable-next-line import/no-unassigned-import, n/no-missing-require, import/no-unresolved
-    require('@netlify/plugin-nextjs')
     return true
   } catch {
     // Ignore the MODULE_NOT_FOUND error

--- a/packages/runtime/src/helpers/utils.ts
+++ b/packages/runtime/src/helpers/utils.ts
@@ -179,7 +179,7 @@ export const findModuleFromBase = ({ paths, candidates }): string | null => {
 
 export const isNextAuthInstalled = (): boolean => {
   try {
-    // eslint-disable-next-line import/no-unassigned-import
+    // eslint-disable-next-line import/no-unassigned-import, import/no-extraneous-dependencies, n/no-extraneous-require
     require('next-auth')
     return true
   } catch {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -19,7 +19,7 @@ import { updateConfig, writeEdgeFunctions, loadMiddlewareManifest } from './help
 import { moveStaticPages, movePublicFiles, patchNextFiles } from './helpers/files'
 import { generateFunctions, setupImageFunction, generatePagesResolver } from './helpers/functions'
 import { generateRedirects, generateStaticRedirects } from './helpers/redirects'
-import { shouldSkip, isNextAuthInstalled, isOldPluginInstalled, getCustomImageResponseHeaders } from './helpers/utils'
+import { shouldSkip, isNextAuthInstalled, getCustomImageResponseHeaders } from './helpers/utils'
 import {
   verifyNetlifyBuildVersion,
   checkNextSiteHasBuilt,
@@ -39,10 +39,6 @@ const plugin: NetlifyPlugin = {
       cache,
     },
   }) {
-    if (isOldPluginInstalled()) {
-      return
-    }
-
     const { publish } = netlifyConfig.build
     if (shouldSkip()) {
       await restoreCache({ cache, publish })
@@ -69,7 +65,7 @@ const plugin: NetlifyPlugin = {
       build: { failBuild },
     },
   }) {
-    if (isOldPluginInstalled() || shouldSkip()) {
+    if (shouldSkip()) {
       return
     }
     const { publish } = netlifyConfig.build
@@ -181,14 +177,6 @@ const plugin: NetlifyPlugin = {
     constants: { FUNCTIONS_DIST },
   }) {
     await saveCache({ cache, publish })
-
-    if (isOldPluginInstalled()) {
-      status.show({
-        summary:
-          'Please remove @netlify/plugin-nextjs from your site. It is no longer required and will prevent you using new features. Learn more: https://ntl.fyi/3w85e2E',
-      })
-      return
-    }
 
     if (shouldSkip()) {
       status.show({

--- a/test/index.js
+++ b/test/index.js
@@ -2,7 +2,6 @@ jest.mock('../packages/runtime/src/helpers/utils', () => {
   return {
     ...jest.requireActual('../packages/runtime/src/helpers/utils'),
     isNextAuthInstalled: jest.fn(),
-    isOldPluginInstalled: jest.fn(),
   }
 })
 
@@ -34,6 +33,8 @@ const {
 } = require('../packages/runtime/src/helpers/config')
 const { dirname } = require('path')
 const { getProblematicUserRewrites } = require('../packages/runtime/src/helpers/verification')
+const { onPostBuild } = require('../packages/runtime/lib')
+const { basePath } = require('../demos/next-i18next/next.config')
 
 const chance = new Chance()
 const FIXTURES_DIR = `${__dirname}/fixtures`
@@ -561,47 +562,6 @@ describe('onBuild()', () => {
 })
 
 describe('onPostBuild', () => {
-  const { isOldPluginInstalled } = require('../packages/runtime/src/helpers/utils')
-
-  test('show warning message to remove old plugin', async () => {
-    isOldPluginInstalled.mockImplementation(() => {
-      return true
-    })
-    const mockStatusFunc = jest.fn()
-
-    await nextRuntime.onPostBuild({
-      ...defaultArgs,
-      utils: { ...utils, status: { show: mockStatusFunc } },
-    })
-
-    expect(mockStatusFunc).toHaveBeenCalledWith({
-      summary:
-        'Please remove @netlify/plugin-nextjs from your site. It is no longer required and will prevent you using new features. Learn more: https://ntl.fyi/3w85e2E',
-    })
-  })
-
-  test('does not show warning message to remove old plugin', async () => {
-    isOldPluginInstalled.mockImplementation(() => {
-      return false
-    })
-    const mockStatusFunc = jest.fn()
-    await moveNextDist()
-
-    await nextRuntime.onPostBuild({
-      ...defaultArgs,
-      utils: {
-        ...utils,
-        status: { show: mockStatusFunc },
-        functions: { list: jest.fn().mockResolvedValue([]) },
-      },
-    })
-
-    expect(mockStatusFunc).not.toHaveBeenCalledWith({
-      summary:
-        'Please remove @netlify/plugin-nextjs from your site. It is no longer required and will prevent you using new features.',
-    })
-  })
-
   test('saves cache with right paths', async () => {
     await moveNextDist()
 


### PR DESCRIPTION
<!--Please tag yourself as the Assignee and netlify/frameworks as the Reviewer -->

### Summary

Reverts https://github.com/netlify/next-runtime/pull/1536, and changes the npm package name to `@netlify/plugin-nextjs` in the package's package.json
