### PR TITLE
test: fix test to match new minimum ODB TTL logging

### DIFF
--- a/cypress/integration/default/dynamic-routes.spec.ts
+++ b/cypress/integration/default/dynamic-routes.spec.ts
@@ -17,7 +17,7 @@ describe('Static Routing', () => {
   it('renders correct page via ODB on a static route', () => {
     cy.request({ url: '/getStaticProps/with-revalidate/', headers: { 'x-nf-debug-logging': '1' } }).then((res) => {
       expect(res.status).to.eq(200)
-      expect(res.headers).to.have.property('x-nf-render-mode', 'odb ttl=1')
+      expect(res.headers).to.have.property('x-nf-render-mode', 'odb ttl=60')
       expect(res.body).to.contain('Dancing with the Stars')
     })
   })


### PR DESCRIPTION
We recently updated the ODB handler logging to match the minimum TTL enforced by the ODB function itself, but did not update the Cypress test to match. This PR fixes that.