### PR TITLE
Add the option to disable IPX function

### DIFF
--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -152,16 +152,18 @@ const plugin: NetlifyPlugin = {
       netlifyConfig,
       nextConfig: { basePath, i18n },
     })
-
-    await setupImageFunction({
-      constants,
-      imageconfig: images,
-      netlifyConfig,
-      basePath,
-      remotePatterns: getRemotePatterns(experimental, images),
-      responseHeaders: getCustomImageResponseHeaders(netlifyConfig.headers),
-    })
-
+    
+    if (!process.env.DISABLE_IPX) {
+      await setupImageFunction({
+        constants,
+        imageconfig: images,
+        netlifyConfig,
+        basePath,
+        remotePatterns: getRemotePatterns(experimental, images),
+        responseHeaders: getCustomImageResponseHeaders(netlifyConfig.headers),
+      })
+    }
+    
     await generateRedirects({
       netlifyConfig,
       nextConfig: { basePath, i18n, trailingSlash, appDir },


### PR DESCRIPTION
### Summary

Add the option to disable IPX function using DISABLE_IPX env var.

To be honest I would disable IPX by default and give the option to enable it via an env var (Having this enabled by default put Netlify customer at risk of XSS), but this PR does the opposite since it would be a breaking change.