### PR TITLE
chore: disable critical css to avoid upstream bug

### DIFF
--- a/demos/default/next.config.js
+++ b/demos/default/next.config.js
@@ -78,7 +78,7 @@ module.exports = {
     includePaths: [path.join(__dirname, 'styles-sass-test')],
   },
   experimental: {
-    optimizeCss: true,
+    optimizeCss: false,
     images: {
       remotePatterns: [
         {

--- a/test/index.js
+++ b/test/index.js
@@ -468,8 +468,6 @@ describe('onBuild()', () => {
       '.next/BUILD_ID',
       '.next/static/chunks/webpack-middleware*.js',
       '!.next/server/**/*.js.nft.json',
-      '.next/static/css/1152424140993be6.css',
-      '.next/static/css/84099ae0bbc955fa.css',
       '!../../node_modules/next/dist/compiled/@ampproject/toolbox-optimizer/**/*',
       `!node_modules/next/dist/server/lib/squoosh/**/*.wasm`,
       `!node_modules/next/dist/next-server/server/lib/squoosh/**/*.wasm`,


### PR DESCRIPTION
### Summary

The Next.js experimental option to inline critical css uses a dependency called [critters](https://github.com/GoogleChromeLabs/critters) that currently has a [bug](https://github.com/GoogleChromeLabs/critters/issues/103) that is adding noise to the build/function logs when testing the default demo site.

We can disable this option for now as there are no plans to add test coverage.

### Test plan

1. Build the default demo site and bask in the serenity of log output without...

```
6 rules skipped due to selector errors:
  .prose :where(hr+*):not(:where([class~=not-prose] *)) -> Cannot read properties of undefined (reading 'type')
  .prose :where(h2+*):not(:where([class~=not-prose] *)) -> Cannot read properties of undefined (reading 'type')
  .prose :where(h3+*):not(:where([class~=not-prose] *)) -> Cannot read properties of undefined (reading 'type')
  .prose :where(h4+*):not(:where([class~=not-prose] *)) -> Cannot read properties of undefined (reading 'type')
  .prose>:where():not(:where([class~=not-prose] *)) -> Empty sub-selector
  .prose>:where():not(:where([class~=not-prose] *)) -> Empty sub-selector
```