### PR TITLE
feat: cache redirects for 60 seconds if no ttl provided

### DIFF
--- a/packages/runtime/src/templates/getHandler.ts
+++ b/packages/runtime/src/templates/getHandler.ts
@@ -131,8 +131,9 @@ const makeHandler = (conf: NextConfig, app, pageRoot, staticManifest: Array<[str
           // ODBs currently have a minimum TTL of 60 seconds
           result.ttl = Math.max(ttl, 60)
         }
-        // Only cache 404s ephemerally
-        if (ttl === ONE_YEAR_IN_SECONDS && result.statusCode === 404) {
+        const ephemeralCodes = [301, 302, 307, 308, 404]
+        if (ttl === ONE_YEAR_IN_SECONDS && ephemeralCodes.includes(result.statusCode)) {
+          // Only cache for 60s if default TTL provided
           result.ttl = 60
         }
         if (result.ttl > 0) {


### PR DESCRIPTION
### Summary

Next.js uses 307 and 308 codes for its redirects, but our ODB functions currently only invalidate cached content for 200, 301 and 404 codes. This means ISR pages that conditionally return a redirect are not updating as expected.

A fix to Netlify Proxy for the above issue is currently in progress and this PR is a corresponding fix for a specific Next.js case: ISR pages with redirects, but without a `revalidate` value, are returned to the ODB with a default `max-age` of 1 year, which causes the ODB to cache them indefinitely. This PR ensures that redirects without `revalidate` are cached ephemerally for 60s.

### Test plan

~Visit /getStaticProps/with-revalidate-redirect/ on the demo site deploy preview and observe that the page should redirect if the last digit of the current minute is 0-4 and should show a successful 200 response if the last digit is 5-9.~
Unable to create a test page in the default demo because redirect cannot be returned when pre-rendering. Tests to follow in a new demo site.

### Relevant links (GitHub issues, Notion docs, etc.)

netlify/pillar-runtime#443
netlify/proxy#950