### PR TITLE
fix: remove Next.js as a peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5185,9 +5185,9 @@
       "devOptional": true
     },
     "node_modules/@types/react": {
-      "version": "17.0.48",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.48.tgz",
-      "integrity": "sha512-zJ6IYlJ8cYYxiJfUaZOQee4lh99mFihBoqkOSEGV+dFi9leROW6+PgstzQ+w3gWTnUfskALtQPGHK6dYmPj+2A==",
+      "version": "17.0.49",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.49.tgz",
+      "integrity": "sha512-CCBPMZaPhcKkYUTqFs/hOWqKjPxhTEmnZWjlHHgIMop67DsXywf9B5Os9Hz8KSacjNOgIdnZVJamwl232uxoPg==",
       "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
@@ -22944,7 +22944,7 @@
     },
     "packages/runtime": {
       "name": "@netlify/plugin-nextjs",
-      "version": "4.20.0",
+      "version": "4.21.0",
       "license": "MIT",
       "dependencies": {
         "@netlify/esbuild": "0.14.25",
@@ -22978,9 +22978,6 @@
       },
       "engines": {
         "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "next": "*"
       }
     },
     "packages/runtime/node_modules/execa": {
@@ -26695,9 +26692,9 @@
       "devOptional": true
     },
     "@types/react": {
-      "version": "17.0.48",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.48.tgz",
-      "integrity": "sha512-zJ6IYlJ8cYYxiJfUaZOQee4lh99mFihBoqkOSEGV+dFi9leROW6+PgstzQ+w3gWTnUfskALtQPGHK6dYmPj+2A==",
+      "version": "17.0.49",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.49.tgz",
+      "integrity": "sha512-CCBPMZaPhcKkYUTqFs/hOWqKjPxhTEmnZWjlHHgIMop67DsXywf9B5Os9Hz8KSacjNOgIdnZVJamwl232uxoPg==",
       "devOptional": true,
       "requires": {
         "@types/prop-types": "*",

--- a/packages/next/CHANGELOG.md
+++ b/packages/next/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [1.1.0](https://github.com/netlify/next-runtime/compare/next-v1.0.0...next-v1.1.0) (2022-08-22)
 
-
 ### Features
 
-* add edge middleware support to `ntl dev` ([#1546](https://github.com/netlify/next-runtime/issues/1546)) ([b208ff4](https://github.com/netlify/next-runtime/commit/b208ff463499565d86cc15747b95895b3da18e55))
+- add edge middleware support to `ntl dev` ([#1546](https://github.com/netlify/next-runtime/issues/1546))
+  ([b208ff4](https://github.com/netlify/next-runtime/commit/b208ff463499565d86cc15747b95895b3da18e55))

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -48,9 +48,6 @@
     "watch": "tsc --watch",
     "prepare": "npm run build"
   },
-  "peerDependencies": {
-    "next": "*"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/netlify/next-runtime.git"


### PR DESCRIPTION
### Summary

Removes Next.js as a peer dependency within the runtime package as at times it was leading to multiple version of Next.js being installed, and incompatible versions being bundled with the functions when the project was using an older version.

### Test plan

Deploy preview: https://ep-next-test.netlify.app/

The https://ep-next-test.netlify.app/api/hello route is an SSR route

Test case provided in issue: https://ep-hbo-clone.netlify.app/movie (this should render correctly, no error)

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal
Fixes https://github.com/netlify/pod-ecosystem-frameworks/issues/220
