### PR TITLE
feat: only run next-dev middleware in dev

### DIFF
--- a/packages/runtime/src/templates/edge/next-dev.js
+++ b/packages/runtime/src/templates/edge/next-dev.js
@@ -22,11 +22,10 @@ const exists = async (relativePath) => {
 let idx = 0
 
 const handler = async (req, context) => {
-  // Uncomment when CLI update lands
-  // if (!Deno.env.get('NETLIFY_DEV')) {
-  //   // Only run in dev
-  //   return
-  // }
+  if (!Deno.env.get('NETLIFY_DEV')) {
+    // Only run in dev
+    return
+  }
 
   let middleware
   // Dynamic imports and FS operations aren't allowed when deployed,


### PR DESCRIPTION
<!--Please tag yourself as the Assignee and netlify/frameworks as the Reviewer -->

### Summary

Uncommenting this was missed in the launch plan - this solves the immediate issue of the edge function crashing when first running `ntl dev` and then `ntl deploy --build`. There is still other work incoming for the `cli`, but this takes care of the crash.

### Test plan

1. Create a next project, and do a local install of the next runtime (package json and netlify.toml)
2. Run `npm link` in this repo's `packages/runtime` directory
3. In your next project, run `npm link @netlify/plugin-nextjs`
4. In your next project, run `ntl dev`, then cancel out of it
5. In your next project, run `ntl deploy --build`. Wait until it's completed, and view the deployed site - it should show up without a crash message. 

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
