### PR TITLE
chore: allow overriding the check for the bundle size

### DIFF
--- a/packages/runtime/src/helpers/verification.ts
+++ b/packages/runtime/src/helpers/verification.ts
@@ -105,6 +105,8 @@ export const checkForRootPublish = ({
 }
 
 export const checkZipSize = async (file: string, maxSize: number = LAMBDA_MAX_SIZE): Promise<void> => {
+  // Experimental: We can skip checking for the bundle size on the plugin side.
+  // Please reach out to the Netlify support team if you'd like to enable this feature
   if (!process.env.NETLIFY_CHECK_BUNDLE_SIZE) {
     console.log('Skipping the bundle size check. Set env var "NETLIFY_CHECK_BUNDLE_SIZE=true" to enable checking the bundle size')
     return

--- a/packages/runtime/src/helpers/verification.ts
+++ b/packages/runtime/src/helpers/verification.ts
@@ -105,6 +105,11 @@ export const checkForRootPublish = ({
 }
 
 export const checkZipSize = async (file: string, maxSize: number = LAMBDA_MAX_SIZE): Promise<void> => {
+  if (!process.env.NETLIFY_CHECK_BUNDLE_SIZE) {
+    console.log('Skipping the bundle size check. Set env var "NETLIFY_CHECK_BUNDLE_SIZE=true" to enable checking the bundle size')
+    return
+  }
+
   if (!existsSync(file)) {
     console.warn(`Could not check zip size because ${file} does not exist`)
     return


### PR DESCRIPTION
### Summary

Skipping the checks for the bundle size are helpful when folks know what kind of bundles they are uploading to Netlify

![image](https://user-images.githubusercontent.com/1770364/186475490-ccf83b71-41ec-4591-9d8f-4e18c0b6137a.png)


---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
