### PR TITLE
fix: correct handling of edge dev utils

### DIFF
--- a/packages/runtime/src/helpers/edge.ts
+++ b/packages/runtime/src/helpers/edge.ts
@@ -177,11 +177,11 @@ export const writeDevEdgeFunction = async ({
   const edgeFunctionRoot = resolve(INTERNAL_EDGE_FUNCTIONS_SRC)
   await emptyDir(edgeFunctionRoot)
   await writeJson(join(edgeFunctionRoot, 'manifest.json'), manifest)
+  await copy(getEdgeTemplatePath('../edge-shared'), join(edgeFunctionRoot, 'edge-shared'))
 
   const edgeFunctionDir = join(edgeFunctionRoot, 'next-dev')
   await ensureDir(edgeFunctionDir)
   await copyEdgeSourceFile({ edgeFunctionDir, file: 'next-dev.js', target: 'index.js' })
-  await copyEdgeSourceFile({ edgeFunctionDir, file: 'utils.ts' })
 }
 
 /**


### PR DESCRIPTION
<!--Please tag yourself as the Assignee and netlify/frameworks as the Reviewer -->

### Summary
Edge utils files have moved, so we need to copy them correctly in the dev function
