### PR TITLE
fix: handle missing config base

### DIFF
--- a/packages/runtime/src/helpers/dev.ts
+++ b/packages/runtime/src/helpers/dev.ts
@@ -9,18 +9,17 @@ import { patchNextFiles } from './files'
 
 // The types haven't been updated yet
 export const onPreDev: OnPreBuild = async ({ constants, netlifyConfig }) => {
+  const base = netlifyConfig.build.base ?? process.cwd()
+
   // Need to patch the files, because build might not have been run
-  await patchNextFiles(resolve(netlifyConfig.build.publish, '..'))
+  await patchNextFiles(base)
 
   //  Clean up old functions
   await unlink(resolve('.netlify', 'middleware.js')).catch(() => {
     // Ignore if it doesn't exist
   })
   await writeDevEdgeFunction(constants)
-  if (
-    !existsSync(resolve(netlifyConfig.build.base, 'middleware.ts')) &&
-    !existsSync(resolve(netlifyConfig.build.base, 'middleware.js'))
-  ) {
+  if (!existsSync(resolve(base, 'middleware.ts')) && !existsSync(resolve(base, 'middleware.js'))) {
     console.log(
       "No middleware found. Create a 'middleware.ts' or 'middleware.js' file in your project root to add custom middleware.",
     )
@@ -34,8 +33,8 @@ export const onPreDev: OnPreBuild = async ({ constants, netlifyConfig }) => {
     `--format=esm`,
     '--watch',
     // Watch for both, because it can have either ts or js
-    resolve(netlifyConfig.build.base, 'middleware.ts'),
-    resolve(netlifyConfig.build.base, 'middleware.js'),
+    resolve(base, 'middleware.ts'),
+    resolve(base, 'middleware.js'),
   ])
 
   childProcess.stdout.pipe(process.stdout)

--- a/packages/runtime/src/helpers/edge.ts
+++ b/packages/runtime/src/helpers/edge.ts
@@ -144,7 +144,7 @@ export const writeDevEdgeFunction = async ({
 
   const edgeFunctionDir = join(edgeFunctionRoot, 'next-dev')
   await ensureDir(edgeFunctionDir)
-  await copyEdgeSourceFile({ edgeFunctionDir, file: 'next-dev.ts', target: 'index.ts' })
+  await copyEdgeSourceFile({ edgeFunctionDir, file: 'next-dev.js', target: 'index.js' })
   await copyEdgeSourceFile({ edgeFunctionDir, file: 'utils.ts' })
 }
 

--- a/packages/runtime/src/templates/edge/next-dev.js
+++ b/packages/runtime/src/templates/edge/next-dev.js
@@ -1,81 +1,12 @@
-import type { Context } from 'https://edge.netlify.com'
 import { NextRequest, NextResponse } from 'https://esm.sh/next/server'
 import { fromFileUrl } from 'https://deno.land/std/path/mod.ts'
 import { buildResponse } from './utils.ts'
-
-export interface FetchEventResult {
-  response: Response
-  waitUntil: Promise<unknown>
-}
-
-interface I18NConfig {
-  defaultLocale: string
-  domains?: DomainLocale[]
-  localeDetection?: false
-  locales: string[]
-}
-
-interface DomainLocale {
-  defaultLocale: string
-  domain: string
-  http?: true
-  locales?: string[]
-}
-export interface NextRequestInit extends RequestInit {
-  geo?: {
-    city?: string
-    country?: string
-    region?: string
-  }
-  ip?: string
-  nextConfig?: {
-    basePath?: string
-    i18n?: I18NConfig | null
-    trailingSlash?: boolean
-  }
-}
-
-export interface RequestData {
-  geo?: {
-    city?: string
-    country?: string
-    region?: string
-    latitude?: string
-    longitude?: string
-  }
-  headers: Record<string, string>
-  ip?: string
-  method: string
-  nextConfig?: {
-    basePath?: string
-    i18n?: Record<string, unknown>
-    trailingSlash?: boolean
-  }
-  page?: {
-    name?: string
-    params?: { [key: string]: string }
-  }
-  url: string
-  body?: ReadableStream<Uint8Array>
-}
-
-export interface RequestContext {
-  request: Request
-  context: Context
-}
-
-declare global {
-  // deno-lint-ignore no-var
-  var NFRequestContextMap: Map<string, RequestContext>
-  // deno-lint-ignore no-var
-  var __dirname: string
-}
 
 globalThis.NFRequestContextMap ||= new Map()
 globalThis.__dirname = fromFileUrl(new URL('./', import.meta.url)).slice(0, -1)
 
 // Check if a file exists, given a relative path
-const exists = async (relativePath: string) => {
+const exists = async (relativePath) => {
   const path = fromFileUrl(new URL(relativePath, import.meta.url))
   try {
     await Deno.stat(path)
@@ -88,7 +19,7 @@ const exists = async (relativePath: string) => {
   }
 }
 
-const handler = async (req: Request, context: Context) => {
+const handler = async (req, context) => {
   // Uncomment when CLI update lands
   // if (!Deno.env.get('NETLIFY_DEV')) {
   //   // Only run in dev
@@ -111,7 +42,7 @@ const handler = async (req: Request, context: Context) => {
   }
 
   //  This is the format expected by Next.js
-  const geo: NextRequestInit['geo'] = {
+  const geo = {
     country: context.geo.country?.code,
     region: context.geo.subdivision?.code,
     city: context.geo.city,
@@ -125,7 +56,7 @@ const handler = async (req: Request, context: Context) => {
     context,
   })
 
-  const request: NextRequestInit = {
+  const request = {
     headers: Object.fromEntries(req.headers.entries()),
     geo,
     method: req.method,
@@ -133,7 +64,7 @@ const handler = async (req: Request, context: Context) => {
     body: req.body || undefined,
   }
 
-  const nextRequest: NextRequest = new NextRequest(req, request)
+  const nextRequest = new NextRequest(req, request)
 
   try {
     const response = await middleware(nextRequest)


### PR DESCRIPTION
<!--Please tag yourself as the Assignee and netlify/frameworks as the Reviewer -->

### Summary

In unliked sites, `netlifyConfig.build.base` is unset, so we default to `process.cwd()`. Also use JS for the dev edge function because of Deno type conflicts in next.
