### PR TITLE
ci: use fossa action

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -6,32 +6,11 @@ on:
       - main
       - chore/fossa-workflow # convenience branch for future fossa tweaks
 
-defaults:
-  run:
-    shell: bash
-
 jobs:
-  fossa:
+  fossa-scan:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Download fossa cli
-        run: |-
-          curl -L https://github.com/fossas/fossa-cli/releases/download/v1.1.2/fossa-cli_1.1.2_linux_amd64.tar.gz > fossa-cli.tar.gz
-              tar -xvzf fossa-cli.tar.gz
-              mkdir -p $HOME/.local/bin
-              echo "$HOME/.local/bin" >> $GITHUB_PATH
-              mv fossa $HOME/.local/bin/fossa
-      - name: Fossa init
-        run: fossa init
-      - name: Set env
-        run: echo "line_number=$(grep -n "project" .fossa.yml | cut -f1 -d:)" >> $GITHUB_ENV
-      - name: Configuration
-        run: |-
-          sed -i "${line_number}s|.*|  project: git@github.com:${GITHUB_REPOSITORY}.git|" .fossa.yml
-          cat .fossa.yml
-      - name: Upload dependencies
-        run: fossa analyze --debug
-        env:
-          FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
+      - uses: actions/checkout@v3
+      - uses: fossas/fossa-action@main # Use a specific version if locking is preferred
+        with:
+          api-key: ${{secrets.FOSSA_API_KEY}}


### PR DESCRIPTION
<!--Please tag yourself as the Assignee and netlify/frameworks as the Reviewer -->

### Summary

Switch fossa scan to use the official fossa action. The existing action is broken