### PR TITLE
chore: override semicolon lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -45,6 +45,7 @@ module.exports = {
         // unsupported by Node 12, i.e. optional chaining
         // TODO: re-enable after dropping support for Node 12
         'n/no-unsupported-features/es-syntax': 'off',
+        '@typescript-eslint/no-extra-semi': 'off',
       },
     },
     {


### PR DESCRIPTION
There appears to be a conflict between [`@typescript-eslint/no-extra-semi`](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/configs/recommended.ts#L19) (which is part of the [`@typescript-eslint/recommended`](https://github.com/netlify/eslint-config-node/blob/main/.eslintrc.cjs#L389) config) and the prettier rule [`semi: false`](https://github.com/netlify/eslint-config-node/blob/main/.prettierrc.json#L2).

The [prettier rule](https://prettier.io/docs/en/options.html#semicolons) will add a semicolon in the following instance to protect from [ASI failures](https://prettier.io/docs/en/rationale.html#semicolons).

https://github.com/netlify/next-runtime/blob/main/packages/runtime/src/helpers/config.ts#L95

However, the linter then complains because of the `no-extra-semi` rule.

Since we are removing semicolons anyway, I think we can safely disable the `no-extra-semi` rule.