### PR TITLE
chore: revert runtime dep name in demos

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -44,7 +44,7 @@ body:
     id: runtime-version
     attributes:
       label: Next Runtime version
-      description: The version of `@netlify/next-runtime` that you are using. (This is in the build logs)
+      description: The version of `@netlify/plugin-nextjs` that you are using. (This is in the build logs)
       placeholder: x.x.x
     validations:
       required: true

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 # Next.js Runtime
 
 <p align="center">
-  <a aria-label="npm version" href="https://www.npmjs.com/package/@netlify/next-runtime">
-    <img alt="" src="https://img.shields.io/npm/v/@netlify/next-runtime">
+  <a aria-label="npm version" href="https://www.npmjs.com/package/@netlify/plugin-nextjs">
+    <img alt="" src="https://img.shields.io/npm/v/@netlify/plugin-nextjs">
   </a>
-  <a aria-label="MIT License" href="https://img.shields.io/npm/l/@netlify/next-runtime">
-    <img alt="" src="https://img.shields.io/npm/l/@netlify/next-runtime">
+  <a aria-label="MIT License" href="https://img.shields.io/npm/l/@netlify/plugin-nextjs">
+    <img alt="" src="https://img.shields.io/npm/l/@netlify/plugin-nextjs">
   </a>
 </p>
 
@@ -115,14 +115,14 @@ Edge runtime or middleware is enabled it will also generate edge functions for m
 The Next.js Runtime installs automatically for new Next.js sites on Netlify. You can also install it manually like this:
 
 ```shell
-npm install -D @netlify/next-runtime
+npm install -D @netlify/plugin-nextjs
 ```
 
 ...then add the following to your `netlify.toml` file:
 
 ```toml
 [[plugins]]
-package = "@netlify/next-runtime"
+package = "@netlify/plugin-nextjs"
 ```
 
 ## Manually upgrading from an older version of the Next.js Runtime

--- a/demos/base-path/local-plugin/manifest.yml
+++ b/demos/base-path/local-plugin/manifest.yml
@@ -1,1 +1,1 @@
-name: '@netlify/next-runtime-local'
+name: '@netlify/plugin-nextjs-local'

--- a/demos/base-path/package.json
+++ b/demos/base-path/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "devDependencies": {
-    "@netlify/next-runtime": "*",
+    "@netlify/plugin-nextjs": "*",
     "@types/fs-extra": "^9.0.13",
     "@types/jest": "^27.4.1",
     "@types/node": "^17.0.25",

--- a/demos/custom-routes/package.json
+++ b/demos/custom-routes/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "devDependencies": {
-    "@netlify/next-runtime": "*",
+    "@netlify/plugin-nextjs": "*",
     "@types/fs-extra": "^9.0.13",
     "@types/jest": "^27.4.1",
     "@types/node": "^17.0.25",

--- a/demos/default/package.json
+++ b/demos/default/package.json
@@ -25,7 +25,7 @@
     "react-dom": "^18.0.0"
   },
   "devDependencies": {
-    "@netlify/next-runtime": "*",
+    "@netlify/plugin-nextjs": "*",
     "@types/fs-extra": "^9.0.13",
     "@types/jest": "^27.4.1",
     "@types/node": "^17.0.25",

--- a/demos/middleware/package.json
+++ b/demos/middleware/package.json
@@ -9,7 +9,7 @@
     "ntl": "ntl-internal"
   },
   "dependencies": {
-    "@netlify/next-runtime": "*",
+    "@netlify/plugin-nextjs": "*",
     "@netlify/next": "*",
     "next": "^12.2.0",
     "react": "18.0.0",

--- a/demos/next-export/package.json
+++ b/demos/next-export/package.json
@@ -6,7 +6,7 @@
     "next": "^12.2.0"
   },
   "devDependencies": {
-    "@netlify/next-runtime": "*",
+    "@netlify/plugin-nextjs": "*",
     "@types/fs-extra": "^9.0.13",
     "@types/jest": "^27.4.1",
     "@types/node": "^17.0.25",

--- a/demos/nx-next-monorepo-demo/local-plugin/manifest.yml
+++ b/demos/nx-next-monorepo-demo/local-plugin/manifest.yml
@@ -1,1 +1,1 @@
-name: '@netlify/next-runtime-local'
+name: '@netlify/plugin-nextjs-local'

--- a/demos/plugin-wrapper/package.json
+++ b/demos/plugin-wrapper/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {
-    "@netlify/next-runtime": "*",
+    "@netlify/plugin-nextjs": "*",
     "@types/fs-extra": "^9.0.13",
     "@types/jest": "^27.4.1",
     "@types/node": "^17.0.25",

--- a/demos/server-components/package.json
+++ b/demos/server-components/package.json
@@ -16,7 +16,7 @@
     "react-dom": "^18.0.0"
   },
   "devDependencies": {
-    "@netlify/next-runtime": "*",
+    "@netlify/plugin-nextjs": "*",
     "@types/fs-extra": "^9.0.13",
     "@types/jest": "^27.4.1",
     "@types/node": "^17.0.25",

--- a/demos/static-root/local-plugin/manifest.yml
+++ b/demos/static-root/local-plugin/manifest.yml
@@ -1,1 +1,1 @@
-name: '@netlify/next-runtime-local'
+name: '@netlify/plugin-nextjs-local'

--- a/demos/static-root/package.json
+++ b/demos/static-root/package.json
@@ -6,7 +6,7 @@
     "next": "^12.2.0"
   },
   "devDependencies": {
-    "@netlify/next-runtime": "*",
+    "@netlify/plugin-nextjs": "*",
     "@types/fs-extra": "^9.0.13",
     "@types/jest": "^27.4.1",
     "@types/node": "^17.0.25",

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "next": "^12.2.0"
       },
       "devDependencies": {
-        "@netlify/next-runtime": "*",
+        "@netlify/plugin-nextjs": "*",
         "@types/fs-extra": "^9.0.13",
         "@types/jest": "^27.4.1",
         "@types/node": "^17.0.25",
@@ -84,7 +84,7 @@
         "next": "^12.2.0"
       },
       "devDependencies": {
-        "@netlify/next-runtime": "*",
+        "@netlify/plugin-nextjs": "*",
         "@types/fs-extra": "^9.0.13",
         "@types/jest": "^27.4.1",
         "@types/node": "^17.0.25",
@@ -118,7 +118,7 @@
         "react-dom": "^18.0.0"
       },
       "devDependencies": {
-        "@netlify/next-runtime": "*",
+        "@netlify/plugin-nextjs": "*",
         "@types/fs-extra": "^9.0.13",
         "@types/jest": "^27.4.1",
         "@types/node": "^17.0.25",
@@ -190,7 +190,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@netlify/next": "*",
-        "@netlify/next-runtime": "*",
+        "@netlify/plugin-nextjs": "*",
         "next": "^12.2.0",
         "react": "18.0.0",
         "react-dom": "18.0.0"
@@ -249,7 +249,7 @@
         "next": "^12.2.0"
       },
       "devDependencies": {
-        "@netlify/next-runtime": "*",
+        "@netlify/plugin-nextjs": "*",
         "@types/fs-extra": "^9.0.13",
         "@types/jest": "^27.4.1",
         "@types/node": "^17.0.25",
@@ -264,7 +264,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@netlify/next-runtime": "*",
+        "@netlify/plugin-nextjs": "*",
         "@types/fs-extra": "^9.0.13",
         "@types/jest": "^27.4.1",
         "@types/node": "^17.0.25",
@@ -284,7 +284,7 @@
         "react-dom": "^18.0.0"
       },
       "devDependencies": {
-        "@netlify/next-runtime": "*",
+        "@netlify/plugin-nextjs": "*",
         "@types/fs-extra": "^9.0.13",
         "@types/jest": "^27.4.1",
         "@types/node": "^17.0.25",
@@ -301,7 +301,7 @@
         "next": "^12.2.0"
       },
       "devDependencies": {
-        "@netlify/next-runtime": "*",
+        "@netlify/plugin-nextjs": "*",
         "@types/fs-extra": "^9.0.13",
         "@types/jest": "^27.4.1",
         "@types/node": "^17.0.25",
@@ -4231,10 +4231,6 @@
     },
     "node_modules/@netlify/next": {
       "resolved": "packages/next",
-      "link": true
-    },
-    "node_modules/@netlify/next-runtime": {
-      "resolved": "packages/runtime",
       "link": true
     },
     "node_modules/@netlify/open-api": {
@@ -25785,45 +25781,6 @@
         "typescript": "^4.6.3"
       }
     },
-    "@netlify/next-runtime": {
-      "version": "file:packages/runtime",
-      "requires": {
-        "@delucis/if-env": "^1.1.2",
-        "@netlify/build": "^27.14.0",
-        "@netlify/functions": "^1.2.0",
-        "@netlify/ipx": "^1.2.2",
-        "@types/fs-extra": "^9.0.13",
-        "@types/jest": "^27.4.1",
-        "@types/node": "^17.0.25",
-        "@vercel/node-bridge": "^2.1.0",
-        "chalk": "^4.1.2",
-        "fs-extra": "^10.0.0",
-        "globby": "^11.0.4",
-        "moize": "^6.1.0",
-        "next": "^12.2.0",
-        "node-fetch": "^2.6.6",
-        "node-stream-zip": "^1.15.0",
-        "npm-run-all": "^4.1.5",
-        "outdent": "^0.8.0",
-        "p-limit": "^3.1.0",
-        "pathe": "^0.2.0",
-        "pretty-bytes": "^5.6.0",
-        "semver": "^7.3.5",
-        "slash": "^3.0.0",
-        "tiny-glob": "^0.2.9",
-        "typescript": "^4.6.3"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.3.7",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
-      }
-    },
     "@netlify/open-api": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/@netlify/open-api/-/open-api-2.11.0.tgz",
@@ -27502,7 +27459,7 @@
     "base-path-demo": {
       "version": "file:demos/base-path",
       "requires": {
-        "@netlify/next-runtime": "*",
+        "@netlify/plugin-nextjs": "*",
         "@types/fs-extra": "^9.0.13",
         "@types/jest": "^27.4.1",
         "@types/node": "^17.0.25",
@@ -29253,7 +29210,7 @@
     "custom-routes": {
       "version": "file:demos/custom-routes",
       "requires": {
-        "@netlify/next-runtime": "*",
+        "@netlify/plugin-nextjs": "*",
         "@types/fs-extra": "^9.0.13",
         "@types/jest": "^27.4.1",
         "@types/node": "^17.0.25",
@@ -29583,7 +29540,7 @@
     "default-demo": {
       "version": "file:demos/default",
       "requires": {
-        "@netlify/next-runtime": "*",
+        "@netlify/plugin-nextjs": "*",
         "@reach/dialog": "^0.16.2",
         "@reach/visually-hidden": "^0.16.0",
         "@types/fs-extra": "^9.0.13",
@@ -34327,7 +34284,7 @@
     "local-plugin": {
       "version": "file:demos/plugin-wrapper",
       "requires": {
-        "@netlify/next-runtime": "*",
+        "@netlify/plugin-nextjs": "*",
         "@types/fs-extra": "^9.0.13",
         "@types/jest": "^27.4.1",
         "@types/node": "^17.0.25",
@@ -35109,7 +35066,7 @@
       "version": "file:demos/middleware",
       "requires": {
         "@netlify/next": "*",
-        "@netlify/next-runtime": "*",
+        "@netlify/plugin-nextjs": "*",
         "@types/fs-extra": "^9.0.13",
         "@types/jest": "^27.4.1",
         "@types/node": "^17.0.25",
@@ -35553,7 +35510,7 @@
     "next-export-demo": {
       "version": "file:demos/next-export",
       "requires": {
-        "@netlify/next-runtime": "*",
+        "@netlify/plugin-nextjs": "*",
         "@types/fs-extra": "^9.0.13",
         "@types/jest": "^27.4.1",
         "@types/node": "^17.0.25",
@@ -37885,7 +37842,7 @@
     "server-components": {
       "version": "file:demos/server-components",
       "requires": {
-        "@netlify/next-runtime": "*",
+        "@netlify/plugin-nextjs": "*",
         "@types/fs-extra": "^9.0.13",
         "@types/jest": "^27.4.1",
         "@types/node": "^17.0.25",
@@ -38470,7 +38427,7 @@
     "static-root-demo": {
       "version": "file:demos/static-root",
       "requires": {
-        "@netlify/next-runtime": "*",
+        "@netlify/plugin-nextjs": "*",
         "@types/fs-extra": "^9.0.13",
         "@types/jest": "^27.4.1",
         "@types/node": "^17.0.25",


### PR DESCRIPTION
<!--Please tag yourself as the Assignee and netlify/frameworks as the Reviewer -->

### Summary

We've backed-out the runtime name. This reverts the dependencies in the demos.

### Test plan

1. Ensure all demo sites build

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal
![capy and guinea](https://user-images.githubusercontent.com/213306/185305281-7592ef73-7cd0-4939-9f1c-0011e587ba46.png)

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
