### PR TITLE
feat: use display names for edge functions

### DIFF
--- a/packages/runtime/src/helpers/edge.ts
+++ b/packages/runtime/src/helpers/edge.ts
@@ -129,6 +129,7 @@ const writeEdgeFunction = async ({
 }): Promise<
   Array<{
     function: string
+    name: string
     pattern: string
   }>
 > => {
@@ -162,7 +163,7 @@ const writeEdgeFunction = async ({
   // We add a defintion for each matching path
   return matchers.map((matcher) => {
     const pattern = matcher.regexp
-    return { function: name, pattern }
+    return { function: name, pattern, name: edgeFunctionDefinition.name }
   })
 }
 export const cleanupEdgeFunctions = ({
@@ -176,6 +177,7 @@ export const writeDevEdgeFunction = async ({
     functions: [
       {
         function: 'next-dev',
+        name: 'netlify dev handler',
         path: '/*',
       },
     ],
@@ -226,6 +228,7 @@ export const writeEdgeFunctions = async (netlifyConfig: NetlifyConfig) => {
     )
     manifest.functions.push({
       function: 'ipx',
+      name: 'next/image handler',
       path: '/_next/image*',
     })
   }


### PR DESCRIPTION
<!--Please tag yourself as the Assignee and netlify/frameworks as the Reviewer -->

### Summary

Edge functions now support display names. This PR adds support for these. Aside from the ipx and dev edge funcitons, these just use the name from Next.js, which is the path.

### Test plan

1. Visit a deploy that uses edge functions (e.g. [this one with middleware](https://app.netlify.com/sites/next-plugin-edge-middleware/edge-functions?scope=deployid:634004bb7ee81700098bf533) or [this one with server components](https://app.netlify.com/sites/next-plugin-rsc-demo/edge-functions?scope=deployid:634004bbd73ce8000850da97)
2. View the edge function logs
3. Observe that the list of functions in the filter uses display names (e.g. middleware, next/image handler)

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
