### PR TITLE
fix: prevent Next from defining duplicate global property in edge functions

### DIFF
--- a/cypress/integration/middleware/standard.spec.ts
+++ b/cypress/integration/middleware/standard.spec.ts
@@ -43,3 +43,11 @@ describe('Middleware matchers', () => {
     })
   })
 })
+
+describe('Middleware with edge API', () => {
+  it('serves API routes from the edge runtime', () => {
+    cy.request('/api/edge').then((response) => {
+      expect(response.body).to.include('Hello world')
+    })
+  })
+})

--- a/demos/middleware/pages/api/edge.ts
+++ b/demos/middleware/pages/api/edge.ts
@@ -1,0 +1,5 @@
+export const config = {
+  runtime: 'experimental-edge',
+}
+
+export default (req) => new Response('Hello world!')

--- a/package-lock.json
+++ b/package-lock.json
@@ -23348,7 +23348,7 @@
     },
     "packages/runtime": {
       "name": "@netlify/plugin-nextjs",
-      "version": "4.24.3",
+      "version": "4.25.0",
       "license": "MIT",
       "dependencies": {
         "@netlify/esbuild": "0.14.39",

--- a/packages/runtime/src/helpers/edge.ts
+++ b/packages/runtime/src/helpers/edge.ts
@@ -74,7 +74,7 @@ const sanitizeName = (name: string) => `next_${name.replace(/\W/g, '_')}`
 const preamble = /* js */ `
 
 globalThis.process = { env: {...Deno.env.toObject(), NEXT_RUNTIME: 'edge', 'NEXT_PRIVATE_MINIMAL_MODE': '1' } }
-const _ENTRIES = {}
+let _ENTRIES = {}
 // Deno defines "window", but naughty libraries think this means it's a browser
 delete globalThis.window
 // Next uses "self" as a function-scoped global-like object


### PR DESCRIPTION
### Summary

Currently Next.js creates a global function in the edge runtime called `__import_unsupported` by defining it as an immutable property on `globalThis`. This means that if there is more than one of these definitions in a single edge function bundle then there is an error when they both try to define it. This PR patches the generated bundle (yeah, I know) to add a check before defining it. I suppose I _could_ try contributing upstream.

The only scenario where this happens now is if you have more than one Next.js edge function or middleware. This means that you need to define an API route to use `experimental-edge` runtime, and also have middleware.

### Test plan

1. Visit the middleware deploy preview
2. Load the edge API page `/api/edge`

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal
![image](https://user-images.githubusercontent.com/213306/195896848-d64f76f5-cdd2-43f1-8aab-6314738a6010.png)

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
