### PR TITLE
fix: check for middleware manifest before providing to Object.keys

### DIFF
--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -85,7 +85,7 @@ const plugin: NetlifyPlugin = {
 
     let usingEdge = false
 
-    if (Object.keys(middlewareManifest?.functions).length !== 0) {
+    if (middlewareManifest?.functions && Object.keys(middlewareManifest.functions).length !== 0) {
       usingEdge = true
       if (process.env.NEXT_DISABLE_NETLIFY_EDGE) {
         failBuild(outdent`

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -95,7 +95,7 @@ const plugin: NetlifyPlugin = {
       }
     }
 
-    if (Object.keys(middlewareManifest?.middleware).length !== 0) {
+    if (middlewareManifest?.middleware && Object.keys(middlewareManifest.middleware).length !== 0) {
       usingEdge = true
       if (process.env.NEXT_DISABLE_NETLIFY_EDGE) {
         console.log(


### PR DESCRIPTION
### Summary
Fixes the onBuild error `TypeError: Cannot convert undefined or null to object` when providing a null middlewareManifest, or null middlewareManifest.functions to `Object.keys`. This can happen with Next 11 (no middlewareManifest), and middleware beta (no middlewareManifest.functions)

### Test plan

1. Visit the Deploy Preview ([insert link to specific page]()) ...

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
