### PR TITLE
fix: ensure newly-created middleware works

### DIFF
--- a/packages/runtime/src/helpers/dev.ts
+++ b/packages/runtime/src/helpers/dev.ts
@@ -31,6 +31,7 @@ export const onPreDev: OnPreBuild = async ({ constants, netlifyConfig }) => {
     `--bundle`,
     `--outdir=${resolve('.netlify')}`,
     `--format=esm`,
+    `--target=esnext`,
     '--watch',
     // Watch for both, because it can have either ts or js
     resolve(base, 'middleware.ts'),

--- a/packages/runtime/src/helpers/dev.ts
+++ b/packages/runtime/src/helpers/dev.ts
@@ -27,18 +27,14 @@ export const onPreDev: OnPreBuild = async ({ constants, netlifyConfig }) => {
     console.log('Watching for changes in Next.js middleware...')
   }
   // Eventually we might want to do this via esbuild's API, but for now the CLI works fine
-  const childProcess = execa(`esbuild`, [
-    `--bundle`,
-    `--outdir=${resolve('.netlify')}`,
-    `--format=esm`,
-    `--target=esnext`,
-    '--watch',
-    // Watch for both, because it can have either ts or js
-    resolve(base, 'middleware.ts'),
-    resolve(base, 'middleware.js'),
-  ])
 
-  childProcess.stdout.pipe(process.stdout)
-  childProcess.stderr.pipe(process.stderr)
+  const common = [`--bundle`, `--outdir=${resolve('.netlify')}`, `--format=esm`, `--target=esnext`, '--watch']
+
+  // TypeScript
+  execa(`esbuild`, [...common, resolve(base, 'middleware.ts')], { all: true }).all.pipe(process.stdout)
+
+  // JavaScript
+  execa(`esbuild`, [...common, resolve(base, 'middleware.js')], { all: true }).all.pipe(process.stdout)
+
   // Don't return the promise because we don't want to wait for the child process to finish
 }

--- a/packages/runtime/src/templates/edge/next-dev.js
+++ b/packages/runtime/src/templates/edge/next-dev.js
@@ -19,6 +19,7 @@ const exists = async (relativePath) => {
     throw error
   }
 }
+let idx = 0
 
 const handler = async (req, context) => {
   // Uncomment when CLI update lands
@@ -34,8 +35,9 @@ const handler = async (req, context) => {
   // because that would also throw if there's an error in the middleware,
   // which we would want to surface not ignore.
   if (await exists('../../middleware.js')) {
-    // These will be user code
-    const nextMiddleware = await import('../../middleware.js')
+    // We need to cache-bust the import because otherwise it will claim it
+    // doesn't exist if the user creates it after the server starts
+    const nextMiddleware = await import(`../../middleware.js#${idx++}`)
     middleware = nextMiddleware.middleware
   } else {
     //  No middleware, so we silently return


### PR DESCRIPTION
<!--Please tag yourself as the Assignee and netlify/frameworks as the Reviewer -->

### Summary

Currently when running `ntl dev`, if there isn't any middleware when you start the server and then create one, even though the file is correctly compiled, the middleware isn't imported until a restart because Deno has cached the "fact" that it's missing. It correctly updates any changes if the middleware already exists at the time the server starts.

This PR adds a cache-busting hash to the import URL, which ensures it try to load dynamically on every request.

Published as `@netlify/plugin-nextjs@4.17.1-runtime.4`

### Test plan

1. Install `@netlify/plugin-nextjs@4.17.1-runtime.4` in a new Next.js project
2. start `ntl dev`
3. Add a `middleware.ts`, such as the one below
4. Reload the page and check it works

```typescript
import { NextResponse } from 'next/server'

export async function middleware(req) {
    const response = NextResponse.next()
    response.headers.set('x-hello-deno', 'Deno' in globalThis ? 'true' : 'false')
    return response
}
```

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
