### PR TITLE
feat: allows disabling function size check

### DIFF
--- a/packages/runtime/src/helpers/utils.ts
+++ b/packages/runtime/src/helpers/utils.ts
@@ -196,4 +196,7 @@ export const getCustomImageResponseHeaders = (headers: Header[]): Record<string,
   }
   return null
 }
+
+export const isBundleSizeCheckDisabled = () =>
+  process.env.DISABLE_BUNDLE_ZIP_SIZE_CHECK === '1' || process.env.DISABLE_BUNDLE_ZIP_SIZE_CHECK === 'true'
 /* eslint-enable max-lines */

--- a/packages/runtime/src/helpers/verification.ts
+++ b/packages/runtime/src/helpers/verification.ts
@@ -11,6 +11,8 @@ import { satisfies } from 'semver'
 
 import { LAMBDA_MAX_SIZE } from '../constants'
 
+import { isBundleSizeCheckDisabled } from './utils'
+
 // This is when nft support was added
 const REQUIRED_BUILD_VERSION = '>=18.16.0'
 
@@ -105,6 +107,15 @@ export const checkForRootPublish = ({
 }
 
 export const checkZipSize = async (file: string, maxSize: number = LAMBDA_MAX_SIZE): Promise<void> => {
+  // Requires contacting the Netlify Support team to fully enable.
+  // Enabling this without contacting them can result in failed deploys.
+  if (isBundleSizeCheckDisabled()) {
+    console.warn(
+      'Function bundle size check was DISABLED with the DISABLE_BUNDLE_ZIP_SIZE_CHECK environment. Your deployment will break if it exceeds the maximum supported size of function zip files in your account.',
+    )
+    return
+  }
+
   if (!existsSync(file)) {
     console.warn(`Could not check zip size because ${file} does not exist`)
     return

--- a/packages/runtime/src/helpers/verification.ts
+++ b/packages/runtime/src/helpers/verification.ts
@@ -111,7 +111,7 @@ export const checkZipSize = async (file: string, maxSize: number = LAMBDA_MAX_SI
   // Enabling this without contacting them can result in failed deploys.
   if (isBundleSizeCheckDisabled()) {
     console.warn(
-      'Function bundle size check was DISABLED with the DISABLE_BUNDLE_ZIP_SIZE_CHECK environment. Your deployment will break if it exceeds the maximum supported size of function zip files in your account.',
+      'Function bundle size check was DISABLED with the DISABLE_BUNDLE_ZIP_SIZE_CHECK environment variable. Your deployment will break if it exceeds the maximum supported size of function zip files in your account.',
     )
     return
   }

--- a/test/helpers/verification.spec.ts
+++ b/test/helpers/verification.spec.ts
@@ -9,6 +9,7 @@ const chance = new Chance()
 
 jest.mock('fs', () => {
   return {
+    ...jest.requireActual('fs'),
     existsSync: jest.fn(),
   }
 })
@@ -90,13 +91,12 @@ describe('checkZipSize', () => {
   })
 
   afterEach(() => {
-    jest.restoreAllMocks()
     delete process.env.DISABLE_BUNDLE_ZIP_SIZE_CHECK
   })
 
   it('emits a warning that DISABLE_BUNDLE_ZIP_SIZE_CHECK was enabled', async () => {
-    process.env.DISABLE_BUNDLE_ZIP_SIZE_CHECK = 'false'
+    process.env.DISABLE_BUNDLE_ZIP_SIZE_CHECK = 'true'
     await checkZipSize(chance.string())
-    expect(consoleSpy).toHaveBeenCalledWith('Function bundle size check was DISABLED with the DISABLE_BUNDLE_ZIP_SIZE_CHECK environment. Your deployment will break if it exceeds the maximum supported size of function zip files in your account.')
+    expect(consoleSpy).toHaveBeenCalledWith('Function bundle size check was DISABLED with the DISABLE_BUNDLE_ZIP_SIZE_CHECK environment variable. Your deployment will break if it exceeds the maximum supported size of function zip files in your account.')
   })
 })


### PR DESCRIPTION
### Summary
Replaces #1569

Allows overriding the function bundle size check. This should only be enabled in consultation with someone from the Netlify support team. If enabled, your deployments may break due to exceeding the maximum size limit on the underlying infrastructure that this check is is raising awareness of.

### Test plan

Build a site with `ntl build` and `DISABLE_BUNDLE_ZIP_SIZE_CHECK` enabled. Should see a warning message about this functionality

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal
![penguin](https://user-images.githubusercontent.com/5655473/186509105-5b75cba1-0361-44f0-be10-93ca64413324.png)

