### PR TITLE
feat: support Next 13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,12 +15,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        node-version: [12, '*']
+        node-version: [14, '*']
         exclude:
           - os: macOS-latest
-            node-version: 12
+            node-version: 14
           - os: windows-latest
-            node-version: 12
+            node-version: 14
       fail-fast: false
 
     steps:
@@ -50,12 +50,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        node-version: [12, '*']
+        node-version: [14, '*']
         exclude:
           - os: macOS-latest
-            node-version: 12
+            node-version: 14
           - os: windows-latest
-            node-version: 12
+            node-version: 14
       fail-fast: false
 
     if: github.ref_name == 'main'

--- a/.vscode/feat-test.code-snippets
+++ b/.vscode/feat-test.code-snippets
@@ -16,7 +16,7 @@
 			"\treturn (",
 			"\t\t<div>",
 			"\t\t<h1>$1</h1>",
-			"\t\t<Link href=\"\"><a>Read Docs</a></Link>",
+			"\t\t<Link href=\"\">Read Docs</Link>",
 			"\t\t<p>Description of feature</p>",
 			"\t\t<p>Example/test of feature</p>",
 			"\t\t</div>",

--- a/demos/base-path/package.json
+++ b/demos/base-path/package.json
@@ -13,7 +13,7 @@
     "typescript": "^4.6.3"
   },
   "dependencies": {
-    "next": "^12.3.0"
+    "next": "^12.3.2-canary.43"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/demos/custom-routes/package.json
+++ b/demos/custom-routes/package.json
@@ -14,7 +14,7 @@
     "typescript": "^4.7.4"
   },
   "dependencies": {
-    "next": "^12.3.0"
+    "next": "^12.3.2-canary.43"
   },
   "scripts": {
     "build": "next build",

--- a/demos/default/package.json
+++ b/demos/default/package.json
@@ -21,7 +21,7 @@
     "@reach/dialog": "^0.16.2",
     "@reach/visually-hidden": "^0.16.0",
     "@vercel/og": "^0.0.15",
-    "next": "^12.3.0",
+    "next": "^12.3.2-canary.43",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },

--- a/demos/default/pages/broken-image.tsx
+++ b/demos/default/pages/broken-image.tsx
@@ -1,4 +1,4 @@
-import Image from 'next/image'
+import Image from 'next/legacy/image'
 
 // This should cause an error, because broken-domain is not part of the configured next.config.js image domains
 const Images = () => (

--- a/demos/default/pages/css/index.tsx
+++ b/demos/default/pages/css/index.tsx
@@ -12,23 +12,27 @@ function BuiltInCSSSupport() {
   return (
     <div>
       <h1>Built In CSS Support</h1>
-      <Link href="https://nextjs.org/docs/basic-features/built-in-css-support"><a>Read Docs</a></Link>
+      <Link href="https://nextjs.org/docs/basic-features/built-in-css-support">Read Docs</Link>
 
-      
       <h2>CSS Modules</h2>
       <p>CSS Modules are an optional feature and are only enabled for files with the .module.css extension. </p>
       <p className={styles.error}>This is made with an imported css module</p>
 
-      <h2>Import styles from <code>node_modules</code></h2>
+      <h2>
+        Import styles from <code>node_modules</code>
+      </h2>
       <p>This page imports a node module&apos;s css file for the dialog below:</p>
-      <ExampleDialog/>
+      <ExampleDialog />
 
       <h2>Sass Support</h2>
       <p>✅ Sass variable imported, color: {variables.primaryColor || <code>Error. Something went wrong</code>}</p>
 
       <div data-testid="css-in-js">
         <h2>CSS-in-JS</h2>
-        <p>NextJS bundles styled-jsx to provide support for isolated scoped CSS. The aim is to support &quot;shadow CSS&quot; similar to Web Components, which unfortunately do not support server-rendering and are JS-only.</p>
+        <p>
+          NextJS bundles styled-jsx to provide support for isolated scoped CSS. The aim is to support &quot;shadow
+          CSS&quot; similar to Web Components, which unfortunately do not support server-rendering and are JS-only.
+        </p>
         <style jsx>{`
           p {
             color: white;
@@ -46,7 +50,6 @@ function BuiltInCSSSupport() {
           }
         `}</style>
       </div>
-
     </div>
   )
 }

--- a/demos/default/pages/deep/import.js
+++ b/demos/default/pages/deep/import.js
@@ -20,9 +20,7 @@ const Show = ({ show }) => (
 
     <hr />
 
-    <Link href="/">
-      <a>Go back home</a>
-    </Link>
+    <Link href="/">Go back home</Link>
   </div>
 )
 

--- a/demos/default/pages/font.tsx
+++ b/demos/default/pages/font.tsx
@@ -5,17 +5,18 @@ function Font() {
   return (
     <div>
       {/* <Head> */}
-        <link
-          href="https://fonts.googleapis.com/css2?family=Inter&display=optional"
-          rel="stylesheet"
-        />
+      <link href="https://fonts.googleapis.com/css2?family=Inter&display=optional" rel="stylesheet" />
       {/* </Head> */}
       <h1>Font Optimization</h1>
-      <Link href="https://nextjs.org/docs/basic-features/font-optimization"><a>Read Docs</a></Link>
+      <Link href="https://nextjs.org/docs/basic-features/font-optimization">Read Docs</Link>
       <p>
-        By default, Next.js will automatically inline font CSS at build time, eliminating an extra round trip to fetch font declarations.
+        By default, Next.js will automatically inline font CSS at build time, eliminating an extra round trip to fetch
+        font declarations.
       </p>
-      <p>If optimized font is enabled (default), it should show <code>style</code>, otherwise it should show <code>link</code> in the head</p>
+      <p>
+        If optimized font is enabled (default), it should show <code>style</code>, otherwise it should show{' '}
+        <code>link</code> in the head
+      </p>
     </div>
   )
 }

--- a/demos/default/pages/getServerSideProps/[id].js
+++ b/demos/default/pages/getServerSideProps/[id].js
@@ -25,9 +25,7 @@ const Show = ({ errorCode, show, env }) => {
 
       <hr />
 
-      <Link href="/">
-        <a>Go back home</a>
-      </Link>
+      <Link href="/">Go back home</Link>
     </div>
   )
 }

--- a/demos/default/pages/getServerSideProps/all/[[...slug]].js
+++ b/demos/default/pages/getServerSideProps/all/[[...slug]].js
@@ -25,9 +25,7 @@ const Show = ({ errorCode, show }) => {
 
       <hr />
 
-      <Link href="/">
-        <a>Go back home</a>
-      </Link>
+      <Link href="/">Go back home</Link>
     </div>
   )
 }

--- a/demos/default/pages/getServerSideProps/static.js
+++ b/demos/default/pages/getServerSideProps/static.js
@@ -17,9 +17,7 @@ const Show = ({ show }) => (
 
     <hr />
 
-    <Link href="/">
-      <a>Go back home</a>
-    </Link>
+    <Link href="/">Go back home</Link>
   </div>
 )
 

--- a/demos/default/pages/getStaticProps/[id].js
+++ b/demos/default/pages/getStaticProps/[id].js
@@ -11,9 +11,7 @@ const Show = ({ show, time }) => (
     <p>Rendered at {time} (slowly)</p>
     <hr />
 
-    <Link href="/">
-      <a>Go back home</a>
-    </Link>
+    <Link href="/">Go back home</Link>
   </div>
 )
 

--- a/demos/default/pages/getStaticProps/env.js
+++ b/demos/default/pages/getStaticProps/env.js
@@ -7,9 +7,7 @@ const Env = ({ env }) => (
     <hr />
     <p>env: {env}</p>
 
-    <Link href="/">
-      <a>Go back home</a>
-    </Link>
+    <Link href="/">Go back home</Link>
   </div>
 )
 

--- a/demos/default/pages/getStaticProps/static.js
+++ b/demos/default/pages/getStaticProps/static.js
@@ -11,9 +11,7 @@ const Show = ({ show }) => (
 
     <hr />
 
-    <Link href="/">
-      <a>Go back home</a>
-    </Link>
+    <Link href="/">Go back home</Link>
   </div>
 )
 

--- a/demos/default/pages/getStaticProps/with-revalidate-404.js
+++ b/demos/default/pages/getStaticProps/with-revalidate-404.js
@@ -4,9 +4,7 @@ const Show = () => (
   <div>
     <p>This page is ISR, but will return a 404 if the current time ends in 0-4.</p>
 
-    <Link href="/">
-      <a>Go back home</a>
-    </Link>
+    <Link href="/">Go back home</Link>
   </div>
 )
 

--- a/demos/default/pages/getStaticProps/with-revalidate.js
+++ b/demos/default/pages/getStaticProps/with-revalidate.js
@@ -11,9 +11,7 @@ const Show = ({ show }) => (
 
     <hr />
 
-    <Link href="/">
-      <a>Go back home</a>
-    </Link>
+    <Link href="/">Go back home</Link>
   </div>
 )
 

--- a/demos/default/pages/getStaticProps/withFallback/[...slug].js
+++ b/demos/default/pages/getStaticProps/withFallback/[...slug].js
@@ -23,9 +23,7 @@ const Show = ({ show, time }) => {
       <p>Rendered at {time} </p>
       <hr />
 
-      <Link href="/">
-        <a>Go back home</a>
-      </Link>
+      <Link href="/">Go back home</Link>
     </div>
   )
 }

--- a/demos/default/pages/getStaticProps/withFallback/[id].js
+++ b/demos/default/pages/getStaticProps/withFallback/[id].js
@@ -23,9 +23,7 @@ const Show = ({ show, time }) => {
       <p>Rendered at {time} </p>
       <hr />
 
-      <Link href="/">
-        <a>Go back home</a>
-      </Link>
+      <Link href="/">Go back home</Link>
     </div>
   )
 }

--- a/demos/default/pages/getStaticProps/withFallbackBlocking/[id].js
+++ b/demos/default/pages/getStaticProps/withFallbackBlocking/[id].js
@@ -12,9 +12,7 @@ const Show = ({ show, time }) => (
     <p>Rendered at {time} </p>
     <hr />
 
-    <Link href="/">
-      <a>Go back home</a>
-    </Link>
+    <Link href="/">Go back home</Link>
   </div>
 )
 

--- a/demos/default/pages/getStaticProps/withRevalidate/[id].js
+++ b/demos/default/pages/getStaticProps/withRevalidate/[id].js
@@ -12,9 +12,7 @@ const Show = ({ show, time }) => (
     <p>Rendered at {time} (slowly)</p>
     <hr />
 
-    <Link href="/">
-      <a>Go back home</a>
-    </Link>
+    <Link href="/">Go back home</Link>
   </div>
 )
 

--- a/demos/default/pages/getStaticProps/withRevalidate/withFallback/[id].js
+++ b/demos/default/pages/getStaticProps/withRevalidate/withFallback/[id].js
@@ -24,9 +24,7 @@ const Show = ({ show, time }) => {
       <p>Rendered at {time} </p>
       <hr />
 
-      <Link href="/">
-        <a>Go back home</a>
-      </Link>
+      <Link href="/">Go back home</Link>
     </div>
   )
 }

--- a/demos/default/pages/getStaticProps/withRevalidate/withFallbackBlocking/[id].js
+++ b/demos/default/pages/getStaticProps/withRevalidate/withFallbackBlocking/[id].js
@@ -12,9 +12,7 @@ const Show = ({ show, time }) => (
     <p>Rendered at {time} </p>
     <hr />
 
-    <Link href="/">
-      <a>Go back home</a>
-    </Link>
+    <Link href="/">Go back home</Link>
   </div>
 )
 

--- a/demos/default/pages/image.js
+++ b/demos/default/pages/image.js
@@ -1,4 +1,4 @@
-import Image from 'next/image'
+import Image from 'next/legacy/image'
 import img from './unsplash.jpg'
 import logo from './logomark.svg'
 

--- a/demos/default/pages/index.js
+++ b/demos/default/pages/index.js
@@ -31,9 +31,7 @@ const Index = ({ shows, nodeEnv }) => {
           {shows.map(({ id, name }) => (
             <li key={id}>
               <Link href={`/shows/${id}`}>
-                <a>
-                  #{id}: {name}
-                </a>
+                #{id}: {name}
               </Link>
             </li>
           ))}
@@ -46,9 +44,7 @@ const Index = ({ shows, nodeEnv }) => {
           {shows.slice(0, 3).map(({ id, name }) => (
             <li key={id}>
               <Link href={`/shows/${id}`}>
-                <a>
-                  #{id}: {name}
-                </a>
+                #{id}: {name}
               </Link>
             </li>
           ))}
@@ -58,19 +54,13 @@ const Index = ({ shows, nodeEnv }) => {
 
         <ul data-testid="list-catch-all">
           <li>
-            <Link href={`/shows/73/whatever/path/you/want`}>
-              <a>/shows/73/whatever/path/you/want</a>
-            </Link>
+            <Link href={`/shows/73/whatever/path/you/want`}>/shows/73/whatever/path/you/want</Link>
           </li>
           <li>
-            <Link href={`/shows/94/whatever/path/you`}>
-              <a>/shows/94/whatever/path/you</a>
-            </Link>
+            <Link href={`/shows/94/whatever/path/you`}>/shows/94/whatever/path/you</Link>
           </li>
           <li>
-            <Link href={`/shows/106/whatever/path`}>
-              <a>/shows/106/whatever/path</a>
-            </Link>
+            <Link href={`/shows/106/whatever/path`}>/shows/106/whatever/path</Link>
           </li>
         </ul>
 
@@ -78,14 +68,10 @@ const Index = ({ shows, nodeEnv }) => {
 
         <ul data-testid="list-static">
           <li>
-            <Link href="/static">
-              <a>Static NextJS page: /static</a>
-            </Link>
+            <Link href="/static">Static NextJS page: /static</Link>
           </li>
           <li>
-            <Link href="/static/123456789">
-              <a>Static NextJS page with dynamic routing: /static/:id</a>
-            </Link>
+            <Link href="/static/123456789">Static NextJS page with dynamic routing: /static/:id</Link>
           </li>
         </ul>
 
@@ -98,131 +84,91 @@ const Index = ({ shows, nodeEnv }) => {
         <p>Click on the links below to see the above text change</p>
         <ul data-testid="list-localization">
           <li>
-            <Link href="/fr">
-              <a>/fr</a>
-            </Link>
+            <Link href="/fr">/fr</Link>
           </li>
           <li>
-            <Link href="/en">
-              <a>/en (default locale)</a>
-            </Link>
+            <Link href="/en">/en (default locale)</Link>
           </li>
         </ul>
         <h2>Page types</h2>
         <ul>
           <li>
-            <Link href="/getServerSideProps/static">
-              <a>/getServerSideProps/static (SSR)</a>
-            </Link>
+            <Link href="/getServerSideProps/static">/getServerSideProps/static (SSR)</Link>
           </li>
           <li>
-            <Link href="/getServerSideProps/1">
-              <a>/getServerSideProps/1 (SSR)</a>
-            </Link>
+            <Link href="/getServerSideProps/1">/getServerSideProps/1 (SSR)</Link>
           </li>
           <li>
-            <Link href="/getServerSideProps/all/1">
-              <a>/getServerSideProps/all/1 (SSR)</a>
-            </Link>
+            <Link href="/getServerSideProps/all/1">/getServerSideProps/all/1 (SSR)</Link>
           </li>
           <li>
-            <Link href="/getStaticProps/static">
-              <a>/getStaticProps/static (CDN)</a>
-            </Link>
+            <Link href="/getStaticProps/static">/getStaticProps/static (CDN)</Link>
           </li>
           <li>
-            <Link href="/getStaticProps/1">
-              <a>/getStaticProps/1 (CDN)</a>
-            </Link>
+            <Link href="/getStaticProps/1">/getStaticProps/1 (CDN)</Link>
           </li>
           <li>
-            <Link href="/getStaticProps/3">
-              <a>/getStaticProps/3 (404)</a>
-            </Link>
+            <Link href="/getStaticProps/3">/getStaticProps/3 (404)</Link>
           </li>
           <li>
-            <Link href="/getStaticProps/withFallback/1">
-              <a>/getStaticProps/withFallback/1 (CDN)</a>
-            </Link>
+            <Link href="/getStaticProps/withFallback/1">/getStaticProps/withFallback/1 (CDN)</Link>
           </li>
           <li>
-            <Link href="/getStaticProps/withFallback/3">
-              <a>/getStaticProps/withFallback/3 (ODB)</a>
-            </Link>
+            <Link href="/getStaticProps/withFallback/3">/getStaticProps/withFallback/3 (ODB)</Link>
           </li>
           <li>
-            <Link href="/getStaticProps/withFallbackBlocking/1">
-              <a>/getStaticProps/withFallbackBlocking/1 (CDN)</a>
-            </Link>
+            <Link href="/getStaticProps/withFallbackBlocking/1">/getStaticProps/withFallbackBlocking/1 (CDN)</Link>
           </li>
           <li>
-            <Link href="/getStaticProps/withFallbackBlocking/3">
-              <a>/getStaticProps/withFallbackBlocking/3 (ODB)</a>
-            </Link>
+            <Link href="/getStaticProps/withFallbackBlocking/3">/getStaticProps/withFallbackBlocking/3 (ODB)</Link>
           </li>
           <li>
-            <Link href="/getStaticProps/with-revalidate">
-              <a>/getStaticProps/with-revalidate (ODB)</a>
-            </Link>
+            <Link href="/getStaticProps/with-revalidate">/getStaticProps/with-revalidate (ODB)</Link>
           </li>
           <li>
-            <Link href="/getStaticProps/withRevalidate/1">
-              <a>/getStaticProps/withRevalidate/1 (ODB)</a>
-            </Link>
+            <Link href="/getStaticProps/withRevalidate/1">/getStaticProps/withRevalidate/1 (ODB)</Link>
           </li>
           <li>
-            <Link href="/getStaticProps/withRevalidate/3">
-              <a>/getStaticProps/withRevalidate/3 (404)</a>
-            </Link>
+            <Link href="/getStaticProps/withRevalidate/3">/getStaticProps/withRevalidate/3 (404)</Link>
           </li>
           <li>
             <Link href="/getStaticProps/withRevalidate/withFallback/1">
-              <a>/getStaticProps/withRevalidate/withFallback/1 (ODB)</a>
+              /getStaticProps/withRevalidate/withFallback/1 (ODB)
             </Link>
           </li>
           <li>
             <Link href="/getStaticProps/withRevalidate/withFallback/3">
-              <a>/getStaticProps/withRevalidate/withFallback/3 (ODB)</a>
+              /getStaticProps/withRevalidate/withFallback/3 (ODB)
             </Link>
           </li>
           <li>
             <Link href="/getStaticProps/withRevalidate/withFallbackBlocking/1">
-              <a>/getStaticProps/withRevalidate/withFallbackBlocking/1 (ODB)</a>
+              /getStaticProps/withRevalidate/withFallbackBlocking/1 (ODB)
             </Link>
           </li>
           <li>
             <Link href="/getStaticProps/withRevalidate/withFallbackBlocking/3">
-              <a>/getStaticProps/withRevalidate/withFallbackBlocking/3 (ODB)</a>
+              /getStaticProps/withRevalidate/withFallbackBlocking/3 (ODB)
             </Link>
           </li>
           <li>
-            <Link href="/old/image">
-              <a>Rewrite (should display image)</a>
-            </Link>
+            <Link href="/old/image">Rewrite (should display image)</Link>
           </li>
           <li>
-            <Link href="/rewriteToStatic">
-              <a>Rewrite to static (should show getStaticProps/1)</a>
-            </Link>
+            <Link href="/rewriteToStatic">Rewrite to static (should show getStaticProps/1)</Link>
           </li>
         </ul>
         <h4>Preview mode</h4>
         <p>Preview mode: </p>
         <ul>
           <li>
-            <Link href="/previewTest">
-              <a>Check for preview mode</a>
-            </Link>
+            <Link href="/previewTest">Check for preview mode</Link>
           </li>
           <li>
-            <Link href="/api/enterPreview">
-              <a>Enter preview</a>
-            </Link>
+            <Link href="/api/enterPreview">Enter preview</Link>
           </li>
           <li>
-            <Link href="/api/exitPreview">
-              <a>Exit preview</a>
-            </Link>
+            <Link href="/api/exitPreview">Exit preview</Link>
           </li>
         </ul>
       </div>

--- a/demos/default/pages/layouts.tsx
+++ b/demos/default/pages/layouts.tsx
@@ -1,30 +1,33 @@
 import Link from 'next/link'
-import { useEffect } from 'react';
+import { useEffect } from 'react'
 
 function Layouts() {
   return (
     <div>
-    <h1>Layout</h1>
-    <Link href="https://nextjs.org/docs/basic-features/layouts#per-page-layouts"><a>Read Docs</a></Link>
-    <p>The React model allows us to deconstruct a page into a series of components. Many of these components are often reused between pages. For example, you might have the same navigation bar and footer on every page.</p>
-    <p>This page should have an <code>span</code> tag that is added through a layout and the title should have changed in a <code>useEffect</code></p>
+      <h1>Layout</h1>
+      <Link href="https://nextjs.org/docs/basic-features/layouts#per-page-layouts">Read Docs</Link>
+      <p>
+        The React model allows us to deconstruct a page into a series of components. Many of these components are often
+        reused between pages. For example, you might have the same navigation bar and footer on every page.
+      </p>
+      <p>
+        This page should have an <code>span</code> tag that is added through a layout and the title should have changed
+        in a <code>useEffect</code>
+      </p>
     </div>
   )
 }
 
-
 Layouts.getLayout = function getLayout(page) {
-  return (
-    <TestLayout>{page}</TestLayout>
-  )
+  return <TestLayout>{page}</TestLayout>
 }
 
-function TestLayout({children}) {
+function TestLayout({ children }) {
   useEffect(() => {
     // Update the document title using the browser API
-    document.title = `Per Page Layout test title`;
-  });
-  
+    document.title = `Per Page Layout test title`
+  })
+
   return (
     <div>
       <span>Test layout wrapper</span>

--- a/demos/default/pages/previewTest.js
+++ b/demos/default/pages/previewTest.js
@@ -3,20 +3,18 @@ import Link from 'next/link'
 const StaticTest = ({ isPreview }) => {
   return (
     <div>
-
-
-      <h1>Is preview? {isPreview ? "Yes!" : "No"}</h1>
-      <p><a href={isPreview ? "/api/exitPreview" : "/api/enterPreview"}>{isPreview ? "Exit Preview" : "Enter Preview"}</a></p>
-      <Link href="/">
-        <a>Go back home</a>
-      </Link>
+      <h1>Is preview? {isPreview ? 'Yes!' : 'No'}</h1>
+      <p>
+        <a href={isPreview ? '/api/exitPreview' : '/api/enterPreview'}>
+          {isPreview ? 'Exit Preview' : 'Enter Preview'}
+        </a>
+      </p>
+      <Link href="/">Go back home</Link>
     </div>
   )
 }
 
 export const getStaticProps = async ({ preview }) => {
-
-
   return {
     props: {
       isPreview: Boolean(preview),

--- a/demos/default/pages/shows/[...params].js
+++ b/demos/default/pages/shows/[...params].js
@@ -34,9 +34,7 @@ const CatchAll = ({ errorCode, show, params }) => {
 
       <hr />
 
-      <Link href="/">
-        <a>Go back home</a>
-      </Link>
+      <Link href="/">Go back home</Link>
     </div>
   )
 }

--- a/demos/default/pages/shows/[id].js
+++ b/demos/default/pages/shows/[id].js
@@ -25,9 +25,7 @@ const Show = ({ errorCode, show }) => {
 
       <hr />
 
-      <Link href="/">
-        <a>Go back home</a>
-      </Link>
+      <Link href="/">Go back home</Link>
     </div>
   )
 }

--- a/demos/default/pages/static.js
+++ b/demos/default/pages/static.js
@@ -17,9 +17,7 @@ const Static = (props) => (
 
     <hr />
 
-    <Link href="/">
-      <a>Go back home</a>
-    </Link>
+    <Link href="/">Go back home</Link>
   </div>
 )
 

--- a/demos/default/pages/static/[id].js
+++ b/demos/default/pages/static/[id].js
@@ -23,9 +23,7 @@ const StaticWithID = (props) => (
 
     <hr />
 
-    <Link href="/">
-      <a>Go back home</a>
-    </Link>
+    <Link href="/">Go back home</Link>
   </div>
 )
 

--- a/demos/middleware/package.json
+++ b/demos/middleware/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@netlify/next": "*",
     "@netlify/plugin-nextjs": "*",
-    "next": "^12.3.0",
+    "next": "^12.3.2-canary.43",
     "react": "18.0.0",
     "react-dom": "18.0.0"
   },

--- a/demos/middleware/pages/shows/[id].js
+++ b/demos/middleware/pages/shows/[id].js
@@ -11,13 +11,11 @@ const Show = ({ errorCode, show, env }) => {
   return (
     <div>
       <p>
-        This page uses getInitialProps() to fetch the show with the ID provided
-        in the URL: /shows/:id
+        This page uses getInitialProps() to fetch the show with the ID provided in the URL: /shows/:id
         <br />
         Refresh the page to see server-side rendering in action.
         <br />
-        You can also try changing the ID to any other number between 1-10000.
-        Env: {env}
+        You can also try changing the ID to any other number between 1-10000. Env: {env}
       </p>
       <hr />
 
@@ -26,9 +24,7 @@ const Show = ({ errorCode, show, env }) => {
 
       <hr />
 
-      <Link href="/">
-        <a>Go back home</a>
-      </Link>
+      <Link href="/">Go back home</Link>
     </div>
   )
 }

--- a/demos/middleware/pages/shows/index.js
+++ b/demos/middleware/pages/shows/index.js
@@ -7,9 +7,7 @@ const Show = () => {
       <p>Add a number between 1 and 10000 to the URL</p>
       <hr />
 
-      <Link href="/">
-        <a>Go back home</a>
-      </Link>
+      <Link href="/">Go back home</Link>
     </div>
   )
 }

--- a/demos/middleware/pages/shows/static/[id].js
+++ b/demos/middleware/pages/shows/static/[id].js
@@ -22,9 +22,7 @@ const Show = ({ show }) => {
 
       <hr />
 
-      <Link href="/">
-        <a>Go back home</a>
-      </Link>
+      <Link href="/">Go back home</Link>
     </div>
   )
 }

--- a/demos/next-auth/components/footer.tsx
+++ b/demos/next-auth/components/footer.tsx
@@ -17,9 +17,7 @@ export default function Footer() {
           <a href="https://github.com/nextauthjs/next-auth-example">GitHub</a>
         </li>
         <li className={styles.navItem}>
-          <Link href="/policy">
-            <a>Policy</a>
-          </Link>
+          <Link href="/policy">Policy</Link>
         </li>
         <li className={styles.navItem}>
           <em>next-auth@{packageJSON.dependencies["next-auth"]}</em>

--- a/demos/next-auth/components/header.tsx
+++ b/demos/next-auth/components/header.tsx
@@ -15,16 +15,10 @@ export default function Header() {
         <style>{`.nojs-show { opacity: 1; top: 0; }`}</style>
       </noscript>
       <div className={styles.signedInStatus}>
-        <p
-          className={`nojs-show ${
-            !session && loading ? styles.loading : styles.loaded
-          }`}
-        >
+        <p className={`nojs-show ${!session && loading ? styles.loading : styles.loaded}`}>
           {!session && (
             <>
-              <span className={styles.notSignedInText}>
-                You are not signed in
-              </span>
+              <span className={styles.notSignedInText}>You are not signed in</span>
               <a
                 href={`/api/auth/signin`}
                 className={styles.buttonPrimary}
@@ -40,10 +34,7 @@ export default function Header() {
           {session?.user && (
             <>
               {session.user.image && (
-                <span
-                  style={{ backgroundImage: `url('${session.user.image}')` }}
-                  className={styles.avatar}
-                />
+                <span style={{ backgroundImage: `url('${session.user.image}')` }} className={styles.avatar} />
               )}
               <span className={styles.signedInText}>
                 <small>Signed in as</small>
@@ -67,39 +58,25 @@ export default function Header() {
       <nav>
         <ul className={styles.navItems}>
           <li className={styles.navItem}>
-            <Link href="/">
-              <a>Home</a>
-            </Link>
+            <Link href="/">Home</Link>
           </li>
           <li className={styles.navItem}>
-            <Link href="/client">
-              <a>Client</a>
-            </Link>
+            <Link href="/client">Client</Link>
           </li>
           <li className={styles.navItem}>
-            <Link href="/server">
-              <a>Server</a>
-            </Link>
+            <Link href="/server">Server</Link>
           </li>
           <li className={styles.navItem}>
-            <Link href="/protected">
-              <a>Protected</a>
-            </Link>
+            <Link href="/protected">Protected</Link>
           </li>
           <li className={styles.navItem}>
-            <Link href="/api-example">
-              <a>API</a>
-            </Link>
+            <Link href="/api-example">API</Link>
           </li>
           <li className={styles.navItem}>
-            <Link href="/admin">
-              <a>Admin</a>
-            </Link>
+            <Link href="/admin">Admin</Link>
           </li>
           <li className={styles.navItem}>
-            <Link href="/me">
-              <a>Me</a>
-            </Link>
+            <Link href="/me">Me</Link>
           </li>
         </ul>
       </nav>

--- a/demos/next-auth/package.json
+++ b/demos/next-auth/package.json
@@ -23,7 +23,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "next": "^12.3.0",
+    "next": "^12.3.2-canary.43",
     "next-auth": "^4.7.0",
     "nodemailer": "^6.6.3",
     "react": "^18.0.0",

--- a/demos/next-export/package.json
+++ b/demos/next-export/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "dependencies": {
-    "next": "^12.3.0"
+    "next": "^12.3.2-canary.43"
   },
   "devDependencies": {
     "@netlify/plugin-nextjs": "*",

--- a/demos/next-i18next/package-lock.json
+++ b/demos/next-i18next/package-lock.json
@@ -8,7 +8,7 @@
       "name": "next-i18next",
       "version": "0.1.0",
       "dependencies": {
-        "next": "^12.3.0",
+        "next": "^12.3.2-canary.43",
         "next-i18next": "^11.0.0",
         "react": "18.1.0",
         "react-dom": "18.1.0"
@@ -96,9 +96,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@next/env": {
-      "version": "12.2.5",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.2.5.tgz",
-      "integrity": "sha512-vLPLV3cpPGjUPT3PjgRj7e3nio9t6USkuew3JE/jMeon/9Mvp1WyR18v3iwnCuX7eUAm1HmAbJHHLAbcu/EJcw=="
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.3.2-canary.43.tgz",
+      "integrity": "sha512-Sb+EIjatpJ6MGPxM4vbOu1Psq7ARCPtmJCDAFGSQMDz4PZbPK649pzdj8D7SlFgZNdKMcr33urKutbGR4s6hUQ=="
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "12.2.4",
@@ -130,9 +130,9 @@
       }
     },
     "node_modules/@next/swc-android-arm-eabi": {
-      "version": "12.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.2.5.tgz",
-      "integrity": "sha512-cPWClKxGhgn2dLWnspW+7psl3MoLQUcNqJqOHk2BhNcou9ARDtC0IjQkKe5qcn9qg7I7U83Gp1yh2aesZfZJMA==",
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.2-canary.43.tgz",
+      "integrity": "sha512-Y8tl1H9EXPAWPG4fkULYg2kqsrBNav5zNXvjlvqv83ZR2hrGHW7QyjAdyv0fjGMckrGA9fiqITT1/241gmGdHA==",
       "cpu": [
         "arm"
       ],
@@ -145,9 +145,9 @@
       }
     },
     "node_modules/@next/swc-android-arm64": {
-      "version": "12.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.2.5.tgz",
-      "integrity": "sha512-vMj0efliXmC5b7p+wfcQCX0AfU8IypjkzT64GiKJD9PgiA3IILNiGJr1fw2lyUDHkjeWx/5HMlMEpLnTsQslwg==",
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.2-canary.43.tgz",
+      "integrity": "sha512-OuHmP9pEuC9j2IVvOwL0fVHTkhrzvkJO7Sbm9LQW6s0+FJxGjuoLjdOm+GRusnZFyzXRvVWEHd8Wu9aDTzoBGg==",
       "cpu": [
         "arm64"
       ],
@@ -160,9 +160,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "12.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.2.5.tgz",
-      "integrity": "sha512-VOPWbO5EFr6snla/WcxUKtvzGVShfs302TEMOtzYyWni6f9zuOetijJvVh9CCTzInnXAZMtHyNhefijA4HMYLg==",
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.2-canary.43.tgz",
+      "integrity": "sha512-WJqEndZXTaqFDoaxE9NImrWavGoagpBQg0GCNQ3t/IIyG53mbEgegkEoMw7ZYVkQzQcd2b6Nxj6f9nU9T4ebfA==",
       "cpu": [
         "arm64"
       ],
@@ -175,9 +175,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "12.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.2.5.tgz",
-      "integrity": "sha512-5o8bTCgAmtYOgauO/Xd27vW52G2/m3i5PX7MUYePquxXAnX73AAtqA3WgPXBRitEB60plSKZgOTkcpqrsh546A==",
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.2-canary.43.tgz",
+      "integrity": "sha512-cWrlfaIx2WkFfl5+TGf09zvgNsij8cTOJ5io1ILHzKt9rTOrr39tK5jk5HYfF5QhKVS4Dw2GHUj7L74xEKqznA==",
       "cpu": [
         "x64"
       ],
@@ -190,9 +190,9 @@
       }
     },
     "node_modules/@next/swc-freebsd-x64": {
-      "version": "12.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.2.5.tgz",
-      "integrity": "sha512-yYUbyup1JnznMtEBRkK4LT56N0lfK5qNTzr6/DEyDw5TbFVwnuy2hhLBzwCBkScFVjpFdfiC6SQAX3FrAZzuuw==",
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.2-canary.43.tgz",
+      "integrity": "sha512-6Z8SnCxvgNWzp7QSQROHAUb8SZ+AD4etLaAj4LUhcCqQA/0RGUms2Vlet0RGNVorq3+8KweUAb3Ix+I4BgaP3w==",
       "cpu": [
         "x64"
       ],
@@ -205,9 +205,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm-gnueabihf": {
-      "version": "12.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.2.5.tgz",
-      "integrity": "sha512-2ZE2/G921Acks7UopJZVMgKLdm4vN4U0yuzvAMJ6KBavPzqESA2yHJlm85TV/K9gIjKhSk5BVtauIUntFRP8cg==",
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.2-canary.43.tgz",
+      "integrity": "sha512-cl7P0uVxRDCbkC9jAs8NSk/g8O2JVjdWWb6cF/VCSUKZL7dZMly0ocqS58vwb9oTWAI+OFJrAczZPQbtkMU6aQ==",
       "cpu": [
         "arm"
       ],
@@ -220,9 +220,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "12.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.2.5.tgz",
-      "integrity": "sha512-/I6+PWVlz2wkTdWqhlSYYJ1pWWgUVva6SgX353oqTh8njNQp1SdFQuWDqk8LnM6ulheVfSsgkDzxrDaAQZnzjQ==",
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.2-canary.43.tgz",
+      "integrity": "sha512-KxEatuNa5q9cImU/Fk0Q0KN136L4WGWcuavPhodQW3zwHn+OKBARA6wmtPkqQhRj7slzVzn3mZ01pPxc4DhsVg==",
       "cpu": [
         "arm64"
       ],
@@ -235,9 +235,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "12.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.2.5.tgz",
-      "integrity": "sha512-LPQRelfX6asXyVr59p5sTpx5l+0yh2Vjp/R8Wi4X9pnqcayqT4CUJLiHqCvZuLin3IsFdisJL0rKHMoaZLRfmg==",
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.2-canary.43.tgz",
+      "integrity": "sha512-KWaV7rrbE31L1GsHZ33+DkXMgnzcKaZxgA/eIaiJ3wdVse7MzrpCtJH2p3p1mvAPtKu/WG3Ntv4rLFdSzybjWA==",
       "cpu": [
         "arm64"
       ],
@@ -250,9 +250,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "12.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.2.5.tgz",
-      "integrity": "sha512-0szyAo8jMCClkjNK0hknjhmAngUppoRekW6OAezbEYwHXN/VNtsXbfzgYOqjKWxEx3OoAzrT3jLwAF0HdX2MEw==",
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.2-canary.43.tgz",
+      "integrity": "sha512-fE9zuIDCH48jCbw3/JBhdblZXTEepjaxH+I6A/Nml7Aex2OFAG8GkEdTJdRez3W3IFaMYIhqpGqQcd7VXDw6bw==",
       "cpu": [
         "x64"
       ],
@@ -265,9 +265,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "12.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.2.5.tgz",
-      "integrity": "sha512-zg/Y6oBar1yVnW6Il1I/08/2ukWtOG6s3acdJdEyIdsCzyQi4RLxbbhkD/EGQyhqBvd3QrC6ZXQEXighQUAZ0g==",
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.2-canary.43.tgz",
+      "integrity": "sha512-KHXl4kDLjSA2BAKGY+jisaHWYkxDw2bI9j6eQunvkPnlwW5jwiJPQnehszt5CNwYTdoeqiAJE+BY4UnEIEkeNQ==",
       "cpu": [
         "x64"
       ],
@@ -280,9 +280,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "12.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.2.5.tgz",
-      "integrity": "sha512-3/90DRNSqeeSRMMEhj4gHHQlLhhKg5SCCoYfE3kBjGpE63EfnblYUqsszGGZ9ekpKL/R4/SGB40iCQr8tR5Jiw==",
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.2-canary.43.tgz",
+      "integrity": "sha512-QHU8bxXzkyjhwVNxLut1m4VRo3ZQlbkcidR7erH8WdSaVhYAWUdPZ6ux6aJLAk3yQwwgw0fSZO98iXdkDp6pvw==",
       "cpu": [
         "arm64"
       ],
@@ -295,9 +295,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "12.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.2.5.tgz",
-      "integrity": "sha512-hGLc0ZRAwnaPL4ulwpp4D2RxmkHQLuI8CFOEEHdzZpS63/hMVzv81g8jzYA0UXbb9pus/iTc3VRbVbAM03SRrw==",
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.2-canary.43.tgz",
+      "integrity": "sha512-HyElqKE2rJeS0pb6NowKyIsQ9iK/Ct9hkH4fexmoMyMk4z86zu7F3PS9ThLtEDRyzeM5K3xMtFgD+IcYFLRzmA==",
       "cpu": [
         "ia32"
       ],
@@ -310,9 +310,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "12.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.2.5.tgz",
-      "integrity": "sha512-7h5/ahY7NeaO2xygqVrSG/Y8Vs4cdjxIjowTZ5W6CKoTKn7tmnuxlUc2h74x06FKmbhAd9agOjr/AOKyxYYm9Q==",
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.2-canary.43.tgz",
+      "integrity": "sha512-+0GA+qi1gS/w6QpHj58b4OOxNQ6kWmZuGdAnGuHzBbPmyBERnAWGU4+5DdjOebswM/sCV7ljTjxaHzZo1LN6Ng==",
       "cpu": [
         "x64"
       ],
@@ -366,9 +366,9 @@
       "dev": true
     },
     "node_modules/@swc/helpers": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.3.tgz",
-      "integrity": "sha512-6JrF+fdUK2zbGpJIlN7G3v966PQjyx/dPt1T9km2wj+EUBqgrxCk3uX4Kct16MIm9gGxfKRcfax2hVf5jvlTzA==",
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.11.tgz",
+      "integrity": "sha512-rEUrBSGIoSFuYxwBYtlUFMlE2CwGhmW+w9355/5oduSw8e5h2+Tj4UrAGNNgP9915++wj5vkQo0UuOBqOAq4nw==",
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -761,9 +761,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001332",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001332.tgz",
-      "integrity": "sha512-10T30NYOEQtN6C11YGg411yebhvpnC6Z102+B95eAsN0oB6KUs01ivE8u+G6FMIRtIrVlYXhL+LUwQ3/hXwDWw==",
+      "version": "1.0.30001425",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001425.tgz",
+      "integrity": "sha512-/pzFv0OmNG6W0ym80P3NtapU0QEiDS3VuYAZMGoLLqiC7f6FJFe1MjpQDREGApeenD9wloeytmVDj+JLXPC6qw==",
       "funding": [
         {
           "type": "opencollective",
@@ -773,8 +773,7 @@
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
         }
-      ],
-      "license": "CC-BY-4.0"
+      ]
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -792,6 +791,11 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -2361,43 +2365,43 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "12.2.5",
-      "resolved": "https://registry.npmjs.org/next/-/next-12.2.5.tgz",
-      "integrity": "sha512-tBdjqX5XC/oFs/6gxrZhjmiq90YWizUYU6qOWAfat7zJwrwapJ+BYgX2PmiacunXMaRpeVT4vz5MSPSLgNkrpA==",
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/next/-/next-12.3.2-canary.43.tgz",
+      "integrity": "sha512-NgKLhMndPIL2DJEPfzONjSLpW+pl4YFzRp/DhYMgtYjOi5auYoM0SA9f3IJBN39PsFuyfNgJkTxiHtQ6q/T1MA==",
       "dependencies": {
-        "@next/env": "12.2.5",
-        "@swc/helpers": "0.4.3",
-        "caniuse-lite": "^1.0.30001332",
+        "@next/env": "12.3.2-canary.43",
+        "@swc/helpers": "0.4.11",
+        "caniuse-lite": "^1.0.30001406",
         "postcss": "8.4.14",
-        "styled-jsx": "5.0.4",
+        "styled-jsx": "5.1.0",
         "use-sync-external-store": "1.2.0"
       },
       "bin": {
         "next": "dist/bin/next"
       },
       "engines": {
-        "node": ">=12.22.0"
+        "node": ">=14.6.0"
       },
       "optionalDependencies": {
-        "@next/swc-android-arm-eabi": "12.2.5",
-        "@next/swc-android-arm64": "12.2.5",
-        "@next/swc-darwin-arm64": "12.2.5",
-        "@next/swc-darwin-x64": "12.2.5",
-        "@next/swc-freebsd-x64": "12.2.5",
-        "@next/swc-linux-arm-gnueabihf": "12.2.5",
-        "@next/swc-linux-arm64-gnu": "12.2.5",
-        "@next/swc-linux-arm64-musl": "12.2.5",
-        "@next/swc-linux-x64-gnu": "12.2.5",
-        "@next/swc-linux-x64-musl": "12.2.5",
-        "@next/swc-win32-arm64-msvc": "12.2.5",
-        "@next/swc-win32-ia32-msvc": "12.2.5",
-        "@next/swc-win32-x64-msvc": "12.2.5"
+        "@next/swc-android-arm-eabi": "12.3.2-canary.43",
+        "@next/swc-android-arm64": "12.3.2-canary.43",
+        "@next/swc-darwin-arm64": "12.3.2-canary.43",
+        "@next/swc-darwin-x64": "12.3.2-canary.43",
+        "@next/swc-freebsd-x64": "12.3.2-canary.43",
+        "@next/swc-linux-arm-gnueabihf": "12.3.2-canary.43",
+        "@next/swc-linux-arm64-gnu": "12.3.2-canary.43",
+        "@next/swc-linux-arm64-musl": "12.3.2-canary.43",
+        "@next/swc-linux-x64-gnu": "12.3.2-canary.43",
+        "@next/swc-linux-x64-musl": "12.3.2-canary.43",
+        "@next/swc-win32-arm64-msvc": "12.3.2-canary.43",
+        "@next/swc-win32-ia32-msvc": "12.3.2-canary.43",
+        "@next/swc-win32-x64-msvc": "12.3.2-canary.43"
       },
       "peerDependencies": {
         "fibers": ">= 3.1.0",
         "node-sass": "^6.0.0 || ^7.0.0",
-        "react": "^17.0.2 || ^18.0.0-0",
-        "react-dom": "^17.0.2 || ^18.0.0-0",
+        "react": "^18.0.0-0",
+        "react-dom": "^18.0.0-0",
         "sass": "^1.3.0"
       },
       "peerDependenciesMeta": {
@@ -3094,9 +3098,12 @@
       }
     },
     "node_modules/styled-jsx": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.4.tgz",
-      "integrity": "sha512-sDFWLbg4zR+UkNzfk5lPilyIgtpddfxXEULxhujorr5jtePTUqiPDc5BC0v1NRqTr/WaFBGQQUoYToGlF4B2KQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.0.tgz",
+      "integrity": "sha512-/iHaRJt9U7T+5tp6TRelLnqBqiaIT0HsO0+vgyj8hK2KUk7aejFqRrumqPUlAqDwAj8IbS/1hk3IhBAAK/FCUQ==",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3394,9 +3401,9 @@
       "dev": true
     },
     "@next/env": {
-      "version": "12.2.5",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.2.5.tgz",
-      "integrity": "sha512-vLPLV3cpPGjUPT3PjgRj7e3nio9t6USkuew3JE/jMeon/9Mvp1WyR18v3iwnCuX7eUAm1HmAbJHHLAbcu/EJcw=="
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.3.2-canary.43.tgz",
+      "integrity": "sha512-Sb+EIjatpJ6MGPxM4vbOu1Psq7ARCPtmJCDAFGSQMDz4PZbPK649pzdj8D7SlFgZNdKMcr33urKutbGR4s6hUQ=="
     },
     "@next/eslint-plugin-next": {
       "version": "12.2.4",
@@ -3424,81 +3431,81 @@
       }
     },
     "@next/swc-android-arm-eabi": {
-      "version": "12.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.2.5.tgz",
-      "integrity": "sha512-cPWClKxGhgn2dLWnspW+7psl3MoLQUcNqJqOHk2BhNcou9ARDtC0IjQkKe5qcn9qg7I7U83Gp1yh2aesZfZJMA==",
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.2-canary.43.tgz",
+      "integrity": "sha512-Y8tl1H9EXPAWPG4fkULYg2kqsrBNav5zNXvjlvqv83ZR2hrGHW7QyjAdyv0fjGMckrGA9fiqITT1/241gmGdHA==",
       "optional": true
     },
     "@next/swc-android-arm64": {
-      "version": "12.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.2.5.tgz",
-      "integrity": "sha512-vMj0efliXmC5b7p+wfcQCX0AfU8IypjkzT64GiKJD9PgiA3IILNiGJr1fw2lyUDHkjeWx/5HMlMEpLnTsQslwg==",
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.2-canary.43.tgz",
+      "integrity": "sha512-OuHmP9pEuC9j2IVvOwL0fVHTkhrzvkJO7Sbm9LQW6s0+FJxGjuoLjdOm+GRusnZFyzXRvVWEHd8Wu9aDTzoBGg==",
       "optional": true
     },
     "@next/swc-darwin-arm64": {
-      "version": "12.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.2.5.tgz",
-      "integrity": "sha512-VOPWbO5EFr6snla/WcxUKtvzGVShfs302TEMOtzYyWni6f9zuOetijJvVh9CCTzInnXAZMtHyNhefijA4HMYLg==",
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.2-canary.43.tgz",
+      "integrity": "sha512-WJqEndZXTaqFDoaxE9NImrWavGoagpBQg0GCNQ3t/IIyG53mbEgegkEoMw7ZYVkQzQcd2b6Nxj6f9nU9T4ebfA==",
       "optional": true
     },
     "@next/swc-darwin-x64": {
-      "version": "12.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.2.5.tgz",
-      "integrity": "sha512-5o8bTCgAmtYOgauO/Xd27vW52G2/m3i5PX7MUYePquxXAnX73AAtqA3WgPXBRitEB60plSKZgOTkcpqrsh546A==",
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.2-canary.43.tgz",
+      "integrity": "sha512-cWrlfaIx2WkFfl5+TGf09zvgNsij8cTOJ5io1ILHzKt9rTOrr39tK5jk5HYfF5QhKVS4Dw2GHUj7L74xEKqznA==",
       "optional": true
     },
     "@next/swc-freebsd-x64": {
-      "version": "12.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.2.5.tgz",
-      "integrity": "sha512-yYUbyup1JnznMtEBRkK4LT56N0lfK5qNTzr6/DEyDw5TbFVwnuy2hhLBzwCBkScFVjpFdfiC6SQAX3FrAZzuuw==",
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.2-canary.43.tgz",
+      "integrity": "sha512-6Z8SnCxvgNWzp7QSQROHAUb8SZ+AD4etLaAj4LUhcCqQA/0RGUms2Vlet0RGNVorq3+8KweUAb3Ix+I4BgaP3w==",
       "optional": true
     },
     "@next/swc-linux-arm-gnueabihf": {
-      "version": "12.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.2.5.tgz",
-      "integrity": "sha512-2ZE2/G921Acks7UopJZVMgKLdm4vN4U0yuzvAMJ6KBavPzqESA2yHJlm85TV/K9gIjKhSk5BVtauIUntFRP8cg==",
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.2-canary.43.tgz",
+      "integrity": "sha512-cl7P0uVxRDCbkC9jAs8NSk/g8O2JVjdWWb6cF/VCSUKZL7dZMly0ocqS58vwb9oTWAI+OFJrAczZPQbtkMU6aQ==",
       "optional": true
     },
     "@next/swc-linux-arm64-gnu": {
-      "version": "12.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.2.5.tgz",
-      "integrity": "sha512-/I6+PWVlz2wkTdWqhlSYYJ1pWWgUVva6SgX353oqTh8njNQp1SdFQuWDqk8LnM6ulheVfSsgkDzxrDaAQZnzjQ==",
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.2-canary.43.tgz",
+      "integrity": "sha512-KxEatuNa5q9cImU/Fk0Q0KN136L4WGWcuavPhodQW3zwHn+OKBARA6wmtPkqQhRj7slzVzn3mZ01pPxc4DhsVg==",
       "optional": true
     },
     "@next/swc-linux-arm64-musl": {
-      "version": "12.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.2.5.tgz",
-      "integrity": "sha512-LPQRelfX6asXyVr59p5sTpx5l+0yh2Vjp/R8Wi4X9pnqcayqT4CUJLiHqCvZuLin3IsFdisJL0rKHMoaZLRfmg==",
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.2-canary.43.tgz",
+      "integrity": "sha512-KWaV7rrbE31L1GsHZ33+DkXMgnzcKaZxgA/eIaiJ3wdVse7MzrpCtJH2p3p1mvAPtKu/WG3Ntv4rLFdSzybjWA==",
       "optional": true
     },
     "@next/swc-linux-x64-gnu": {
-      "version": "12.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.2.5.tgz",
-      "integrity": "sha512-0szyAo8jMCClkjNK0hknjhmAngUppoRekW6OAezbEYwHXN/VNtsXbfzgYOqjKWxEx3OoAzrT3jLwAF0HdX2MEw==",
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.2-canary.43.tgz",
+      "integrity": "sha512-fE9zuIDCH48jCbw3/JBhdblZXTEepjaxH+I6A/Nml7Aex2OFAG8GkEdTJdRez3W3IFaMYIhqpGqQcd7VXDw6bw==",
       "optional": true
     },
     "@next/swc-linux-x64-musl": {
-      "version": "12.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.2.5.tgz",
-      "integrity": "sha512-zg/Y6oBar1yVnW6Il1I/08/2ukWtOG6s3acdJdEyIdsCzyQi4RLxbbhkD/EGQyhqBvd3QrC6ZXQEXighQUAZ0g==",
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.2-canary.43.tgz",
+      "integrity": "sha512-KHXl4kDLjSA2BAKGY+jisaHWYkxDw2bI9j6eQunvkPnlwW5jwiJPQnehszt5CNwYTdoeqiAJE+BY4UnEIEkeNQ==",
       "optional": true
     },
     "@next/swc-win32-arm64-msvc": {
-      "version": "12.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.2.5.tgz",
-      "integrity": "sha512-3/90DRNSqeeSRMMEhj4gHHQlLhhKg5SCCoYfE3kBjGpE63EfnblYUqsszGGZ9ekpKL/R4/SGB40iCQr8tR5Jiw==",
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.2-canary.43.tgz",
+      "integrity": "sha512-QHU8bxXzkyjhwVNxLut1m4VRo3ZQlbkcidR7erH8WdSaVhYAWUdPZ6ux6aJLAk3yQwwgw0fSZO98iXdkDp6pvw==",
       "optional": true
     },
     "@next/swc-win32-ia32-msvc": {
-      "version": "12.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.2.5.tgz",
-      "integrity": "sha512-hGLc0ZRAwnaPL4ulwpp4D2RxmkHQLuI8CFOEEHdzZpS63/hMVzv81g8jzYA0UXbb9pus/iTc3VRbVbAM03SRrw==",
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.2-canary.43.tgz",
+      "integrity": "sha512-HyElqKE2rJeS0pb6NowKyIsQ9iK/Ct9hkH4fexmoMyMk4z86zu7F3PS9ThLtEDRyzeM5K3xMtFgD+IcYFLRzmA==",
       "optional": true
     },
     "@next/swc-win32-x64-msvc": {
-      "version": "12.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.2.5.tgz",
-      "integrity": "sha512-7h5/ahY7NeaO2xygqVrSG/Y8Vs4cdjxIjowTZ5W6CKoTKn7tmnuxlUc2h74x06FKmbhAd9agOjr/AOKyxYYm9Q==",
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.2-canary.43.tgz",
+      "integrity": "sha512-+0GA+qi1gS/w6QpHj58b4OOxNQ6kWmZuGdAnGuHzBbPmyBERnAWGU4+5DdjOebswM/sCV7ljTjxaHzZo1LN6Ng==",
       "optional": true
     },
     "@nodelib/fs.scandir": {
@@ -3534,9 +3541,9 @@
       "dev": true
     },
     "@swc/helpers": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.3.tgz",
-      "integrity": "sha512-6JrF+fdUK2zbGpJIlN7G3v966PQjyx/dPt1T9km2wj+EUBqgrxCk3uX4Kct16MIm9gGxfKRcfax2hVf5jvlTzA==",
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.11.tgz",
+      "integrity": "sha512-rEUrBSGIoSFuYxwBYtlUFMlE2CwGhmW+w9355/5oduSw8e5h2+Tj4UrAGNNgP9915++wj5vkQo0UuOBqOAq4nw==",
       "requires": {
         "tslib": "^2.4.0"
       },
@@ -3805,9 +3812,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001332",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001332.tgz",
-      "integrity": "sha512-10T30NYOEQtN6C11YGg411yebhvpnC6Z102+B95eAsN0oB6KUs01ivE8u+G6FMIRtIrVlYXhL+LUwQ3/hXwDWw=="
+      "version": "1.0.30001425",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001425.tgz",
+      "integrity": "sha512-/pzFv0OmNG6W0ym80P3NtapU0QEiDS3VuYAZMGoLLqiC7f6FJFe1MjpQDREGApeenD9wloeytmVDj+JLXPC6qw=="
     },
     "chalk": {
       "version": "4.1.2",
@@ -3818,6 +3825,11 @@
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
       }
+    },
+    "client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
     },
     "color-convert": {
       "version": "2.0.1",
@@ -4929,28 +4941,28 @@
       "dev": true
     },
     "next": {
-      "version": "12.2.5",
-      "resolved": "https://registry.npmjs.org/next/-/next-12.2.5.tgz",
-      "integrity": "sha512-tBdjqX5XC/oFs/6gxrZhjmiq90YWizUYU6qOWAfat7zJwrwapJ+BYgX2PmiacunXMaRpeVT4vz5MSPSLgNkrpA==",
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/next/-/next-12.3.2-canary.43.tgz",
+      "integrity": "sha512-NgKLhMndPIL2DJEPfzONjSLpW+pl4YFzRp/DhYMgtYjOi5auYoM0SA9f3IJBN39PsFuyfNgJkTxiHtQ6q/T1MA==",
       "requires": {
-        "@next/env": "12.2.5",
-        "@next/swc-android-arm-eabi": "12.2.5",
-        "@next/swc-android-arm64": "12.2.5",
-        "@next/swc-darwin-arm64": "12.2.5",
-        "@next/swc-darwin-x64": "12.2.5",
-        "@next/swc-freebsd-x64": "12.2.5",
-        "@next/swc-linux-arm-gnueabihf": "12.2.5",
-        "@next/swc-linux-arm64-gnu": "12.2.5",
-        "@next/swc-linux-arm64-musl": "12.2.5",
-        "@next/swc-linux-x64-gnu": "12.2.5",
-        "@next/swc-linux-x64-musl": "12.2.5",
-        "@next/swc-win32-arm64-msvc": "12.2.5",
-        "@next/swc-win32-ia32-msvc": "12.2.5",
-        "@next/swc-win32-x64-msvc": "12.2.5",
-        "@swc/helpers": "0.4.3",
-        "caniuse-lite": "^1.0.30001332",
+        "@next/env": "12.3.2-canary.43",
+        "@next/swc-android-arm-eabi": "12.3.2-canary.43",
+        "@next/swc-android-arm64": "12.3.2-canary.43",
+        "@next/swc-darwin-arm64": "12.3.2-canary.43",
+        "@next/swc-darwin-x64": "12.3.2-canary.43",
+        "@next/swc-freebsd-x64": "12.3.2-canary.43",
+        "@next/swc-linux-arm-gnueabihf": "12.3.2-canary.43",
+        "@next/swc-linux-arm64-gnu": "12.3.2-canary.43",
+        "@next/swc-linux-arm64-musl": "12.3.2-canary.43",
+        "@next/swc-linux-x64-gnu": "12.3.2-canary.43",
+        "@next/swc-linux-x64-musl": "12.3.2-canary.43",
+        "@next/swc-win32-arm64-msvc": "12.3.2-canary.43",
+        "@next/swc-win32-ia32-msvc": "12.3.2-canary.43",
+        "@next/swc-win32-x64-msvc": "12.3.2-canary.43",
+        "@swc/helpers": "0.4.11",
+        "caniuse-lite": "^1.0.30001406",
         "postcss": "8.4.14",
-        "styled-jsx": "5.0.4",
+        "styled-jsx": "5.1.0",
         "use-sync-external-store": "1.2.0"
       }
     },
@@ -5381,9 +5393,12 @@
       "dev": true
     },
     "styled-jsx": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.4.tgz",
-      "integrity": "sha512-sDFWLbg4zR+UkNzfk5lPilyIgtpddfxXEULxhujorr5jtePTUqiPDc5BC0v1NRqTr/WaFBGQQUoYToGlF4B2KQ=="
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.0.tgz",
+      "integrity": "sha512-/iHaRJt9U7T+5tp6TRelLnqBqiaIT0HsO0+vgyj8hK2KUk7aejFqRrumqPUlAqDwAj8IbS/1hk3IhBAAK/FCUQ==",
+      "requires": {
+        "client-only": "0.0.1"
+      }
     },
     "supports-color": {
       "version": "7.2.0",

--- a/demos/next-i18next/package.json
+++ b/demos/next-i18next/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "next": "^12.3.0",
+    "next": "^12.3.2-canary.43",
     "next-i18next": "^11.0.0",
     "react": "18.1.0",
     "react-dom": "18.1.0"

--- a/demos/next-i18next/pages/index.js
+++ b/demos/next-i18next/pages/index.js
@@ -17,7 +17,7 @@ export default function IndexPage() {
       </p>
       <div>
         <Link href="/" locale={router.locale === 'en' ? 'fr' : 'en'}>
-          <a>Change locale</a>
+          Change locale
         </Link>
       </div>
       <p>The text below will be translated:</p>

--- a/demos/nx-next-monorepo-demo/package-lock.json
+++ b/demos/nx-next-monorepo-demo/package-lock.json
@@ -1966,7 +1966,7 @@
       "version": "2.88.10",
       "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.10.tgz",
       "integrity": "sha512-Zp7F+R93N0yZyG34GutyTNr+okam7s/Fzc1+i3kcqOP8vk6OuajuE9qZJ6Rs+10/1JFtXFYMdyarnU1rZuJesg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -1995,7 +1995,7 @@
       "version": "6.5.3",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
       "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=0.6"
       }
@@ -2020,7 +2020,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@cypress/xvfb/-/xvfb-1.2.4.tgz",
       "integrity": "sha512-skbBzPggOVYCbnGgV+0dmBdW/s77ZkAOXIC1knS8NagwDjBrNC1LuXtQJeiN6l+m7lzmHtaoUw/ctJKdqkG57Q==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "debug": "^3.1.0",
         "lodash.once": "^4.1.1"
@@ -2030,7 +2030,7 @@
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
       }
@@ -2039,7 +2039,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.2.tgz",
       "integrity": "sha512-AXYd23w1S/bv3fTs3Lz0vjiYemS08jWkI3hYyS9I1ry+0f+Yjs1wm+sU0BS8qDOPrBIkp4qHYC16I8uVtpLajQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -2062,13 +2062,13 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
       "version": "13.17.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
       "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -2083,7 +2083,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -2095,7 +2095,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -2107,7 +2107,7 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -2119,7 +2119,7 @@
       "version": "0.9.5",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
       "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
@@ -2133,7 +2133,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -4391,13 +4391,13 @@
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.1.tgz",
       "integrity": "sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@types/sizzle": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
       "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@types/sockjs": {
       "version": "0.3.33",
@@ -4974,7 +4974,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "devOptional": true,
+      "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
@@ -5003,7 +5003,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
       "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "clean-stack": "^2.0.0",
         "indent-string": "^4.0.0"
@@ -5142,7 +5142,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
       "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5255,7 +5255,7 @@
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
       "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "safer-buffer": "~2.1.0"
       }
@@ -5264,7 +5264,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=0.8"
       }
@@ -5279,7 +5279,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -5293,13 +5293,13 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -5351,7 +5351,7 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -5360,7 +5360,7 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/axe-core": {
       "version": "4.4.3",
@@ -5666,7 +5666,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "tweetnacl": "^0.14.3"
       }
@@ -5701,7 +5701,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/blob-util/-/blob-util-2.0.2.tgz",
       "integrity": "sha512-T7JQa+zsXXEa6/8ZhHcQEW1UFfVM49Ts65uBkFL6fz2QmrElqmbajIDJvuA0tEhRe5eIjpV9ZF+0RfZR9voJFQ==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/bluebird": {
       "version": "3.7.1",
@@ -5893,7 +5893,7 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -5926,7 +5926,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.3.0.tgz",
       "integrity": "sha512-A+Fezp4zxnit6FanDmv9EqXNAi3vt9DWp51/71UEhXukb7QUuvtv9344h91dyAxuTLoSYJFU299qzR3tzwPAhw==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -5992,7 +5992,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/chalk": {
       "version": "4.1.0",
@@ -6021,7 +6021,7 @@
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
       "integrity": "sha512-Pj779qHxV2tuapviy1bSZNEL1maXr13bPYpsvSDB68HlYcYuhlDrmGd63i0JHMCLKzc7rUSNIrpdJlhVlNwrxA==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -6074,7 +6074,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -6105,7 +6105,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.3.tgz",
       "integrity": "sha512-w5Jac5SykAeZJKntOxJCrm63Eg5/4dhMWIcuTbo9rpE+brgaSZo0RuNJZeOyMgsUdhDeojvgyQLmjI+K50ZGyg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "string-width": "^4.2.0"
       },
@@ -6120,7 +6120,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
       "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "slice-ansi": "^3.0.0",
         "string-width": "^4.2.0"
@@ -6210,7 +6210,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -6235,7 +6235,7 @@
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
       "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -6905,7 +6905,7 @@
       "version": "10.10.0",
       "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.10.0.tgz",
       "integrity": "sha512-bU8r44x1NIYAUNNXt3CwJpLOVth7HUv2hUhYCxZmgZ1IugowDvuHNpevnoZRQx1KKOEisLvIJW+Xen5Pjn41pg==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@cypress/request": "^2.88.10",
@@ -6962,19 +6962,19 @@
       "version": "14.18.32",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.32.tgz",
       "integrity": "sha512-Y6S38pFr04yb13qqHf8uk1nHE3lXgQ30WZbv1mLliV9pt0NjvqdWttLcrOYLnXbOafknVYRHZGoMSpR9UwfYow==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/cypress/node_modules/bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/cypress/node_modules/commander": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
       "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -6983,7 +6983,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
       "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "cross-spawn": "^7.0.0",
         "get-stream": "^5.0.0",
@@ -7006,7 +7006,7 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
       "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
@@ -7021,7 +7021,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "pump": "^3.0.0"
       },
@@ -7036,7 +7036,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
       "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=8.12.0"
       }
@@ -7045,7 +7045,7 @@
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -7066,7 +7066,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "assert-plus": "^1.0.0"
       },
@@ -7105,7 +7105,7 @@
       "version": "1.11.5",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.5.tgz",
       "integrity": "sha512-CAdX5Q3YW3Gclyo5Vpqkgpj8fSdLQcRuzfX6mC6Phy0nfJ0eGYOeS7m4mt2plDWLAtA4TqTakvbboHvUxfe4iA==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -7146,7 +7146,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/deepmerge": {
       "version": "4.2.2",
@@ -7194,7 +7194,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -7276,7 +7276,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
       "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "esutils": "^2.0.2"
       },
@@ -7378,7 +7378,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -7687,7 +7687,7 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.15.0.tgz",
       "integrity": "sha512-GG5USZ1jhCu8HJkzGgeK8/+RGnHaNYZGrGDzUtigK3BsGESW/rs2az23XqE0WVwDxy1VRvvjSSGu5nB0Bu+6SA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.2.3",
         "@humanwhocodes/config-array": "^0.9.2",
@@ -8097,7 +8097,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
       "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "eslint-visitor-keys": "^2.0.0"
       },
@@ -8115,7 +8115,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
       "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -8124,7 +8124,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
       "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
@@ -8133,13 +8133,13 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/eslint/node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -8151,7 +8151,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
       "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -8164,7 +8164,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -8176,7 +8176,7 @@
       "version": "13.17.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
       "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -8191,7 +8191,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -8203,7 +8203,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -8215,7 +8215,7 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -8227,7 +8227,7 @@
       "version": "9.4.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.0.tgz",
       "integrity": "sha512-DQmnRpLj7f6TgN/NYb0MTzJXL+vJF9h3pHy4JhCIs3zwcgez8xmGg3sXHcEO97BrmO2OSvCwMdfdlyl+E9KjOw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "acorn": "^8.8.0",
         "acorn-jsx": "^5.3.2",
@@ -8307,7 +8307,7 @@
       "version": "6.4.7",
       "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.7.tgz",
       "integrity": "sha512-tYUSVOGeQPKt/eC1ABfhHy5Xd96N3oIijJvN3O9+TsC28T5V9yX9oEfEK5faP0EFSNVOG97qtAS68GBrQB2hDg==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
@@ -8348,7 +8348,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/executable/-/executable-4.1.1.tgz",
       "integrity": "sha512-8iA79xD3uAch729dUG8xaaBBFGaEa0wdD2VkYLFHwlqosEj/jT66AzcreRDSgV7ehnNLBW2WR5jIXwGKjVdTLg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "pify": "^2.2.0"
       },
@@ -8491,13 +8491,13 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/extract-zip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
@@ -8517,7 +8517,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "pump": "^3.0.0"
       },
@@ -8532,7 +8532,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
-      "devOptional": true,
+      "dev": true,
       "engines": [
         "node >=0.6.0"
       ]
@@ -8566,7 +8566,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/fastq": {
       "version": "1.13.0",
@@ -8599,7 +8599,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "pend": "~1.2.0"
       }
@@ -8622,7 +8622,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
       "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "flat-cache": "^3.0.4"
       },
@@ -8781,7 +8781,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
       "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "flatted": "^3.1.0",
         "rimraf": "^3.0.2"
@@ -8794,7 +8794,7 @@
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/follow-redirects": {
       "version": "1.15.2",
@@ -8819,7 +8819,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -8890,7 +8890,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -8996,7 +8996,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/functions-have-names": {
       "version": "1.2.3",
@@ -9091,7 +9091,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/getos/-/getos-3.2.1.tgz",
       "integrity": "sha512-U56CfOK17OKgTVqozZjUKNdkfEv6jk5WISBJ8SHoagjE6L69zOwl3Z+O8myjY9MEW3i2HPWQBt/LTbCgcC973Q==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "async": "^3.2.0"
       }
@@ -9100,7 +9100,7 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "assert-plus": "^1.0.0"
       }
@@ -9155,7 +9155,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.0.tgz",
       "integrity": "sha512-v8ho2DS5RiCjftj1nD9NmnfaOzTdud7RRnVd9kFNOjqZbISlx5DQ+OrTkywgd0dIt7oFCvKetZSHoHcP3sDdiA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "ini": "2.0.0"
       },
@@ -9466,7 +9466,7 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.3.6.tgz",
       "integrity": "sha512-3adrsD6zqo4GsTqtO7FyrejHNv+NgiIfAfv68+jVlFmSr9OGy7zrxONceFRLKvnnZA5jbxQBX1u9PpB6Wi32Gw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "assert-plus": "^1.0.0",
         "jsprim": "^2.0.2",
@@ -9655,7 +9655,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -9678,7 +9678,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
       "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -9779,7 +9779,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
       "integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "ci-info": "^3.2.0"
       },
@@ -9866,7 +9866,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.4.0.tgz",
       "integrity": "sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "global-dirs": "^3.0.0",
         "is-path-inside": "^3.0.2"
@@ -9922,7 +9922,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
       "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -10033,13 +10033,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -10092,7 +10092,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -11119,7 +11119,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/jsdom": {
       "version": "19.0.0",
@@ -11231,7 +11231,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -11242,13 +11242,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/json5": {
       "version": "2.2.1",
@@ -11281,7 +11281,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-2.0.2.tgz",
       "integrity": "sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==",
-      "devOptional": true,
+      "dev": true,
       "engines": [
         "node >=0.6.0"
       ],
@@ -11349,7 +11349,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
       "integrity": "sha512-cc8oEVoctTvsFZ/Oje/kGnHbpWHYBe8IAJe4C0QNc3t8uM/0Y8+erSz/7Y1ALuXTEZTMvxXwO6YbX1ey3ujiZw==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": "> 0.8"
       }
@@ -11453,7 +11453,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -11495,7 +11495,7 @@
       "version": "3.14.0",
       "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.14.0.tgz",
       "integrity": "sha512-TyWI8G99GX9GjE54cJ+RrNMcIFBfwMPxc3XTFiAYGN4s10hWROGtOg7+O6u6LE3mNkyld7RSLE6nrKBvTfcs3g==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "cli-truncate": "^2.1.0",
         "colorette": "^2.0.16",
@@ -11522,13 +11522,13 @@
       "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
       "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/listr2/node_modules/rxjs": {
       "version": "7.5.6",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.6.tgz",
       "integrity": "sha512-dnyv2/YsXhnm461G+R/Pe5bWP41Nm6LBXEYWI6eiFP4fiwx6WRI/CD0zbdVAudd9xwLEF2IDcKXLHit0FYjUzw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -11603,13 +11603,13 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/lodash.uniq": {
       "version": "4.5.0",
@@ -11620,7 +11620,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
       "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "chalk": "^4.1.0",
         "is-unicode-supported": "^0.1.0"
@@ -11636,7 +11636,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
       "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "ansi-escapes": "^4.3.0",
         "cli-cursor": "^3.1.0",
@@ -11654,7 +11654,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
       "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "astral-regex": "^2.0.0",
@@ -11671,7 +11671,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -12448,7 +12448,7 @@
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
       "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -12465,7 +12465,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/ospath/-/ospath-1.2.2.tgz",
       "integrity": "sha512-o6E5qJV5zkAbIDNhGSIlyOhScKXgQrSRMilfph0clDfM0nEnBOlKlH4sWDmG95BW/CvwNz0vmm7dJVtU2KlMiA==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/p-finally": {
       "version": "1.0.0",
@@ -12507,7 +12507,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
       "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "aggregate-error": "^3.0.0"
       },
@@ -12694,13 +12694,13 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
@@ -13396,7 +13396,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -13405,7 +13405,7 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
       "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -13420,7 +13420,7 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
       "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=6"
       },
@@ -13520,7 +13520,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
       "integrity": "sha512-F2JHgJQ1iqwnHDcQjVBsq3n/uoaFL+iPW/eAeL7kVxy/2RrWaN4WroKjjvbsoRtv0ftelNyC01bjRhn/bhcf4A==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/prr": {
       "version": "1.0.1",
@@ -13532,13 +13532,13 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
       "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -13825,7 +13825,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -13877,7 +13877,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
       "integrity": "sha512-MnWzEHHaxHO2iWiQuHrUPBi/1WeBf5PkxQqNyNvLl9VAYSdXkP8tQ3pBSeCPD+yw0v0Aq1zosWLz0BdeXpWwZg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "throttleit": "^1.0.0"
       }
@@ -13980,7 +13980,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
       "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
@@ -14568,7 +14568,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
       "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "astral-regex": "^2.0.0",
@@ -14693,7 +14693,7 @@
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
       "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -15257,13 +15257,13 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/throttleit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
       "integrity": "sha512-rkTVqu6IjfQ/6+uNuuc3sZek4CEYxTJom3IktzgdSxcZqdARuebbA/f4QmAxMQIxqq9ZLEUkSYqvuk1I6VKq4g==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/through": {
       "version": "2.3.8",
@@ -15322,7 +15322,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
       "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
@@ -15524,7 +15524,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -15536,13 +15536,13 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "prelude-ls": "^1.2.1"
       },
@@ -15590,6 +15590,7 @@
       "version": "4.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
       "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15680,7 +15681,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
       "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -15855,7 +15856,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
-      "devOptional": true,
+      "dev": true,
       "engines": [
         "node >=0.6.0"
       ],
@@ -15869,7 +15870,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
@@ -16305,7 +16306,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16428,7 +16429,7 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
@@ -17736,7 +17737,7 @@
       "version": "2.88.10",
       "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.10.tgz",
       "integrity": "sha512-Zp7F+R93N0yZyG34GutyTNr+okam7s/Fzc1+i3kcqOP8vk6OuajuE9qZJ6Rs+10/1JFtXFYMdyarnU1rZuJesg==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -17762,7 +17763,7 @@
           "version": "6.5.3",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
           "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
-          "devOptional": true
+          "dev": true
         }
       }
     },
@@ -17780,7 +17781,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@cypress/xvfb/-/xvfb-1.2.4.tgz",
       "integrity": "sha512-skbBzPggOVYCbnGgV+0dmBdW/s77ZkAOXIC1knS8NagwDjBrNC1LuXtQJeiN6l+m7lzmHtaoUw/ctJKdqkG57Q==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "debug": "^3.1.0",
         "lodash.once": "^4.1.1"
@@ -17790,7 +17791,7 @@
           "version": "3.2.7",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
           "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -17801,7 +17802,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.2.tgz",
       "integrity": "sha512-AXYd23w1S/bv3fTs3Lz0vjiYemS08jWkI3hYyS9I1ry+0f+Yjs1wm+sU0BS8qDOPrBIkp4qHYC16I8uVtpLajQ==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -17818,13 +17819,13 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
           "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-          "devOptional": true
+          "dev": true
         },
         "globals": {
           "version": "13.17.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
           "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
           }
@@ -17833,7 +17834,7 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
           "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "argparse": "^2.0.1"
           }
@@ -17842,7 +17843,7 @@
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
           "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -17851,7 +17852,7 @@
           "version": "0.20.2",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
           "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-          "devOptional": true
+          "dev": true
         }
       }
     },
@@ -17859,7 +17860,7 @@
       "version": "0.9.5",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
       "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
@@ -17870,7 +17871,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
-      "devOptional": true
+      "dev": true
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -18991,50 +18992,42 @@
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-6.3.1.tgz",
-      "integrity": "sha512-jDBKArXYO1u0B1dmd2Nf8Oy6aTF5vLDfLoO9Oon/GLkqZ/NiggYWZA+a2HpUMH4ITwNqS3z43k8LWApB8S583w==",
-      "requires": {}
+      "integrity": "sha512-jDBKArXYO1u0B1dmd2Nf8Oy6aTF5vLDfLoO9Oon/GLkqZ/NiggYWZA+a2HpUMH4ITwNqS3z43k8LWApB8S583w=="
     },
     "@svgr/babel-plugin-remove-jsx-attribute": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-6.3.1.tgz",
-      "integrity": "sha512-dQzyJ4prwjcFd929T43Z8vSYiTlTu8eafV40Z2gO7zy/SV5GT+ogxRJRBIKWomPBOiaVXFg3jY4S5hyEN3IBjQ==",
-      "requires": {}
+      "integrity": "sha512-dQzyJ4prwjcFd929T43Z8vSYiTlTu8eafV40Z2gO7zy/SV5GT+ogxRJRBIKWomPBOiaVXFg3jY4S5hyEN3IBjQ=="
     },
     "@svgr/babel-plugin-remove-jsx-empty-expression": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-6.3.1.tgz",
-      "integrity": "sha512-HBOUc1XwSU67fU26V5Sfb8MQsT0HvUyxru7d0oBJ4rA2s4HW3PhyAPC7fV/mdsSGpAvOdd8Wpvkjsr0fWPUO7A==",
-      "requires": {}
+      "integrity": "sha512-HBOUc1XwSU67fU26V5Sfb8MQsT0HvUyxru7d0oBJ4rA2s4HW3PhyAPC7fV/mdsSGpAvOdd8Wpvkjsr0fWPUO7A=="
     },
     "@svgr/babel-plugin-replace-jsx-attribute-value": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-6.3.1.tgz",
-      "integrity": "sha512-C12e6aN4BXAolRrI601gPn5MDFCRHO7C4TM8Kks+rDtl8eEq+NN1sak0eAzJu363x3TmHXdZn7+Efd2nr9I5dA==",
-      "requires": {}
+      "integrity": "sha512-C12e6aN4BXAolRrI601gPn5MDFCRHO7C4TM8Kks+rDtl8eEq+NN1sak0eAzJu363x3TmHXdZn7+Efd2nr9I5dA=="
     },
     "@svgr/babel-plugin-svg-dynamic-title": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-6.3.1.tgz",
-      "integrity": "sha512-6NU55Mmh3M5u2CfCCt6TX29/pPneutrkJnnDCHbKZnjukZmmgUAZLtZ2g6ZoSPdarowaQmAiBRgAHqHmG0vuqA==",
-      "requires": {}
+      "integrity": "sha512-6NU55Mmh3M5u2CfCCt6TX29/pPneutrkJnnDCHbKZnjukZmmgUAZLtZ2g6ZoSPdarowaQmAiBRgAHqHmG0vuqA=="
     },
     "@svgr/babel-plugin-svg-em-dimensions": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-6.3.1.tgz",
-      "integrity": "sha512-HV1NGHYTTe1vCNKlBgq/gKuCSfaRlKcHIADn7P8w8U3Zvujdw1rmusutghJ1pZJV7pDt3Gt8ws+SVrqHnBO/Qw==",
-      "requires": {}
+      "integrity": "sha512-HV1NGHYTTe1vCNKlBgq/gKuCSfaRlKcHIADn7P8w8U3Zvujdw1rmusutghJ1pZJV7pDt3Gt8ws+SVrqHnBO/Qw=="
     },
     "@svgr/babel-plugin-transform-react-native-svg": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-6.3.1.tgz",
-      "integrity": "sha512-2wZhSHvTolFNeKDAN/ZmIeSz2O9JSw72XD+o2bNp2QAaWqa8KGpn5Yk5WHso6xqfSAiRzAE+GXlsrBO4UP9LLw==",
-      "requires": {}
+      "integrity": "sha512-2wZhSHvTolFNeKDAN/ZmIeSz2O9JSw72XD+o2bNp2QAaWqa8KGpn5Yk5WHso6xqfSAiRzAE+GXlsrBO4UP9LLw=="
     },
     "@svgr/babel-plugin-transform-svg-component": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-6.3.1.tgz",
-      "integrity": "sha512-cZ8Tr6ZAWNUFfDeCKn/pGi976iWSkS8ijmEYKosP+6ktdZ7lW9HVLHojyusPw3w0j8PI4VBeWAXAmi/2G7owxw==",
-      "requires": {}
+      "integrity": "sha512-cZ8Tr6ZAWNUFfDeCKn/pGi976iWSkS8ijmEYKosP+6ktdZ7lW9HVLHojyusPw3w0j8PI4VBeWAXAmi/2G7owxw=="
     },
     "@svgr/babel-preset": {
       "version": "6.3.1",
@@ -19571,13 +19564,13 @@
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.1.tgz",
       "integrity": "sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==",
-      "devOptional": true
+      "dev": true
     },
     "@types/sizzle": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
       "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
-      "devOptional": true
+      "dev": true
     },
     "@types/sockjs": {
       "version": "0.3.33",
@@ -20015,15 +20008,13 @@
     "acorn-import-assertions": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
-      "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-      "requires": {}
+      "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw=="
     },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "devOptional": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "8.2.0",
@@ -20043,7 +20034,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
       "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "clean-stack": "^2.0.0",
         "indent-string": "^4.0.0"
@@ -20089,8 +20080,7 @@
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "requires": {}
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
     },
     "ansi-colors": {
       "version": "4.1.3",
@@ -20136,7 +20126,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
       "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
-      "devOptional": true
+      "dev": true
     },
     "arg": {
       "version": "4.1.3",
@@ -20208,7 +20198,7 @@
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
       "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -20217,7 +20207,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
-      "devOptional": true
+      "dev": true
     },
     "ast-types-flow": {
       "version": "0.0.7",
@@ -20229,7 +20219,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-      "devOptional": true
+      "dev": true
     },
     "async": {
       "version": "3.2.4",
@@ -20240,13 +20230,13 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "devOptional": true
+      "dev": true
     },
     "at-least-node": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-      "devOptional": true
+      "dev": true
     },
     "atob": {
       "version": "2.1.2",
@@ -20270,13 +20260,13 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
-      "devOptional": true
+      "dev": true
     },
     "aws4": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
-      "devOptional": true
+      "dev": true
     },
     "axe-core": {
       "version": "4.4.3",
@@ -20509,7 +20499,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "tweetnacl": "^0.14.3"
       }
@@ -20538,7 +20528,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/blob-util/-/blob-util-2.0.2.tgz",
       "integrity": "sha512-T7JQa+zsXXEa6/8ZhHcQEW1UFfVM49Ts65uBkFL6fz2QmrElqmbajIDJvuA0tEhRe5eIjpV9ZF+0RfZR9voJFQ==",
-      "devOptional": true
+      "dev": true
     },
     "bluebird": {
       "version": "3.7.1",
@@ -20680,7 +20670,7 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "devOptional": true
+      "dev": true
     },
     "buffer-from": {
       "version": "1.1.2",
@@ -20701,7 +20691,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.3.0.tgz",
       "integrity": "sha512-A+Fezp4zxnit6FanDmv9EqXNAi3vt9DWp51/71UEhXukb7QUuvtv9344h91dyAxuTLoSYJFU299qzR3tzwPAhw==",
-      "devOptional": true
+      "dev": true
     },
     "call-bind": {
       "version": "1.0.2",
@@ -20742,7 +20732,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
-      "devOptional": true
+      "dev": true
     },
     "chalk": {
       "version": "4.1.0",
@@ -20762,7 +20752,7 @@
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
       "integrity": "sha512-Pj779qHxV2tuapviy1bSZNEL1maXr13bPYpsvSDB68HlYcYuhlDrmGd63i0JHMCLKzc7rUSNIrpdJlhVlNwrxA==",
-      "devOptional": true
+      "dev": true
     },
     "chokidar": {
       "version": "3.5.3",
@@ -20798,7 +20788,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "devOptional": true
+      "dev": true
     },
     "cli-cursor": {
       "version": "3.1.0",
@@ -20817,7 +20807,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.3.tgz",
       "integrity": "sha512-w5Jac5SykAeZJKntOxJCrm63Eg5/4dhMWIcuTbo9rpE+brgaSZo0RuNJZeOyMgsUdhDeojvgyQLmjI+K50ZGyg==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "@colors/colors": "1.5.0",
         "string-width": "^4.2.0"
@@ -20827,7 +20817,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
       "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "slice-ansi": "^3.0.0",
         "string-width": "^4.2.0"
@@ -20900,7 +20890,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -20919,7 +20909,7 @@
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
       "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
-      "devOptional": true
+      "dev": true
     },
     "commondir": {
       "version": "1.0.1",
@@ -21165,8 +21155,7 @@
     "css-declaration-sorter": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.3.1.tgz",
-      "integrity": "sha512-fBffmak0bPAnyqc/HO8C3n2sHrp9wcqQz6ES9koRF2/mLOVAx9zIQ3Y7R29sYCteTPqMCwns4WYQoCX91Xl3+w==",
-      "requires": {}
+      "integrity": "sha512-fBffmak0bPAnyqc/HO8C3n2sHrp9wcqQz6ES9koRF2/mLOVAx9zIQ3Y7R29sYCteTPqMCwns4WYQoCX91Xl3+w=="
     },
     "css-loader": {
       "version": "6.7.1",
@@ -21353,8 +21342,7 @@
     "cssnano-utils": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.1.0.tgz",
-      "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==",
-      "requires": {}
+      "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA=="
     },
     "csso": {
       "version": "4.2.0",
@@ -21397,7 +21385,7 @@
       "version": "10.10.0",
       "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.10.0.tgz",
       "integrity": "sha512-bU8r44x1NIYAUNNXt3CwJpLOVth7HUv2hUhYCxZmgZ1IugowDvuHNpevnoZRQx1KKOEisLvIJW+Xen5Pjn41pg==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",
         "@cypress/xvfb": "^1.2.4",
@@ -21447,25 +21435,25 @@
           "version": "14.18.32",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.32.tgz",
           "integrity": "sha512-Y6S38pFr04yb13qqHf8uk1nHE3lXgQ30WZbv1mLliV9pt0NjvqdWttLcrOYLnXbOafknVYRHZGoMSpR9UwfYow==",
-          "devOptional": true
+          "dev": true
         },
         "bluebird": {
           "version": "3.7.2",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
           "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-          "devOptional": true
+          "dev": true
         },
         "commander": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
           "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-          "devOptional": true
+          "dev": true
         },
         "execa": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
           "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "cross-spawn": "^7.0.0",
             "get-stream": "^5.0.0",
@@ -21482,7 +21470,7 @@
           "version": "9.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
           "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "at-least-node": "^1.0.0",
             "graceful-fs": "^4.2.0",
@@ -21494,7 +21482,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
           "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "pump": "^3.0.0"
           }
@@ -21503,13 +21491,13 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
           "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
-          "devOptional": true
+          "dev": true
         },
         "supports-color": {
           "version": "8.1.1",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
           "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -21526,7 +21514,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -21558,7 +21546,7 @@
       "version": "1.11.5",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.5.tgz",
       "integrity": "sha512-CAdX5Q3YW3Gclyo5Vpqkgpj8fSdLQcRuzfX6mC6Phy0nfJ0eGYOeS7m4mt2plDWLAtA4TqTakvbboHvUxfe4iA==",
-      "devOptional": true
+      "dev": true
     },
     "debug": {
       "version": "4.3.4",
@@ -21588,7 +21576,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "devOptional": true
+      "dev": true
     },
     "deepmerge": {
       "version": "4.2.2",
@@ -21621,7 +21609,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "devOptional": true
+      "dev": true
     },
     "depd": {
       "version": "2.0.0",
@@ -21678,7 +21666,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
       "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "esutils": "^2.0.2"
       }
@@ -21752,7 +21740,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -21988,7 +21976,7 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.15.0.tgz",
       "integrity": "sha512-GG5USZ1jhCu8HJkzGgeK8/+RGnHaNYZGrGDzUtigK3BsGESW/rs2az23XqE0WVwDxy1VRvvjSSGu5nB0Bu+6SA==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "@eslint/eslintrc": "^1.2.3",
         "@humanwhocodes/config-array": "^0.9.2",
@@ -22031,19 +22019,19 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
           "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-          "devOptional": true
+          "dev": true
         },
         "escape-string-regexp": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
           "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-          "devOptional": true
+          "dev": true
         },
         "eslint-scope": {
           "version": "7.1.1",
           "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
           "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "esrecurse": "^4.3.0",
             "estraverse": "^5.2.0"
@@ -22053,7 +22041,7 @@
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
           "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "is-glob": "^4.0.3"
           }
@@ -22062,7 +22050,7 @@
           "version": "13.17.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
           "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
           }
@@ -22071,7 +22059,7 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
           "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "argparse": "^2.0.1"
           }
@@ -22080,7 +22068,7 @@
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
           "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -22089,7 +22077,7 @@
           "version": "0.20.2",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
           "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-          "devOptional": true
+          "dev": true
         }
       }
     },
@@ -22114,8 +22102,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.1.0.tgz",
       "integrity": "sha512-oKMhGv3ihGbCIimCAjqkdzx2Q+jthoqnXSP+d86M9tptwugycmTFdVR4IpLgq2c4SHifbwO90z2fQ8/Aio73yw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-import-resolver-node": {
       "version": "0.3.6",
@@ -22353,8 +22340,7 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
       "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-scope": {
       "version": "5.1.1",
@@ -22376,7 +22362,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
       "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "eslint-visitor-keys": "^2.0.0"
       },
@@ -22385,7 +22371,7 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
           "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-          "devOptional": true
+          "dev": true
         }
       }
     },
@@ -22393,13 +22379,13 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
       "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-      "devOptional": true
+      "dev": true
     },
     "espree": {
       "version": "9.4.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.0.tgz",
       "integrity": "sha512-DQmnRpLj7f6TgN/NYb0MTzJXL+vJF9h3pHy4JhCIs3zwcgez8xmGg3sXHcEO97BrmO2OSvCwMdfdlyl+E9KjOw==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "acorn": "^8.8.0",
         "acorn-jsx": "^5.3.2",
@@ -22451,7 +22437,7 @@
       "version": "6.4.7",
       "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.7.tgz",
       "integrity": "sha512-tYUSVOGeQPKt/eC1ABfhHy5Xd96N3oIijJvN3O9+TsC28T5V9yX9oEfEK5faP0EFSNVOG97qtAS68GBrQB2hDg==",
-      "devOptional": true
+      "dev": true
     },
     "eventemitter3": {
       "version": "4.0.7",
@@ -22483,7 +22469,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/executable/-/executable-4.1.1.tgz",
       "integrity": "sha512-8iA79xD3uAch729dUG8xaaBBFGaEa0wdD2VkYLFHwlqosEj/jT66AzcreRDSgV7ehnNLBW2WR5jIXwGKjVdTLg==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "pify": "^2.2.0"
       }
@@ -22595,13 +22581,13 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "devOptional": true
+      "dev": true
     },
     "extract-zip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "@types/yauzl": "^2.9.1",
         "debug": "^4.1.1",
@@ -22613,7 +22599,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
           "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "pump": "^3.0.0"
           }
@@ -22624,7 +22610,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
-      "devOptional": true
+      "dev": true
     },
     "fast-deep-equal": {
       "version": "3.1.3",
@@ -22652,7 +22638,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-      "devOptional": true
+      "dev": true
     },
     "fastq": {
       "version": "1.13.0",
@@ -22682,7 +22668,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "pend": "~1.2.0"
       }
@@ -22699,7 +22685,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
       "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "flat-cache": "^3.0.4"
       }
@@ -22821,7 +22807,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
       "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "flatted": "^3.1.0",
         "rimraf": "^3.0.2"
@@ -22831,7 +22817,7 @@
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
-      "devOptional": true
+      "dev": true
     },
     "follow-redirects": {
       "version": "1.15.2",
@@ -22842,7 +22828,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
-      "devOptional": true
+      "dev": true
     },
     "fork-ts-checker-webpack-plugin": {
       "version": "7.2.13",
@@ -22886,7 +22872,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -22960,7 +22946,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
-      "devOptional": true
+      "dev": true
     },
     "functions-have-names": {
       "version": "1.2.3",
@@ -23027,7 +23013,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/getos/-/getos-3.2.1.tgz",
       "integrity": "sha512-U56CfOK17OKgTVqozZjUKNdkfEv6jk5WISBJ8SHoagjE6L69zOwl3Z+O8myjY9MEW3i2HPWQBt/LTbCgcC973Q==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "async": "^3.2.0"
       }
@@ -23036,7 +23022,7 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -23081,7 +23067,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.0.tgz",
       "integrity": "sha512-v8ho2DS5RiCjftj1nD9NmnfaOzTdud7RRnVd9kFNOjqZbISlx5DQ+OrTkywgd0dIt7oFCvKetZSHoHcP3sDdiA==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "ini": "2.0.0"
       }
@@ -23315,7 +23301,7 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.3.6.tgz",
       "integrity": "sha512-3adrsD6zqo4GsTqtO7FyrejHNv+NgiIfAfv68+jVlFmSr9OGy7zrxONceFRLKvnnZA5jbxQBX1u9PpB6Wi32Gw==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^2.0.2",
@@ -23353,8 +23339,7 @@
     "icss-utils": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
-      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-      "requires": {}
+      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA=="
     },
     "identity-obj-proxy": {
       "version": "3.0.0",
@@ -23436,7 +23421,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "devOptional": true
+      "dev": true
     },
     "inflight": {
       "version": "1.0.6",
@@ -23456,7 +23441,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
       "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
-      "devOptional": true
+      "dev": true
     },
     "internal-slot": {
       "version": "1.0.3",
@@ -23524,7 +23509,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
       "integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "ci-info": "^3.2.0"
       }
@@ -23578,7 +23563,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.4.0.tgz",
       "integrity": "sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "global-dirs": "^3.0.0",
         "is-path-inside": "^3.0.2"
@@ -23613,7 +23598,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
       "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-      "devOptional": true
+      "dev": true
     },
     "is-plain-obj": {
       "version": "3.0.0",
@@ -23685,13 +23670,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-      "devOptional": true
+      "dev": true
     },
     "is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-      "devOptional": true
+      "dev": true
     },
     "is-weakref": {
       "version": "1.0.2",
@@ -23729,7 +23714,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
-      "devOptional": true
+      "dev": true
     },
     "istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -24192,8 +24177,7 @@
     "jest-pnp-resolver": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
-      "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "requires": {}
+      "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w=="
     },
     "jest-regex-util": {
       "version": "28.0.2",
@@ -24539,7 +24523,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
-      "devOptional": true
+      "dev": true
     },
     "jsdom": {
       "version": "19.0.0",
@@ -24627,7 +24611,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "devOptional": true
+      "dev": true
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -24638,13 +24622,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-      "devOptional": true
+      "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "devOptional": true
+      "dev": true
     },
     "json5": {
       "version": "2.2.1",
@@ -24669,7 +24653,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-2.0.2.tgz",
       "integrity": "sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -24722,7 +24706,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
       "integrity": "sha512-cc8oEVoctTvsFZ/Oje/kGnHbpWHYBe8IAJe4C0QNc3t8uM/0Y8+erSz/7Y1ALuXTEZTMvxXwO6YbX1ey3ujiZw==",
-      "devOptional": true
+      "dev": true
     },
     "less": {
       "version": "3.12.2",
@@ -24791,7 +24775,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -24819,7 +24803,7 @@
       "version": "3.14.0",
       "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.14.0.tgz",
       "integrity": "sha512-TyWI8G99GX9GjE54cJ+RrNMcIFBfwMPxc3XTFiAYGN4s10hWROGtOg7+O6u6LE3mNkyld7RSLE6nrKBvTfcs3g==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "cli-truncate": "^2.1.0",
         "colorette": "^2.0.16",
@@ -24835,13 +24819,13 @@
           "version": "2.0.19",
           "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
           "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
-          "devOptional": true
+          "dev": true
         },
         "rxjs": {
           "version": "7.5.6",
           "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.6.tgz",
           "integrity": "sha512-dnyv2/YsXhnm461G+R/Pe5bWP41Nm6LBXEYWI6eiFP4fiwx6WRI/CD0zbdVAudd9xwLEF2IDcKXLHit0FYjUzw==",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "tslib": "^2.1.0"
           }
@@ -24905,13 +24889,13 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "devOptional": true
+      "dev": true
     },
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
-      "devOptional": true
+      "dev": true
     },
     "lodash.uniq": {
       "version": "4.5.0",
@@ -24922,7 +24906,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
       "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "chalk": "^4.1.0",
         "is-unicode-supported": "^0.1.0"
@@ -24932,7 +24916,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
       "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "ansi-escapes": "^4.3.0",
         "cli-cursor": "^3.1.0",
@@ -24944,7 +24928,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
           "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "ansi-styles": "^4.0.0",
             "astral-regex": "^2.0.0",
@@ -24955,7 +24939,7 @@
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
           "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "ansi-styles": "^4.0.0",
             "string-width": "^4.1.0",
@@ -25505,7 +25489,7 @@
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
       "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -25519,7 +25503,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/ospath/-/ospath-1.2.2.tgz",
       "integrity": "sha512-o6E5qJV5zkAbIDNhGSIlyOhScKXgQrSRMilfph0clDfM0nEnBOlKlH4sWDmG95BW/CvwNz0vmm7dJVtU2KlMiA==",
-      "devOptional": true
+      "dev": true
     },
     "p-finally": {
       "version": "1.0.0",
@@ -25546,7 +25530,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
       "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "aggregate-error": "^3.0.0"
       }
@@ -25692,13 +25676,13 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "devOptional": true
+      "dev": true
     },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-      "devOptional": true
+      "dev": true
     },
     "picocolors": {
       "version": "1.0.0",
@@ -25833,26 +25817,22 @@
     "postcss-discard-comments": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.2.tgz",
-      "integrity": "sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ==",
-      "requires": {}
+      "integrity": "sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ=="
     },
     "postcss-discard-duplicates": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.1.0.tgz",
-      "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==",
-      "requires": {}
+      "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw=="
     },
     "postcss-discard-empty": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.1.1.tgz",
-      "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A==",
-      "requires": {}
+      "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A=="
     },
     "postcss-discard-overridden": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.1.0.tgz",
-      "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==",
-      "requires": {}
+      "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw=="
     },
     "postcss-import": {
       "version": "14.1.0",
@@ -25967,8 +25947,7 @@
     "postcss-modules-extract-imports": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
-      "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-      "requires": {}
+      "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw=="
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -25999,8 +25978,7 @@
     "postcss-normalize-charset": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.1.0.tgz",
-      "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==",
-      "requires": {}
+      "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg=="
     },
     "postcss-normalize-display-values": {
       "version": "5.1.0",
@@ -26129,19 +26107,19 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-      "devOptional": true
+      "dev": true
     },
     "prettier": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
       "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
-      "devOptional": true
+      "dev": true
     },
     "pretty-bytes": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
       "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
-      "devOptional": true
+      "dev": true
     },
     "pretty-format": {
       "version": "28.1.3",
@@ -26220,7 +26198,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
       "integrity": "sha512-F2JHgJQ1iqwnHDcQjVBsq3n/uoaFL+iPW/eAeL7kVxy/2RrWaN4WroKjjvbsoRtv0ftelNyC01bjRhn/bhcf4A==",
-      "devOptional": true
+      "dev": true
     },
     "prr": {
       "version": "1.0.1",
@@ -26232,13 +26210,13 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
       "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
-      "devOptional": true
+      "dev": true
     },
     "pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -26448,7 +26426,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-      "devOptional": true
+      "dev": true
     },
     "regexpu-core": {
       "version": "5.2.1",
@@ -26487,7 +26465,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
       "integrity": "sha512-MnWzEHHaxHO2iWiQuHrUPBi/1WeBf5PkxQqNyNvLl9VAYSdXkP8tQ3pBSeCPD+yw0v0Aq1zosWLz0BdeXpWwZg==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "throttleit": "^1.0.0"
       }
@@ -26559,7 +26537,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
       "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
-      "devOptional": true
+      "dev": true
     },
     "rimraf": {
       "version": "3.0.2",
@@ -26637,8 +26615,7 @@
     "rollup-plugin-peer-deps-external": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/rollup-plugin-peer-deps-external/-/rollup-plugin-peer-deps-external-2.2.4.tgz",
-      "integrity": "sha512-AWdukIM1+k5JDdAqV/Cxd+nejvno2FVLVeZ74NKggm3Q5s9cbbcOgUPGdbxPi4BXu7xGaZ8HG12F+thImYu/0g==",
-      "requires": {}
+      "integrity": "sha512-AWdukIM1+k5JDdAqV/Cxd+nejvno2FVLVeZ74NKggm3Q5s9cbbcOgUPGdbxPi4BXu7xGaZ8HG12F+thImYu/0g=="
     },
     "rollup-plugin-postcss": {
       "version": "4.0.2",
@@ -27009,7 +26986,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
       "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "ansi-styles": "^4.0.0",
         "astral-regex": "^2.0.0",
@@ -27110,7 +27087,7 @@
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
       "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -27271,14 +27248,12 @@
     "style-loader": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.1.tgz",
-      "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==",
-      "requires": {}
+      "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ=="
     },
     "styled-jsx": {
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.7.tgz",
-      "integrity": "sha512-b3sUzamS086YLRuvnaDigdAewz1/EFYlHpYBP5mZovKEdQQOIIYq8lApylub3HHZ6xFjV051kkGU7cudJmrXEA==",
-      "requires": {}
+      "integrity": "sha512-b3sUzamS086YLRuvnaDigdAewz1/EFYlHpYBP5mZovKEdQQOIIYq8lApylub3HHZ6xFjV051kkGU7cudJmrXEA=="
     },
     "stylehacks": {
       "version": "5.1.0",
@@ -27490,13 +27465,13 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-      "devOptional": true
+      "dev": true
     },
     "throttleit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
       "integrity": "sha512-rkTVqu6IjfQ/6+uNuuc3sZek4CEYxTJom3IktzgdSxcZqdARuebbA/f4QmAxMQIxqq9ZLEUkSYqvuk1I6VKq4g==",
-      "devOptional": true
+      "dev": true
     },
     "through": {
       "version": "2.3.8",
@@ -27543,7 +27518,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
       "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
@@ -27672,7 +27647,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -27681,13 +27656,13 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
-      "devOptional": true
+      "dev": true
     },
     "type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "prelude-ls": "^1.2.1"
       }
@@ -27719,7 +27694,8 @@
     "typescript": {
       "version": "4.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
-      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig=="
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "dev": true
     },
     "unbox-primitive": {
       "version": "1.0.2",
@@ -27779,7 +27755,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
       "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
-      "devOptional": true
+      "dev": true
     },
     "upath2": {
       "version": "3.1.15",
@@ -27854,8 +27830,7 @@
     "use-sync-external-store": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
-      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
-      "requires": {}
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA=="
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -27901,7 +27876,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -27912,7 +27887,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
           "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
-          "devOptional": true
+          "dev": true
         }
       }
     },
@@ -28231,7 +28206,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "devOptional": true
+      "dev": true
     },
     "wrap-ansi": {
       "version": "7.0.0",
@@ -28260,8 +28235,7 @@
     "ws": {
       "version": "8.9.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.9.0.tgz",
-      "integrity": "sha512-Ja7nszREasGaYUYCI2k4lCKIRTt+y7XuqVoHR44YpI49TtryyqbqvDMn5eqfW7e6HzTukDRIsXqzVHScqRcafg==",
-      "requires": {}
+      "integrity": "sha512-Ja7nszREasGaYUYCI2k4lCKIRTt+y7XuqVoHR44YpI49TtryyqbqvDMn5eqfW7e6HzTukDRIsXqzVHScqRcafg=="
     },
     "xml-name-validator": {
       "version": "4.0.0",
@@ -28313,7 +28287,7 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"

--- a/demos/static-root/package.json
+++ b/demos/static-root/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "dependencies": {
-    "next": "^12.3.0"
+    "next": "^12.3.2-canary.43"
   },
   "devDependencies": {
     "@netlify/plugin-nextjs": "*",

--- a/demos/static-root/pages/index.js
+++ b/demos/static-root/pages/index.js
@@ -1,5 +1,5 @@
 import Head from 'next/head'
-import Image from 'next/image'
+import Image from 'next/legacy/image'
 import { useRouter } from 'next/router'
 import styles from '../styles/Home.module.css'
 
@@ -21,8 +21,7 @@ export default function Home() {
         <p>The current locale is {locale}</p>
 
         <p className={styles.description}>
-          Get started by editing{' '}
-          <code className={styles.code}>pages/index.js</code>
+          Get started by editing <code className={styles.code}>pages/index.js</code>
         </p>
 
         <div className={styles.grid}>
@@ -36,17 +35,12 @@ export default function Home() {
             <p>Learn about Next.js in an interactive course with quizzes!</p>
           </a>
 
-          <a
-            href="https://github.com/vercel/next.js/tree/master/examples"
-            className={styles.card}
-          >
+          <a href="https://github.com/vercel/next.js/tree/master/examples" className={styles.card}>
             <h2>Examples &rarr;</h2>
             <p>Discover and deploy boilerplate example Next.js projects.</p>
           </a>
         </div>
       </main>
-
-
     </div>
   )
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "demos/next-with-edge-functions"
       ],
       "dependencies": {
-        "next": "^12.3.0"
+        "next": "^12.3.2-canary.43"
       },
       "devDependencies": {
         "@babel/core": "^7.15.8",
@@ -66,7 +66,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "next": "^12.3.0"
+        "next": "^12.3.2-canary.43"
       },
       "devDependencies": {
         "@netlify/plugin-nextjs": "*",
@@ -83,7 +83,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "next": "^12.3.0"
+        "next": "^12.3.2-canary.43"
       },
       "devDependencies": {
         "@netlify/plugin-nextjs": "*",
@@ -116,7 +116,7 @@
         "@reach/dialog": "^0.16.2",
         "@reach/visually-hidden": "^0.16.0",
         "@vercel/og": "^0.0.15",
-        "next": "^12.3.0",
+        "next": "^12.3.2-canary.43",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
       },
@@ -194,7 +194,7 @@
       "dependencies": {
         "@netlify/next": "*",
         "@netlify/plugin-nextjs": "*",
-        "next": "^12.3.0",
+        "next": "^12.3.2-canary.43",
         "react": "18.0.0",
         "react-dom": "18.0.0"
       },
@@ -213,7 +213,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "next": "^12.3.0",
+        "next": "^12.3.2-canary.43",
         "next-auth": "^4.7.0",
         "nodemailer": "^6.6.3",
         "react": "^18.0.0",
@@ -249,7 +249,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "next": "^12.3.0"
+        "next": "^12.3.2-canary.43"
       },
       "devDependencies": {
         "@netlify/plugin-nextjs": "*",
@@ -320,6 +320,7 @@
     },
     "demos/server-components": {
       "version": "1.0.0",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.1.3",
@@ -337,316 +338,12 @@
         "typescript": "^4.6.3"
       }
     },
-    "demos/server-components/node_modules/@next/env": {
-      "version": "12.2.1",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.2.1.tgz",
-      "integrity": "sha512-lz3TJKIvbdGRUsUr/+h3vy7XvBNGTGzHwhurk5AtqrABj4Zyo70xbshcI7YQTNUK4x9OA/E+SOcXvVx0DHmFRw=="
-    },
-    "demos/server-components/node_modules/@next/swc-android-arm-eabi": {
-      "version": "12.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.2.1.tgz",
-      "integrity": "sha512-Gk7fvo1McA9gues9hixoeoxKnvvUusW0P+fya4ZAU3us+bQm1EqSoDrnOrUsdsgwIPQ3HobOJPY5C3xvKOl/tA==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "demos/server-components/node_modules/@next/swc-android-arm64": {
-      "version": "12.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.2.1.tgz",
-      "integrity": "sha512-J+QwWRm2+bOtacZFahoplX3dCYGDpou86VjfcE+M5/E0UCtBmZ6JvItyV4scK8wSKHQQUWq8DmOEm/C0lhsSRQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "demos/server-components/node_modules/@next/swc-darwin-arm64": {
-      "version": "12.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.2.1.tgz",
-      "integrity": "sha512-teSfpKHdHQER4FVVCdvS0fHff35Gh4LB2DZ2eNAateIluP2Gnl+tT881MeM4Knvl2Mvm3Z3vtSJNthVoveJnMA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "demos/server-components/node_modules/@next/swc-darwin-x64": {
-      "version": "12.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.2.1.tgz",
-      "integrity": "sha512-flA1H+9krrINtdWoXBzeESkdIV34OKX0+Lnqd90J1nsERTXntYy6CNOMxMtv1otAcnFy7EHYJQIL8URuu/2XXg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "demos/server-components/node_modules/@next/swc-freebsd-x64": {
-      "version": "12.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.2.1.tgz",
-      "integrity": "sha512-SkAjp7B7aBxAsRVMZGiAp/qMkh65PLzYuLBTsBSu+4fxFuKF7MAEgaIUhvC8zzD58A+Y9yrY/3813bhtrwkcuA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "demos/server-components/node_modules/@next/swc-linux-arm-gnueabihf": {
-      "version": "12.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.2.1.tgz",
-      "integrity": "sha512-V7ov2LXrLWuYVH/syzrzpmwWumg5rCh0siwOPNCRzVkrpgP8WoIRNdeZ/NQIj0ng+kq7gDF1jib583Lk0wbDeQ==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "demos/server-components/node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "12.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.2.1.tgz",
-      "integrity": "sha512-HlnDQD3r4YqCj2gu6uo86oEM0ixBsyKLaPcZcGwWAD5mFG5R4zzTZG7BO2wJkGWmkzijHluE14dlTmfzc8jdEQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "demos/server-components/node_modules/@next/swc-linux-arm64-musl": {
-      "version": "12.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.2.1.tgz",
-      "integrity": "sha512-P8AkWd4RHbuF24ol3jk2akXpntcDI0gv5uD7eMpAOXb8W2A6y/sv0tKNSGUV3efSutOyu23jNn2EiTNxHgU4NQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "demos/server-components/node_modules/@next/swc-linux-x64-gnu": {
-      "version": "12.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.2.1.tgz",
-      "integrity": "sha512-ZbsM+rIMqK6xi3lovspzPJoIPre3LglKrCXKLkln7rD0uiymzfLhS2VCj8u4qRynz22iAzuI4mJNpZa3AsJFrA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "demos/server-components/node_modules/@next/swc-linux-x64-musl": {
-      "version": "12.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.2.1.tgz",
-      "integrity": "sha512-JeATguMe37bviPwkIUjO7T3kcefMBQwJFLhkFTaJYGmPm12EsW1FtKcg87AI87xdGvfrHQKlM3phNaG/dkneTQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "demos/server-components/node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "12.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.2.1.tgz",
-      "integrity": "sha512-8dal/MdrVshDKYBtloJw/RhJx140KUoRRYoRfpJ9oAdP8UXBdR0haKfg5EdOy98t8Q76apArxPsK7DfwoR1f3w==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "demos/server-components/node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "12.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.2.1.tgz",
-      "integrity": "sha512-uSAoOBpCp4oxVD9gTY1f27hr9xNLEOCglxZPH1+FonHpM5n9Sp4H01uQHWE/Y26iHmJeUJAWxtRxEYylnO4U9A==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "demos/server-components/node_modules/@next/swc-win32-x64-msvc": {
-      "version": "12.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.2.1.tgz",
-      "integrity": "sha512-gx4aLMAZAVjtShiCrUSszoxnzBWJWf09Lkey6mcc0jFZjbz4xkyDbp53V229DtOYTUL4t0IZJ0I7+ftQ5CYIjg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "demos/server-components/node_modules/@swc/helpers": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.2.tgz",
-      "integrity": "sha512-556Az0VX7WR6UdoTn4htt/l3zPQ7bsQWK+HqdG4swV7beUCxo/BqmvbOpUkTIm/9ih86LIf1qsUnywNL3obGHw==",
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "demos/server-components/node_modules/next": {
-      "version": "12.2.1",
-      "resolved": "https://registry.npmjs.org/next/-/next-12.2.1.tgz",
-      "integrity": "sha512-090KB5CZRlLG/GWxb8tA1ZFwqL8OfpUtH4mXA7POuisa6NL5ihiAZhfk5nRBdPHvkXuSt0n7zQaVym6SrT3Wiw==",
-      "dependencies": {
-        "@next/env": "12.2.1",
-        "@swc/helpers": "0.4.2",
-        "caniuse-lite": "^1.0.30001332",
-        "postcss": "8.4.5",
-        "styled-jsx": "5.0.2",
-        "use-sync-external-store": "1.1.0"
-      },
-      "bin": {
-        "next": "dist/bin/next"
-      },
-      "engines": {
-        "node": ">=12.22.0"
-      },
-      "optionalDependencies": {
-        "@next/swc-android-arm-eabi": "12.2.1",
-        "@next/swc-android-arm64": "12.2.1",
-        "@next/swc-darwin-arm64": "12.2.1",
-        "@next/swc-darwin-x64": "12.2.1",
-        "@next/swc-freebsd-x64": "12.2.1",
-        "@next/swc-linux-arm-gnueabihf": "12.2.1",
-        "@next/swc-linux-arm64-gnu": "12.2.1",
-        "@next/swc-linux-arm64-musl": "12.2.1",
-        "@next/swc-linux-x64-gnu": "12.2.1",
-        "@next/swc-linux-x64-musl": "12.2.1",
-        "@next/swc-win32-arm64-msvc": "12.2.1",
-        "@next/swc-win32-ia32-msvc": "12.2.1",
-        "@next/swc-win32-x64-msvc": "12.2.1"
-      },
-      "peerDependencies": {
-        "fibers": ">= 3.1.0",
-        "node-sass": "^6.0.0 || ^7.0.0",
-        "react": "^17.0.2 || ^18.0.0-0",
-        "react-dom": "^17.0.2 || ^18.0.0-0",
-        "sass": "^1.3.0"
-      },
-      "peerDependenciesMeta": {
-        "fibers": {
-          "optional": true
-        },
-        "node-sass": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        }
-      }
-    },
-    "demos/server-components/node_modules/postcss": {
-      "version": "8.4.5",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.5.tgz",
-      "integrity": "sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==",
-      "dependencies": {
-        "nanoid": "^3.1.30",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
-      }
-    },
-    "demos/server-components/node_modules/styled-jsx": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.2.tgz",
-      "integrity": "sha512-LqPQrbBh3egD57NBcHET4qcgshPks+yblyhPlH2GY8oaDgKs8SK4C3dBh3oSJjgzJ3G5t1SYEZGHkP+QEpX9EQ==",
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "peerDependencies": {
-        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
-      },
-      "peerDependenciesMeta": {
-        "@babel/core": {
-          "optional": true
-        },
-        "babel-plugin-macros": {
-          "optional": true
-        }
-      }
-    },
-    "demos/server-components/node_modules/use-sync-external-store": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.1.0.tgz",
-      "integrity": "sha512-SEnieB2FPKEVne66NpXPd1Np4R1lTNKfjuy3XdIoPQKYBAFdzbzSZlSn1KJZUiihQLQC5Znot4SBz1EOTBwQAQ==",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
     "demos/static-root": {
       "name": "static-root-demo",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "next": "^12.3.0"
+        "next": "^12.3.2-canary.43"
       },
       "devDependencies": {
         "@netlify/plugin-nextjs": "*",
@@ -3809,15 +3506,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/@netlify/build/node_modules/ajv-errors": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
-      "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
-      "dev": true,
-      "peerDependencies": {
-        "ajv": "^8.0.1"
-      }
-    },
     "node_modules/@netlify/build/node_modules/chalk": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.1.2.tgz",
@@ -4858,11 +4546,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/@next/env": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.3.0.tgz",
-      "integrity": "sha512-PTJpjAFVbzBQ9xXpzMTroShvD5YDIIy46jQ7d4LrWpY+/5a8H90Tm8hE3Hvkc5RBRspVo7kvEOnqQms0A+2Q6w=="
-    },
     "node_modules/@next/eslint-plugin-next": {
       "version": "12.2.4",
       "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-12.2.4.tgz",
@@ -4902,201 +4585,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/@next/swc-android-arm-eabi": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.0.tgz",
-      "integrity": "sha512-/PuirPnAKsYBw93w/7Q9hqy+KGOU9mjYprZ/faxMUJh/dc6v3rYLxkZKNG9nFPIW4QKNTCnhP40xF9hLnxO+xg==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-android-arm64": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.0.tgz",
-      "integrity": "sha512-OaI+FhAM6P9B6Ybwbn0Zl8YwWido0lLwhDBi9WiYCh4RQmIXAyVIoIJPHo4fP05+mXaJ/k1trvDvuURvHOq2qw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-darwin-arm64": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.0.tgz",
-      "integrity": "sha512-9s4d3Mhii+WFce8o8Jok7WC3Bawkr9wEUU++SJRptjU1L5tsfYJMrSYCACHLhZujziNDLyExe4Hwwsccps1sfg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-darwin-x64": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.0.tgz",
-      "integrity": "sha512-2scC4MqUTwGwok+wpVxP+zWp7WcCAVOtutki2E1n99rBOTnUOX6qXkgxSy083yBN6GqwuC/dzHeN7hIKjavfRA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-freebsd-x64": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.0.tgz",
-      "integrity": "sha512-xAlruUREij/bFa+qsE1tmsP28t7vz02N4ZDHt2lh3uJUniE0Ne9idyIDLc1Ed0IF2RjfgOp4ZVunuS3OM0sngw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm-gnueabihf": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.0.tgz",
-      "integrity": "sha512-jin2S4VT/cugc2dSZEUIabhYDJNgrUh7fufbdsaAezgcQzqfdfJqfxl4E9GuafzB4cbRPTaqA0V5uqbp0IyGkQ==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.0.tgz",
-      "integrity": "sha512-RqJHDKe0WImeUrdR0kayTkRWgp4vD/MS7g0r6Xuf8+ellOFH7JAAJffDW3ayuVZeMYOa7RvgNFcOoWnrTUl9Nw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.0.tgz",
-      "integrity": "sha512-nvNWoUieMjvDjpYJ/4SQe9lQs2xMj6ZRs8N+bmTrVu9leY2Fg3WD6W9p/1uU9hGO8u+OdF13wc4iRShu/WYIHg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.0.tgz",
-      "integrity": "sha512-4ajhIuVU9PeQCMMhdDgZTLrHmjbOUFuIyg6J19hZqwEwDTSqQyrSLkbJs2Nd7IRiM6Ul/XyrtEFCpk4k+xD2+w==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-musl": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.0.tgz",
-      "integrity": "sha512-U092RBYbaGxoMAwpauePJEu2PuZSEoUCGJBvsptQr2/2XIMwAJDYM4c/M5NfYEsBr+yjvsYNsOpYfeQ88D82Yg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.0.tgz",
-      "integrity": "sha512-pzSzaxjDEJe67bUok9Nxf9rykbJfHXW0owICFsPBsqHyc+cr8vpF7g9e2APTCddtVhvjkga9ILoZJ9NxWS7Yiw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.0.tgz",
-      "integrity": "sha512-MQGUpMbYhQmTZ06a9e0hPQJnxFMwETo2WtyAotY3GEzbNCQVbCGhsvqEKcl+ZEHgShlHXUWvSffq1ZscY6gK7A==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.0.tgz",
-      "integrity": "sha512-C/nw6OgQpEULWqs+wgMHXGvlJLguPRFFGqR2TAqWBerQ8J+Sg3z1ZTqwelkSi4FoqStGuZ2UdFHIDN1ySmR1xA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -6157,6 +5645,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-errors": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
+      "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
+      "dev": true,
+      "peerDependencies": {
+        "ajv": "^8.0.1"
       }
     },
     "node_modules/ansi-align": {
@@ -7358,9 +6855,9 @@
       "integrity": "sha512-W2lPwkBkMZwFlPCXhIlYgxu+7gC/NUlCtdK652DAJ1JdgV0sTrvuPFshNPrFa1TY2JOkLhgdeEBplB4ezEa+xg=="
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001402",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001402.tgz",
-      "integrity": "sha512-Mx4MlhXO5NwuvXGgVb+hg65HZ+bhUYsz8QtDGDo2QmaJS2GBX47Xfi2koL86lc8K+l+htXeTEB/Aeqvezoo6Ew==",
+      "version": "1.0.30001425",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001425.tgz",
+      "integrity": "sha512-/pzFv0OmNG6W0ym80P3NtapU0QEiDS3VuYAZMGoLLqiC7f6FJFe1MjpQDREGApeenD9wloeytmVDj+JLXPC6qw==",
       "funding": [
         {
           "type": "opencollective",
@@ -7757,6 +7254,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
     },
     "node_modules/clipboardy": {
       "version": "3.0.0",
@@ -17108,7 +16610,8 @@
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
     },
     "node_modules/murmurhash": {
       "version": "2.0.0",
@@ -17304,43 +16807,43 @@
       }
     },
     "node_modules/next": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/next/-/next-12.3.0.tgz",
-      "integrity": "sha512-GpzI6me9V1+XYtfK0Ae9WD0mKqHyzQlGq1xH1rzNIYMASo4Tkl4rTe9jSqtBpXFhOS33KohXs9ZY38Akkhdciw==",
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/next/-/next-12.3.2-canary.43.tgz",
+      "integrity": "sha512-NgKLhMndPIL2DJEPfzONjSLpW+pl4YFzRp/DhYMgtYjOi5auYoM0SA9f3IJBN39PsFuyfNgJkTxiHtQ6q/T1MA==",
       "dependencies": {
-        "@next/env": "12.3.0",
+        "@next/env": "12.3.2-canary.43",
         "@swc/helpers": "0.4.11",
-        "caniuse-lite": "^1.0.30001332",
+        "caniuse-lite": "^1.0.30001406",
         "postcss": "8.4.14",
-        "styled-jsx": "5.0.6",
+        "styled-jsx": "5.1.0",
         "use-sync-external-store": "1.2.0"
       },
       "bin": {
         "next": "dist/bin/next"
       },
       "engines": {
-        "node": ">=12.22.0"
+        "node": ">=14.6.0"
       },
       "optionalDependencies": {
-        "@next/swc-android-arm-eabi": "12.3.0",
-        "@next/swc-android-arm64": "12.3.0",
-        "@next/swc-darwin-arm64": "12.3.0",
-        "@next/swc-darwin-x64": "12.3.0",
-        "@next/swc-freebsd-x64": "12.3.0",
-        "@next/swc-linux-arm-gnueabihf": "12.3.0",
-        "@next/swc-linux-arm64-gnu": "12.3.0",
-        "@next/swc-linux-arm64-musl": "12.3.0",
-        "@next/swc-linux-x64-gnu": "12.3.0",
-        "@next/swc-linux-x64-musl": "12.3.0",
-        "@next/swc-win32-arm64-msvc": "12.3.0",
-        "@next/swc-win32-ia32-msvc": "12.3.0",
-        "@next/swc-win32-x64-msvc": "12.3.0"
+        "@next/swc-android-arm-eabi": "12.3.2-canary.43",
+        "@next/swc-android-arm64": "12.3.2-canary.43",
+        "@next/swc-darwin-arm64": "12.3.2-canary.43",
+        "@next/swc-darwin-x64": "12.3.2-canary.43",
+        "@next/swc-freebsd-x64": "12.3.2-canary.43",
+        "@next/swc-linux-arm-gnueabihf": "12.3.2-canary.43",
+        "@next/swc-linux-arm64-gnu": "12.3.2-canary.43",
+        "@next/swc-linux-arm64-musl": "12.3.2-canary.43",
+        "@next/swc-linux-x64-gnu": "12.3.2-canary.43",
+        "@next/swc-linux-x64-musl": "12.3.2-canary.43",
+        "@next/swc-win32-arm64-msvc": "12.3.2-canary.43",
+        "@next/swc-win32-ia32-msvc": "12.3.2-canary.43",
+        "@next/swc-win32-x64-msvc": "12.3.2-canary.43"
       },
       "peerDependencies": {
         "fibers": ">= 3.1.0",
         "node-sass": "^6.0.0 || ^7.0.0",
-        "react": "^17.0.2 || ^18.0.0-0",
-        "react-dom": "^17.0.2 || ^18.0.0-0",
+        "react": "^18.0.0-0",
+        "react-dom": "^18.0.0-0",
         "sass": "^1.3.0"
       },
       "peerDependenciesMeta": {
@@ -17395,6 +16898,228 @@
     "node_modules/next-with-edge-functions": {
       "resolved": "demos/next-with-edge-functions",
       "link": true
+    },
+    "node_modules/next/node_modules/@next/env": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.3.2-canary.43.tgz",
+      "integrity": "sha512-Sb+EIjatpJ6MGPxM4vbOu1Psq7ARCPtmJCDAFGSQMDz4PZbPK649pzdj8D7SlFgZNdKMcr33urKutbGR4s6hUQ=="
+    },
+    "node_modules/next/node_modules/@next/swc-android-arm-eabi": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.2-canary.43.tgz",
+      "integrity": "sha512-Y8tl1H9EXPAWPG4fkULYg2kqsrBNav5zNXvjlvqv83ZR2hrGHW7QyjAdyv0fjGMckrGA9fiqITT1/241gmGdHA==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next/node_modules/@next/swc-android-arm64": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.2-canary.43.tgz",
+      "integrity": "sha512-OuHmP9pEuC9j2IVvOwL0fVHTkhrzvkJO7Sbm9LQW6s0+FJxGjuoLjdOm+GRusnZFyzXRvVWEHd8Wu9aDTzoBGg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next/node_modules/@next/swc-darwin-arm64": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.2-canary.43.tgz",
+      "integrity": "sha512-WJqEndZXTaqFDoaxE9NImrWavGoagpBQg0GCNQ3t/IIyG53mbEgegkEoMw7ZYVkQzQcd2b6Nxj6f9nU9T4ebfA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next/node_modules/@next/swc-darwin-x64": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.2-canary.43.tgz",
+      "integrity": "sha512-cWrlfaIx2WkFfl5+TGf09zvgNsij8cTOJ5io1ILHzKt9rTOrr39tK5jk5HYfF5QhKVS4Dw2GHUj7L74xEKqznA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next/node_modules/@next/swc-freebsd-x64": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.2-canary.43.tgz",
+      "integrity": "sha512-6Z8SnCxvgNWzp7QSQROHAUb8SZ+AD4etLaAj4LUhcCqQA/0RGUms2Vlet0RGNVorq3+8KweUAb3Ix+I4BgaP3w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next/node_modules/@next/swc-linux-arm-gnueabihf": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.2-canary.43.tgz",
+      "integrity": "sha512-cl7P0uVxRDCbkC9jAs8NSk/g8O2JVjdWWb6cF/VCSUKZL7dZMly0ocqS58vwb9oTWAI+OFJrAczZPQbtkMU6aQ==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next/node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.2-canary.43.tgz",
+      "integrity": "sha512-KxEatuNa5q9cImU/Fk0Q0KN136L4WGWcuavPhodQW3zwHn+OKBARA6wmtPkqQhRj7slzVzn3mZ01pPxc4DhsVg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next/node_modules/@next/swc-linux-arm64-musl": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.2-canary.43.tgz",
+      "integrity": "sha512-KWaV7rrbE31L1GsHZ33+DkXMgnzcKaZxgA/eIaiJ3wdVse7MzrpCtJH2p3p1mvAPtKu/WG3Ntv4rLFdSzybjWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next/node_modules/@next/swc-linux-x64-gnu": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.2-canary.43.tgz",
+      "integrity": "sha512-fE9zuIDCH48jCbw3/JBhdblZXTEepjaxH+I6A/Nml7Aex2OFAG8GkEdTJdRez3W3IFaMYIhqpGqQcd7VXDw6bw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next/node_modules/@next/swc-linux-x64-musl": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.2-canary.43.tgz",
+      "integrity": "sha512-KHXl4kDLjSA2BAKGY+jisaHWYkxDw2bI9j6eQunvkPnlwW5jwiJPQnehszt5CNwYTdoeqiAJE+BY4UnEIEkeNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next/node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.2-canary.43.tgz",
+      "integrity": "sha512-QHU8bxXzkyjhwVNxLut1m4VRo3ZQlbkcidR7erH8WdSaVhYAWUdPZ6ux6aJLAk3yQwwgw0fSZO98iXdkDp6pvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next/node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.2-canary.43.tgz",
+      "integrity": "sha512-HyElqKE2rJeS0pb6NowKyIsQ9iK/Ct9hkH4fexmoMyMk4z86zu7F3PS9ThLtEDRyzeM5K3xMtFgD+IcYFLRzmA==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next/node_modules/@next/swc-win32-x64-msvc": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.2-canary.43.tgz",
+      "integrity": "sha512-+0GA+qi1gS/w6QpHj58b4OOxNQ6kWmZuGdAnGuHzBbPmyBERnAWGU4+5DdjOebswM/sCV7ljTjxaHzZo1LN6Ng==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next/node_modules/styled-jsx": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.0.tgz",
+      "integrity": "sha512-/iHaRJt9U7T+5tp6TRelLnqBqiaIT0HsO0+vgyj8hK2KUk7aejFqRrumqPUlAqDwAj8IbS/1hk3IhBAAK/FCUQ==",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
     },
     "node_modules/nice-try": {
       "version": "1.0.5",
@@ -20562,10 +20287,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/server-components": {
-      "resolved": "demos/server-components",
-      "link": true
-    },
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -21586,25 +21307,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/styled-jsx": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.6.tgz",
-      "integrity": "sha512-xOeROtkK5MGMDimBQ3J6iPId8q0t/BDoG5XN6oKkZClVz9ISF/hihN8OCn2LggMU6N32aXnrXBdn3auSqNS9fA==",
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "peerDependencies": {
-        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
-      },
-      "peerDependenciesMeta": {
-        "@babel/core": {
-          "optional": true
-        },
-        "babel-plugin-macros": {
-          "optional": true
-        }
       }
     },
     "node_modules/supports-color": {
@@ -23475,7 +23177,7 @@
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^17.0.25",
-        "next": "^12.3.0",
+        "next": "^12.3.2-canary.43",
         "npm-run-all": "^4.1.5",
         "typescript": "^4.6.3"
       },
@@ -23520,7 +23222,7 @@
         "@types/jest": "^27.4.1",
         "@types/merge-stream": "^1.1.2",
         "@types/node": "^17.0.25",
-        "next": "^12.3.0",
+        "next": "^12.3.2-canary.43",
         "npm-run-all": "^4.1.5",
         "typescript": "^4.6.3"
       },
@@ -23622,46 +23324,6 @@
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "plugin": {
-      "name": "@netlify/plugin-nextjs",
-      "version": "4.14.1",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "@netlify/functions": "^1.0.0",
-        "@netlify/ipx": "^1.2.0",
-        "@vercel/node-bridge": "^2.1.0",
-        "chalk": "^4.1.2",
-        "fs-extra": "^10.0.0",
-        "globby": "^11.0.4",
-        "moize": "^6.1.0",
-        "node-fetch": "^2.6.6",
-        "node-stream-zip": "^1.15.0",
-        "outdent": "^0.8.0",
-        "p-limit": "^3.1.0",
-        "pathe": "^0.2.0",
-        "pretty-bytes": "^5.6.0",
-        "semver": "^7.3.5",
-        "slash": "^3.0.0",
-        "tiny-glob": "^0.2.9"
-      },
-      "devDependencies": {
-        "@delucis/if-env": "^1.1.2",
-        "@netlify/build": "^27.11.2",
-        "@types/fs-extra": "^9.0.13",
-        "@types/jest": "^27.4.1",
-        "@types/node": "^17.0.25",
-        "next": "^12.3.0",
-        "npm-run-all": "^4.1.5",
-        "typescript": "^4.6.3"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "next": "*"
       }
     }
   },
@@ -25992,12 +25654,6 @@
             "uri-js": "^4.2.2"
           }
         },
-        "ajv-errors": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
-          "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
-          "dev": true
-        },
         "chalk": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.1.2.tgz",
@@ -26444,7 +26100,7 @@
       "version": "file:packages/next",
       "requires": {
         "@types/node": "^17.0.25",
-        "next": "^12.3.0",
+        "next": "^12.3.2-canary.43",
         "npm-run-all": "^4.1.5",
         "typescript": "^4.6.3"
       }
@@ -26475,7 +26131,7 @@
         "globby": "^11.0.4",
         "merge-stream": "^2.0.0",
         "moize": "^6.1.0",
-        "next": "^12.3.0",
+        "next": "^12.3.2-canary.43",
         "node-fetch": "^2.6.6",
         "node-stream-zip": "^1.15.0",
         "npm-run-all": "^4.1.5",
@@ -26742,11 +26398,6 @@
         }
       }
     },
-    "@next/env": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.3.0.tgz",
-      "integrity": "sha512-PTJpjAFVbzBQ9xXpzMTroShvD5YDIIy46jQ7d4LrWpY+/5a8H90Tm8hE3Hvkc5RBRspVo7kvEOnqQms0A+2Q6w=="
-    },
     "@next/eslint-plugin-next": {
       "version": "12.2.4",
       "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-12.2.4.tgz",
@@ -26780,84 +26431,6 @@
           }
         }
       }
-    },
-    "@next/swc-android-arm-eabi": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.0.tgz",
-      "integrity": "sha512-/PuirPnAKsYBw93w/7Q9hqy+KGOU9mjYprZ/faxMUJh/dc6v3rYLxkZKNG9nFPIW4QKNTCnhP40xF9hLnxO+xg==",
-      "optional": true
-    },
-    "@next/swc-android-arm64": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.0.tgz",
-      "integrity": "sha512-OaI+FhAM6P9B6Ybwbn0Zl8YwWido0lLwhDBi9WiYCh4RQmIXAyVIoIJPHo4fP05+mXaJ/k1trvDvuURvHOq2qw==",
-      "optional": true
-    },
-    "@next/swc-darwin-arm64": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.0.tgz",
-      "integrity": "sha512-9s4d3Mhii+WFce8o8Jok7WC3Bawkr9wEUU++SJRptjU1L5tsfYJMrSYCACHLhZujziNDLyExe4Hwwsccps1sfg==",
-      "optional": true
-    },
-    "@next/swc-darwin-x64": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.0.tgz",
-      "integrity": "sha512-2scC4MqUTwGwok+wpVxP+zWp7WcCAVOtutki2E1n99rBOTnUOX6qXkgxSy083yBN6GqwuC/dzHeN7hIKjavfRA==",
-      "optional": true
-    },
-    "@next/swc-freebsd-x64": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.0.tgz",
-      "integrity": "sha512-xAlruUREij/bFa+qsE1tmsP28t7vz02N4ZDHt2lh3uJUniE0Ne9idyIDLc1Ed0IF2RjfgOp4ZVunuS3OM0sngw==",
-      "optional": true
-    },
-    "@next/swc-linux-arm-gnueabihf": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.0.tgz",
-      "integrity": "sha512-jin2S4VT/cugc2dSZEUIabhYDJNgrUh7fufbdsaAezgcQzqfdfJqfxl4E9GuafzB4cbRPTaqA0V5uqbp0IyGkQ==",
-      "optional": true
-    },
-    "@next/swc-linux-arm64-gnu": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.0.tgz",
-      "integrity": "sha512-RqJHDKe0WImeUrdR0kayTkRWgp4vD/MS7g0r6Xuf8+ellOFH7JAAJffDW3ayuVZeMYOa7RvgNFcOoWnrTUl9Nw==",
-      "optional": true
-    },
-    "@next/swc-linux-arm64-musl": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.0.tgz",
-      "integrity": "sha512-nvNWoUieMjvDjpYJ/4SQe9lQs2xMj6ZRs8N+bmTrVu9leY2Fg3WD6W9p/1uU9hGO8u+OdF13wc4iRShu/WYIHg==",
-      "optional": true
-    },
-    "@next/swc-linux-x64-gnu": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.0.tgz",
-      "integrity": "sha512-4ajhIuVU9PeQCMMhdDgZTLrHmjbOUFuIyg6J19hZqwEwDTSqQyrSLkbJs2Nd7IRiM6Ul/XyrtEFCpk4k+xD2+w==",
-      "optional": true
-    },
-    "@next/swc-linux-x64-musl": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.0.tgz",
-      "integrity": "sha512-U092RBYbaGxoMAwpauePJEu2PuZSEoUCGJBvsptQr2/2XIMwAJDYM4c/M5NfYEsBr+yjvsYNsOpYfeQ88D82Yg==",
-      "optional": true
-    },
-    "@next/swc-win32-arm64-msvc": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.0.tgz",
-      "integrity": "sha512-pzSzaxjDEJe67bUok9Nxf9rykbJfHXW0owICFsPBsqHyc+cr8vpF7g9e2APTCddtVhvjkga9ILoZJ9NxWS7Yiw==",
-      "optional": true
-    },
-    "@next/swc-win32-ia32-msvc": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.0.tgz",
-      "integrity": "sha512-MQGUpMbYhQmTZ06a9e0hPQJnxFMwETo2WtyAotY3GEzbNCQVbCGhsvqEKcl+ZEHgShlHXUWvSffq1ZscY6gK7A==",
-      "optional": true
-    },
-    "@next/swc-win32-x64-msvc": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.0.tgz",
-      "integrity": "sha512-C/nw6OgQpEULWqs+wgMHXGvlJLguPRFFGqR2TAqWBerQ8J+Sg3z1ZTqwelkSi4FoqStGuZ2UdFHIDN1ySmR1xA==",
-      "optional": true
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -27677,6 +27250,12 @@
         "uri-js": "^4.2.2"
       }
     },
+    "ajv-errors": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
+      "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
+      "dev": true
+    },
     "ansi-align": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
@@ -28236,7 +27815,7 @@
         "@types/node": "^17.0.25",
         "husky": "^7.0.4",
         "if-env": "^1.0.4",
-        "next": "^12.3.0",
+        "next": "^12.3.2-canary.43",
         "npm-run-all": "^4.1.5",
         "typescript": "^4.6.3"
       }
@@ -28600,9 +28179,9 @@
       "integrity": "sha512-W2lPwkBkMZwFlPCXhIlYgxu+7gC/NUlCtdK652DAJ1JdgV0sTrvuPFshNPrFa1TY2JOkLhgdeEBplB4ezEa+xg=="
     },
     "caniuse-lite": {
-      "version": "1.0.30001402",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001402.tgz",
-      "integrity": "sha512-Mx4MlhXO5NwuvXGgVb+hg65HZ+bhUYsz8QtDGDo2QmaJS2GBX47Xfi2koL86lc8K+l+htXeTEB/Aeqvezoo6Ew=="
+      "version": "1.0.30001425",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001425.tgz",
+      "integrity": "sha512-/pzFv0OmNG6W0ym80P3NtapU0QEiDS3VuYAZMGoLLqiC7f6FJFe1MjpQDREGApeenD9wloeytmVDj+JLXPC6qw=="
     },
     "caseless": {
       "version": "0.12.0",
@@ -28894,6 +28473,11 @@
           }
         }
       }
+    },
+    "client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
     },
     "clipboardy": {
       "version": "3.0.0",
@@ -30022,7 +29606,7 @@
         "@types/react": "^17.0.47",
         "husky": "^7.0.4",
         "if-env": "^1.0.4",
-        "next": "^12.3.0",
+        "next": "^12.3.2-canary.43",
         "npm-run-all": "^4.1.5",
         "typescript": "^4.7.4"
       },
@@ -30356,7 +29940,7 @@
         "critters": "^0.0.16",
         "husky": "^7.0.4",
         "if-env": "^1.0.4",
-        "next": "^12.3.0",
+        "next": "^12.3.2-canary.43",
         "npm-run-all": "^4.1.5",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
@@ -31586,8 +31170,7 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.1.1.tgz",
       "integrity": "sha512-tjqWDwVZQo7UIPMeDReOpUgHCmCiH+ePnVT+5zVapL0uuHnegBUs2smM13CzOs2Xb5+MHMRFTs9v24yjba4Oig==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-plugin-react": {
       "version": "7.29.4",
@@ -35881,7 +35464,7 @@
         "@types/node": "^17.0.25",
         "@types/react": "^17.0.43",
         "husky": "^7.0.4",
-        "next": "^12.3.0",
+        "next": "^12.3.2-canary.43",
         "npm-run-all": "^4.1.5",
         "react": "18.0.0",
         "react-dom": "18.0.0",
@@ -36090,7 +35673,8 @@
     "ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
     },
     "murmurhash": {
       "version": "2.0.0",
@@ -36249,29 +35833,122 @@
       }
     },
     "next": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/next/-/next-12.3.0.tgz",
-      "integrity": "sha512-GpzI6me9V1+XYtfK0Ae9WD0mKqHyzQlGq1xH1rzNIYMASo4Tkl4rTe9jSqtBpXFhOS33KohXs9ZY38Akkhdciw==",
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/next/-/next-12.3.2-canary.43.tgz",
+      "integrity": "sha512-NgKLhMndPIL2DJEPfzONjSLpW+pl4YFzRp/DhYMgtYjOi5auYoM0SA9f3IJBN39PsFuyfNgJkTxiHtQ6q/T1MA==",
       "requires": {
-        "@next/env": "12.3.0",
-        "@next/swc-android-arm-eabi": "12.3.0",
-        "@next/swc-android-arm64": "12.3.0",
-        "@next/swc-darwin-arm64": "12.3.0",
-        "@next/swc-darwin-x64": "12.3.0",
-        "@next/swc-freebsd-x64": "12.3.0",
-        "@next/swc-linux-arm-gnueabihf": "12.3.0",
-        "@next/swc-linux-arm64-gnu": "12.3.0",
-        "@next/swc-linux-arm64-musl": "12.3.0",
-        "@next/swc-linux-x64-gnu": "12.3.0",
-        "@next/swc-linux-x64-musl": "12.3.0",
-        "@next/swc-win32-arm64-msvc": "12.3.0",
-        "@next/swc-win32-ia32-msvc": "12.3.0",
-        "@next/swc-win32-x64-msvc": "12.3.0",
+        "@next/env": "12.3.2-canary.43",
+        "@next/swc-android-arm-eabi": "12.3.2-canary.43",
+        "@next/swc-android-arm64": "12.3.2-canary.43",
+        "@next/swc-darwin-arm64": "12.3.2-canary.43",
+        "@next/swc-darwin-x64": "12.3.2-canary.43",
+        "@next/swc-freebsd-x64": "12.3.2-canary.43",
+        "@next/swc-linux-arm-gnueabihf": "12.3.2-canary.43",
+        "@next/swc-linux-arm64-gnu": "12.3.2-canary.43",
+        "@next/swc-linux-arm64-musl": "12.3.2-canary.43",
+        "@next/swc-linux-x64-gnu": "12.3.2-canary.43",
+        "@next/swc-linux-x64-musl": "12.3.2-canary.43",
+        "@next/swc-win32-arm64-msvc": "12.3.2-canary.43",
+        "@next/swc-win32-ia32-msvc": "12.3.2-canary.43",
+        "@next/swc-win32-x64-msvc": "12.3.2-canary.43",
         "@swc/helpers": "0.4.11",
-        "caniuse-lite": "^1.0.30001332",
+        "caniuse-lite": "^1.0.30001406",
         "postcss": "8.4.14",
-        "styled-jsx": "5.0.6",
+        "styled-jsx": "5.1.0",
         "use-sync-external-store": "1.2.0"
+      },
+      "dependencies": {
+        "@next/env": {
+          "version": "12.3.2-canary.43",
+          "resolved": "https://registry.npmjs.org/@next/env/-/env-12.3.2-canary.43.tgz",
+          "integrity": "sha512-Sb+EIjatpJ6MGPxM4vbOu1Psq7ARCPtmJCDAFGSQMDz4PZbPK649pzdj8D7SlFgZNdKMcr33urKutbGR4s6hUQ=="
+        },
+        "@next/swc-android-arm-eabi": {
+          "version": "12.3.2-canary.43",
+          "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.2-canary.43.tgz",
+          "integrity": "sha512-Y8tl1H9EXPAWPG4fkULYg2kqsrBNav5zNXvjlvqv83ZR2hrGHW7QyjAdyv0fjGMckrGA9fiqITT1/241gmGdHA==",
+          "optional": true
+        },
+        "@next/swc-android-arm64": {
+          "version": "12.3.2-canary.43",
+          "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.2-canary.43.tgz",
+          "integrity": "sha512-OuHmP9pEuC9j2IVvOwL0fVHTkhrzvkJO7Sbm9LQW6s0+FJxGjuoLjdOm+GRusnZFyzXRvVWEHd8Wu9aDTzoBGg==",
+          "optional": true
+        },
+        "@next/swc-darwin-arm64": {
+          "version": "12.3.2-canary.43",
+          "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.2-canary.43.tgz",
+          "integrity": "sha512-WJqEndZXTaqFDoaxE9NImrWavGoagpBQg0GCNQ3t/IIyG53mbEgegkEoMw7ZYVkQzQcd2b6Nxj6f9nU9T4ebfA==",
+          "optional": true
+        },
+        "@next/swc-darwin-x64": {
+          "version": "12.3.2-canary.43",
+          "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.2-canary.43.tgz",
+          "integrity": "sha512-cWrlfaIx2WkFfl5+TGf09zvgNsij8cTOJ5io1ILHzKt9rTOrr39tK5jk5HYfF5QhKVS4Dw2GHUj7L74xEKqznA==",
+          "optional": true
+        },
+        "@next/swc-freebsd-x64": {
+          "version": "12.3.2-canary.43",
+          "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.2-canary.43.tgz",
+          "integrity": "sha512-6Z8SnCxvgNWzp7QSQROHAUb8SZ+AD4etLaAj4LUhcCqQA/0RGUms2Vlet0RGNVorq3+8KweUAb3Ix+I4BgaP3w==",
+          "optional": true
+        },
+        "@next/swc-linux-arm-gnueabihf": {
+          "version": "12.3.2-canary.43",
+          "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.2-canary.43.tgz",
+          "integrity": "sha512-cl7P0uVxRDCbkC9jAs8NSk/g8O2JVjdWWb6cF/VCSUKZL7dZMly0ocqS58vwb9oTWAI+OFJrAczZPQbtkMU6aQ==",
+          "optional": true
+        },
+        "@next/swc-linux-arm64-gnu": {
+          "version": "12.3.2-canary.43",
+          "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.2-canary.43.tgz",
+          "integrity": "sha512-KxEatuNa5q9cImU/Fk0Q0KN136L4WGWcuavPhodQW3zwHn+OKBARA6wmtPkqQhRj7slzVzn3mZ01pPxc4DhsVg==",
+          "optional": true
+        },
+        "@next/swc-linux-arm64-musl": {
+          "version": "12.3.2-canary.43",
+          "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.2-canary.43.tgz",
+          "integrity": "sha512-KWaV7rrbE31L1GsHZ33+DkXMgnzcKaZxgA/eIaiJ3wdVse7MzrpCtJH2p3p1mvAPtKu/WG3Ntv4rLFdSzybjWA==",
+          "optional": true
+        },
+        "@next/swc-linux-x64-gnu": {
+          "version": "12.3.2-canary.43",
+          "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.2-canary.43.tgz",
+          "integrity": "sha512-fE9zuIDCH48jCbw3/JBhdblZXTEepjaxH+I6A/Nml7Aex2OFAG8GkEdTJdRez3W3IFaMYIhqpGqQcd7VXDw6bw==",
+          "optional": true
+        },
+        "@next/swc-linux-x64-musl": {
+          "version": "12.3.2-canary.43",
+          "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.2-canary.43.tgz",
+          "integrity": "sha512-KHXl4kDLjSA2BAKGY+jisaHWYkxDw2bI9j6eQunvkPnlwW5jwiJPQnehszt5CNwYTdoeqiAJE+BY4UnEIEkeNQ==",
+          "optional": true
+        },
+        "@next/swc-win32-arm64-msvc": {
+          "version": "12.3.2-canary.43",
+          "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.2-canary.43.tgz",
+          "integrity": "sha512-QHU8bxXzkyjhwVNxLut1m4VRo3ZQlbkcidR7erH8WdSaVhYAWUdPZ6ux6aJLAk3yQwwgw0fSZO98iXdkDp6pvw==",
+          "optional": true
+        },
+        "@next/swc-win32-ia32-msvc": {
+          "version": "12.3.2-canary.43",
+          "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.2-canary.43.tgz",
+          "integrity": "sha512-HyElqKE2rJeS0pb6NowKyIsQ9iK/Ct9hkH4fexmoMyMk4z86zu7F3PS9ThLtEDRyzeM5K3xMtFgD+IcYFLRzmA==",
+          "optional": true
+        },
+        "@next/swc-win32-x64-msvc": {
+          "version": "12.3.2-canary.43",
+          "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.2-canary.43.tgz",
+          "integrity": "sha512-+0GA+qi1gS/w6QpHj58b4OOxNQ6kWmZuGdAnGuHzBbPmyBERnAWGU4+5DdjOebswM/sCV7ljTjxaHzZo1LN6Ng==",
+          "optional": true
+        },
+        "styled-jsx": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.0.tgz",
+          "integrity": "sha512-/iHaRJt9U7T+5tp6TRelLnqBqiaIT0HsO0+vgyj8hK2KUk7aejFqRrumqPUlAqDwAj8IbS/1hk3IhBAAK/FCUQ==",
+          "requires": {
+            "client-only": "0.0.1"
+          }
+        }
       }
     },
     "next-auth": {
@@ -36299,7 +35976,7 @@
         "@types/node": "^17.0.14",
         "@types/react": "^18.0.0",
         "husky": "^7.0.4",
-        "next": "^12.3.0",
+        "next": "^12.3.2-canary.43",
         "next-auth": "^4.7.0",
         "nodemailer": "^6.6.3",
         "npm-run-all": "^4.1.5",
@@ -36330,7 +36007,7 @@
         "@types/node": "^17.0.25",
         "husky": "^7.0.4",
         "if-env": "^1.0.4",
-        "next": "^12.3.0",
+        "next": "^12.3.2-canary.43",
         "npm-run-all": "^4.1.5",
         "typescript": "^4.6.3"
       }
@@ -38724,161 +38401,6 @@
         }
       }
     },
-    "server-components": {
-      "version": "file:demos/server-components",
-      "requires": {
-        "@netlify/plugin-nextjs": "*",
-        "@types/fs-extra": "^9.0.13",
-        "@types/jest": "^27.4.1",
-        "@types/node": "^17.0.25",
-        "husky": "^7.0.4",
-        "ms": "2.1.3",
-        "next": "12.2.1",
-        "npm-run-all": "^4.1.5",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0",
-        "typescript": "^4.6.3"
-      },
-      "dependencies": {
-        "@next/env": {
-          "version": "12.2.1",
-          "resolved": "https://registry.npmjs.org/@next/env/-/env-12.2.1.tgz",
-          "integrity": "sha512-lz3TJKIvbdGRUsUr/+h3vy7XvBNGTGzHwhurk5AtqrABj4Zyo70xbshcI7YQTNUK4x9OA/E+SOcXvVx0DHmFRw=="
-        },
-        "@next/swc-android-arm-eabi": {
-          "version": "12.2.1",
-          "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.2.1.tgz",
-          "integrity": "sha512-Gk7fvo1McA9gues9hixoeoxKnvvUusW0P+fya4ZAU3us+bQm1EqSoDrnOrUsdsgwIPQ3HobOJPY5C3xvKOl/tA==",
-          "optional": true
-        },
-        "@next/swc-android-arm64": {
-          "version": "12.2.1",
-          "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.2.1.tgz",
-          "integrity": "sha512-J+QwWRm2+bOtacZFahoplX3dCYGDpou86VjfcE+M5/E0UCtBmZ6JvItyV4scK8wSKHQQUWq8DmOEm/C0lhsSRQ==",
-          "optional": true
-        },
-        "@next/swc-darwin-arm64": {
-          "version": "12.2.1",
-          "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.2.1.tgz",
-          "integrity": "sha512-teSfpKHdHQER4FVVCdvS0fHff35Gh4LB2DZ2eNAateIluP2Gnl+tT881MeM4Knvl2Mvm3Z3vtSJNthVoveJnMA==",
-          "optional": true
-        },
-        "@next/swc-darwin-x64": {
-          "version": "12.2.1",
-          "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.2.1.tgz",
-          "integrity": "sha512-flA1H+9krrINtdWoXBzeESkdIV34OKX0+Lnqd90J1nsERTXntYy6CNOMxMtv1otAcnFy7EHYJQIL8URuu/2XXg==",
-          "optional": true
-        },
-        "@next/swc-freebsd-x64": {
-          "version": "12.2.1",
-          "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.2.1.tgz",
-          "integrity": "sha512-SkAjp7B7aBxAsRVMZGiAp/qMkh65PLzYuLBTsBSu+4fxFuKF7MAEgaIUhvC8zzD58A+Y9yrY/3813bhtrwkcuA==",
-          "optional": true
-        },
-        "@next/swc-linux-arm-gnueabihf": {
-          "version": "12.2.1",
-          "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.2.1.tgz",
-          "integrity": "sha512-V7ov2LXrLWuYVH/syzrzpmwWumg5rCh0siwOPNCRzVkrpgP8WoIRNdeZ/NQIj0ng+kq7gDF1jib583Lk0wbDeQ==",
-          "optional": true
-        },
-        "@next/swc-linux-arm64-gnu": {
-          "version": "12.2.1",
-          "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.2.1.tgz",
-          "integrity": "sha512-HlnDQD3r4YqCj2gu6uo86oEM0ixBsyKLaPcZcGwWAD5mFG5R4zzTZG7BO2wJkGWmkzijHluE14dlTmfzc8jdEQ==",
-          "optional": true
-        },
-        "@next/swc-linux-arm64-musl": {
-          "version": "12.2.1",
-          "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.2.1.tgz",
-          "integrity": "sha512-P8AkWd4RHbuF24ol3jk2akXpntcDI0gv5uD7eMpAOXb8W2A6y/sv0tKNSGUV3efSutOyu23jNn2EiTNxHgU4NQ==",
-          "optional": true
-        },
-        "@next/swc-linux-x64-gnu": {
-          "version": "12.2.1",
-          "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.2.1.tgz",
-          "integrity": "sha512-ZbsM+rIMqK6xi3lovspzPJoIPre3LglKrCXKLkln7rD0uiymzfLhS2VCj8u4qRynz22iAzuI4mJNpZa3AsJFrA==",
-          "optional": true
-        },
-        "@next/swc-linux-x64-musl": {
-          "version": "12.2.1",
-          "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.2.1.tgz",
-          "integrity": "sha512-JeATguMe37bviPwkIUjO7T3kcefMBQwJFLhkFTaJYGmPm12EsW1FtKcg87AI87xdGvfrHQKlM3phNaG/dkneTQ==",
-          "optional": true
-        },
-        "@next/swc-win32-arm64-msvc": {
-          "version": "12.2.1",
-          "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.2.1.tgz",
-          "integrity": "sha512-8dal/MdrVshDKYBtloJw/RhJx140KUoRRYoRfpJ9oAdP8UXBdR0haKfg5EdOy98t8Q76apArxPsK7DfwoR1f3w==",
-          "optional": true
-        },
-        "@next/swc-win32-ia32-msvc": {
-          "version": "12.2.1",
-          "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.2.1.tgz",
-          "integrity": "sha512-uSAoOBpCp4oxVD9gTY1f27hr9xNLEOCglxZPH1+FonHpM5n9Sp4H01uQHWE/Y26iHmJeUJAWxtRxEYylnO4U9A==",
-          "optional": true
-        },
-        "@next/swc-win32-x64-msvc": {
-          "version": "12.2.1",
-          "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.2.1.tgz",
-          "integrity": "sha512-gx4aLMAZAVjtShiCrUSszoxnzBWJWf09Lkey6mcc0jFZjbz4xkyDbp53V229DtOYTUL4t0IZJ0I7+ftQ5CYIjg==",
-          "optional": true
-        },
-        "@swc/helpers": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.2.tgz",
-          "integrity": "sha512-556Az0VX7WR6UdoTn4htt/l3zPQ7bsQWK+HqdG4swV7beUCxo/BqmvbOpUkTIm/9ih86LIf1qsUnywNL3obGHw==",
-          "requires": {
-            "tslib": "^2.4.0"
-          }
-        },
-        "next": {
-          "version": "12.2.1",
-          "resolved": "https://registry.npmjs.org/next/-/next-12.2.1.tgz",
-          "integrity": "sha512-090KB5CZRlLG/GWxb8tA1ZFwqL8OfpUtH4mXA7POuisa6NL5ihiAZhfk5nRBdPHvkXuSt0n7zQaVym6SrT3Wiw==",
-          "requires": {
-            "@next/env": "12.2.1",
-            "@next/swc-android-arm-eabi": "12.2.1",
-            "@next/swc-android-arm64": "12.2.1",
-            "@next/swc-darwin-arm64": "12.2.1",
-            "@next/swc-darwin-x64": "12.2.1",
-            "@next/swc-freebsd-x64": "12.2.1",
-            "@next/swc-linux-arm-gnueabihf": "12.2.1",
-            "@next/swc-linux-arm64-gnu": "12.2.1",
-            "@next/swc-linux-arm64-musl": "12.2.1",
-            "@next/swc-linux-x64-gnu": "12.2.1",
-            "@next/swc-linux-x64-musl": "12.2.1",
-            "@next/swc-win32-arm64-msvc": "12.2.1",
-            "@next/swc-win32-ia32-msvc": "12.2.1",
-            "@next/swc-win32-x64-msvc": "12.2.1",
-            "@swc/helpers": "0.4.2",
-            "caniuse-lite": "^1.0.30001332",
-            "postcss": "8.4.5",
-            "styled-jsx": "5.0.2",
-            "use-sync-external-store": "1.1.0"
-          }
-        },
-        "postcss": {
-          "version": "8.4.5",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.5.tgz",
-          "integrity": "sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==",
-          "requires": {
-            "nanoid": "^3.1.30",
-            "picocolors": "^1.0.0",
-            "source-map-js": "^1.0.1"
-          }
-        },
-        "styled-jsx": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.2.tgz",
-          "integrity": "sha512-LqPQrbBh3egD57NBcHET4qcgshPks+yblyhPlH2GY8oaDgKs8SK4C3dBh3oSJjgzJ3G5t1SYEZGHkP+QEpX9EQ=="
-        },
-        "use-sync-external-store": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.1.0.tgz",
-          "integrity": "sha512-SEnieB2FPKEVne66NpXPd1Np4R1lTNKfjuy3XdIoPQKYBAFdzbzSZlSn1KJZUiihQLQC5Znot4SBz1EOTBwQAQ=="
-        }
-      }
-    },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -39457,7 +38979,7 @@
         "@types/node": "^17.0.25",
         "husky": "^7.0.4",
         "if-env": "^1.0.4",
-        "next": "^12.3.0",
+        "next": "^12.3.2-canary.43",
         "npm-run-all": "^4.1.5",
         "typescript": "^4.6.3"
       }
@@ -39688,11 +39210,6 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
-    },
-    "styled-jsx": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.6.tgz",
-      "integrity": "sha512-xOeROtkK5MGMDimBQ3J6iPId8q0t/BDoG5XN6oKkZClVz9ISF/hihN8OCn2LggMU6N32aXnrXBdn3auSqNS9fA=="
     },
     "supports-color": {
       "version": "9.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4587,6 +4587,201 @@
         "node": "*"
       }
     },
+    "node_modules/@next/swc-android-arm-eabi": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.2-canary.43.tgz",
+      "integrity": "sha512-Y8tl1H9EXPAWPG4fkULYg2kqsrBNav5zNXvjlvqv83ZR2hrGHW7QyjAdyv0fjGMckrGA9fiqITT1/241gmGdHA==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-android-arm64": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.2-canary.43.tgz",
+      "integrity": "sha512-OuHmP9pEuC9j2IVvOwL0fVHTkhrzvkJO7Sbm9LQW6s0+FJxGjuoLjdOm+GRusnZFyzXRvVWEHd8Wu9aDTzoBGg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.2-canary.43.tgz",
+      "integrity": "sha512-WJqEndZXTaqFDoaxE9NImrWavGoagpBQg0GCNQ3t/IIyG53mbEgegkEoMw7ZYVkQzQcd2b6Nxj6f9nU9T4ebfA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.2-canary.43.tgz",
+      "integrity": "sha512-cWrlfaIx2WkFfl5+TGf09zvgNsij8cTOJ5io1ILHzKt9rTOrr39tK5jk5HYfF5QhKVS4Dw2GHUj7L74xEKqznA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-freebsd-x64": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.2-canary.43.tgz",
+      "integrity": "sha512-6Z8SnCxvgNWzp7QSQROHAUb8SZ+AD4etLaAj4LUhcCqQA/0RGUms2Vlet0RGNVorq3+8KweUAb3Ix+I4BgaP3w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm-gnueabihf": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.2-canary.43.tgz",
+      "integrity": "sha512-cl7P0uVxRDCbkC9jAs8NSk/g8O2JVjdWWb6cF/VCSUKZL7dZMly0ocqS58vwb9oTWAI+OFJrAczZPQbtkMU6aQ==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.2-canary.43.tgz",
+      "integrity": "sha512-KxEatuNa5q9cImU/Fk0Q0KN136L4WGWcuavPhodQW3zwHn+OKBARA6wmtPkqQhRj7slzVzn3mZ01pPxc4DhsVg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.2-canary.43.tgz",
+      "integrity": "sha512-KWaV7rrbE31L1GsHZ33+DkXMgnzcKaZxgA/eIaiJ3wdVse7MzrpCtJH2p3p1mvAPtKu/WG3Ntv4rLFdSzybjWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.2-canary.43.tgz",
+      "integrity": "sha512-fE9zuIDCH48jCbw3/JBhdblZXTEepjaxH+I6A/Nml7Aex2OFAG8GkEdTJdRez3W3IFaMYIhqpGqQcd7VXDw6bw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.2-canary.43.tgz",
+      "integrity": "sha512-KHXl4kDLjSA2BAKGY+jisaHWYkxDw2bI9j6eQunvkPnlwW5jwiJPQnehszt5CNwYTdoeqiAJE+BY4UnEIEkeNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.2-canary.43.tgz",
+      "integrity": "sha512-QHU8bxXzkyjhwVNxLut1m4VRo3ZQlbkcidR7erH8WdSaVhYAWUdPZ6ux6aJLAk3yQwwgw0fSZO98iXdkDp6pvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.2-canary.43.tgz",
+      "integrity": "sha512-HyElqKE2rJeS0pb6NowKyIsQ9iK/Ct9hkH4fexmoMyMk4z86zu7F3PS9ThLtEDRyzeM5K3xMtFgD+IcYFLRzmA==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.2-canary.43.tgz",
+      "integrity": "sha512-+0GA+qi1gS/w6QpHj58b4OOxNQ6kWmZuGdAnGuHzBbPmyBERnAWGU4+5DdjOebswM/sCV7ljTjxaHzZo1LN6Ng==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -16904,201 +17099,6 @@
       "resolved": "https://registry.npmjs.org/@next/env/-/env-12.3.2-canary.43.tgz",
       "integrity": "sha512-Sb+EIjatpJ6MGPxM4vbOu1Psq7ARCPtmJCDAFGSQMDz4PZbPK649pzdj8D7SlFgZNdKMcr33urKutbGR4s6hUQ=="
     },
-    "node_modules/next/node_modules/@next/swc-android-arm-eabi": {
-      "version": "12.3.2-canary.43",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.2-canary.43.tgz",
-      "integrity": "sha512-Y8tl1H9EXPAWPG4fkULYg2kqsrBNav5zNXvjlvqv83ZR2hrGHW7QyjAdyv0fjGMckrGA9fiqITT1/241gmGdHA==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/next/node_modules/@next/swc-android-arm64": {
-      "version": "12.3.2-canary.43",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.2-canary.43.tgz",
-      "integrity": "sha512-OuHmP9pEuC9j2IVvOwL0fVHTkhrzvkJO7Sbm9LQW6s0+FJxGjuoLjdOm+GRusnZFyzXRvVWEHd8Wu9aDTzoBGg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/next/node_modules/@next/swc-darwin-arm64": {
-      "version": "12.3.2-canary.43",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.2-canary.43.tgz",
-      "integrity": "sha512-WJqEndZXTaqFDoaxE9NImrWavGoagpBQg0GCNQ3t/IIyG53mbEgegkEoMw7ZYVkQzQcd2b6Nxj6f9nU9T4ebfA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/next/node_modules/@next/swc-darwin-x64": {
-      "version": "12.3.2-canary.43",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.2-canary.43.tgz",
-      "integrity": "sha512-cWrlfaIx2WkFfl5+TGf09zvgNsij8cTOJ5io1ILHzKt9rTOrr39tK5jk5HYfF5QhKVS4Dw2GHUj7L74xEKqznA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/next/node_modules/@next/swc-freebsd-x64": {
-      "version": "12.3.2-canary.43",
-      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.2-canary.43.tgz",
-      "integrity": "sha512-6Z8SnCxvgNWzp7QSQROHAUb8SZ+AD4etLaAj4LUhcCqQA/0RGUms2Vlet0RGNVorq3+8KweUAb3Ix+I4BgaP3w==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/next/node_modules/@next/swc-linux-arm-gnueabihf": {
-      "version": "12.3.2-canary.43",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.2-canary.43.tgz",
-      "integrity": "sha512-cl7P0uVxRDCbkC9jAs8NSk/g8O2JVjdWWb6cF/VCSUKZL7dZMly0ocqS58vwb9oTWAI+OFJrAczZPQbtkMU6aQ==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/next/node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "12.3.2-canary.43",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.2-canary.43.tgz",
-      "integrity": "sha512-KxEatuNa5q9cImU/Fk0Q0KN136L4WGWcuavPhodQW3zwHn+OKBARA6wmtPkqQhRj7slzVzn3mZ01pPxc4DhsVg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/next/node_modules/@next/swc-linux-arm64-musl": {
-      "version": "12.3.2-canary.43",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.2-canary.43.tgz",
-      "integrity": "sha512-KWaV7rrbE31L1GsHZ33+DkXMgnzcKaZxgA/eIaiJ3wdVse7MzrpCtJH2p3p1mvAPtKu/WG3Ntv4rLFdSzybjWA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/next/node_modules/@next/swc-linux-x64-gnu": {
-      "version": "12.3.2-canary.43",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.2-canary.43.tgz",
-      "integrity": "sha512-fE9zuIDCH48jCbw3/JBhdblZXTEepjaxH+I6A/Nml7Aex2OFAG8GkEdTJdRez3W3IFaMYIhqpGqQcd7VXDw6bw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/next/node_modules/@next/swc-linux-x64-musl": {
-      "version": "12.3.2-canary.43",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.2-canary.43.tgz",
-      "integrity": "sha512-KHXl4kDLjSA2BAKGY+jisaHWYkxDw2bI9j6eQunvkPnlwW5jwiJPQnehszt5CNwYTdoeqiAJE+BY4UnEIEkeNQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/next/node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "12.3.2-canary.43",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.2-canary.43.tgz",
-      "integrity": "sha512-QHU8bxXzkyjhwVNxLut1m4VRo3ZQlbkcidR7erH8WdSaVhYAWUdPZ6ux6aJLAk3yQwwgw0fSZO98iXdkDp6pvw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/next/node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "12.3.2-canary.43",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.2-canary.43.tgz",
-      "integrity": "sha512-HyElqKE2rJeS0pb6NowKyIsQ9iK/Ct9hkH4fexmoMyMk4z86zu7F3PS9ThLtEDRyzeM5K3xMtFgD+IcYFLRzmA==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/next/node_modules/@next/swc-win32-x64-msvc": {
-      "version": "12.3.2-canary.43",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.2-canary.43.tgz",
-      "integrity": "sha512-+0GA+qi1gS/w6QpHj58b4OOxNQ6kWmZuGdAnGuHzBbPmyBERnAWGU4+5DdjOebswM/sCV7ljTjxaHzZo1LN6Ng==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/next/node_modules/styled-jsx": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.0.tgz",
@@ -23325,201 +23325,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/@next/swc-android-arm-eabi": {
-      "version": "12.3.2-canary.43",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.2-canary.43.tgz",
-      "integrity": "sha512-Y8tl1H9EXPAWPG4fkULYg2kqsrBNav5zNXvjlvqv83ZR2hrGHW7QyjAdyv0fjGMckrGA9fiqITT1/241gmGdHA==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-android-arm64": {
-      "version": "12.3.2-canary.43",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.2-canary.43.tgz",
-      "integrity": "sha512-OuHmP9pEuC9j2IVvOwL0fVHTkhrzvkJO7Sbm9LQW6s0+FJxGjuoLjdOm+GRusnZFyzXRvVWEHd8Wu9aDTzoBGg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-darwin-arm64": {
-      "version": "12.3.2-canary.43",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.2-canary.43.tgz",
-      "integrity": "sha512-WJqEndZXTaqFDoaxE9NImrWavGoagpBQg0GCNQ3t/IIyG53mbEgegkEoMw7ZYVkQzQcd2b6Nxj6f9nU9T4ebfA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-darwin-x64": {
-      "version": "12.3.2-canary.43",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.2-canary.43.tgz",
-      "integrity": "sha512-cWrlfaIx2WkFfl5+TGf09zvgNsij8cTOJ5io1ILHzKt9rTOrr39tK5jk5HYfF5QhKVS4Dw2GHUj7L74xEKqznA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-freebsd-x64": {
-      "version": "12.3.2-canary.43",
-      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.2-canary.43.tgz",
-      "integrity": "sha512-6Z8SnCxvgNWzp7QSQROHAUb8SZ+AD4etLaAj4LUhcCqQA/0RGUms2Vlet0RGNVorq3+8KweUAb3Ix+I4BgaP3w==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm-gnueabihf": {
-      "version": "12.3.2-canary.43",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.2-canary.43.tgz",
-      "integrity": "sha512-cl7P0uVxRDCbkC9jAs8NSk/g8O2JVjdWWb6cF/VCSUKZL7dZMly0ocqS58vwb9oTWAI+OFJrAczZPQbtkMU6aQ==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "12.3.2-canary.43",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.2-canary.43.tgz",
-      "integrity": "sha512-KxEatuNa5q9cImU/Fk0Q0KN136L4WGWcuavPhodQW3zwHn+OKBARA6wmtPkqQhRj7slzVzn3mZ01pPxc4DhsVg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "12.3.2-canary.43",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.2-canary.43.tgz",
-      "integrity": "sha512-KWaV7rrbE31L1GsHZ33+DkXMgnzcKaZxgA/eIaiJ3wdVse7MzrpCtJH2p3p1mvAPtKu/WG3Ntv4rLFdSzybjWA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "12.3.2-canary.43",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.2-canary.43.tgz",
-      "integrity": "sha512-fE9zuIDCH48jCbw3/JBhdblZXTEepjaxH+I6A/Nml7Aex2OFAG8GkEdTJdRez3W3IFaMYIhqpGqQcd7VXDw6bw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-musl": {
-      "version": "12.3.2-canary.43",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.2-canary.43.tgz",
-      "integrity": "sha512-KHXl4kDLjSA2BAKGY+jisaHWYkxDw2bI9j6eQunvkPnlwW5jwiJPQnehszt5CNwYTdoeqiAJE+BY4UnEIEkeNQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "12.3.2-canary.43",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.2-canary.43.tgz",
-      "integrity": "sha512-QHU8bxXzkyjhwVNxLut1m4VRo3ZQlbkcidR7erH8WdSaVhYAWUdPZ6ux6aJLAk3yQwwgw0fSZO98iXdkDp6pvw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "12.3.2-canary.43",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.2-canary.43.tgz",
-      "integrity": "sha512-HyElqKE2rJeS0pb6NowKyIsQ9iK/Ct9hkH4fexmoMyMk4z86zu7F3PS9ThLtEDRyzeM5K3xMtFgD+IcYFLRzmA==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "12.3.2-canary.43",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.2-canary.43.tgz",
-      "integrity": "sha512-+0GA+qi1gS/w6QpHj58b4OOxNQ6kWmZuGdAnGuHzBbPmyBERnAWGU4+5DdjOebswM/sCV7ljTjxaHzZo1LN6Ng==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
     }
   },
   "dependencies": {
@@ -26626,6 +26431,84 @@
           }
         }
       }
+    },
+    "@next/swc-android-arm-eabi": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.2-canary.43.tgz",
+      "integrity": "sha512-Y8tl1H9EXPAWPG4fkULYg2kqsrBNav5zNXvjlvqv83ZR2hrGHW7QyjAdyv0fjGMckrGA9fiqITT1/241gmGdHA==",
+      "optional": true
+    },
+    "@next/swc-android-arm64": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.2-canary.43.tgz",
+      "integrity": "sha512-OuHmP9pEuC9j2IVvOwL0fVHTkhrzvkJO7Sbm9LQW6s0+FJxGjuoLjdOm+GRusnZFyzXRvVWEHd8Wu9aDTzoBGg==",
+      "optional": true
+    },
+    "@next/swc-darwin-arm64": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.2-canary.43.tgz",
+      "integrity": "sha512-WJqEndZXTaqFDoaxE9NImrWavGoagpBQg0GCNQ3t/IIyG53mbEgegkEoMw7ZYVkQzQcd2b6Nxj6f9nU9T4ebfA==",
+      "optional": true
+    },
+    "@next/swc-darwin-x64": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.2-canary.43.tgz",
+      "integrity": "sha512-cWrlfaIx2WkFfl5+TGf09zvgNsij8cTOJ5io1ILHzKt9rTOrr39tK5jk5HYfF5QhKVS4Dw2GHUj7L74xEKqznA==",
+      "optional": true
+    },
+    "@next/swc-freebsd-x64": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.2-canary.43.tgz",
+      "integrity": "sha512-6Z8SnCxvgNWzp7QSQROHAUb8SZ+AD4etLaAj4LUhcCqQA/0RGUms2Vlet0RGNVorq3+8KweUAb3Ix+I4BgaP3w==",
+      "optional": true
+    },
+    "@next/swc-linux-arm-gnueabihf": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.2-canary.43.tgz",
+      "integrity": "sha512-cl7P0uVxRDCbkC9jAs8NSk/g8O2JVjdWWb6cF/VCSUKZL7dZMly0ocqS58vwb9oTWAI+OFJrAczZPQbtkMU6aQ==",
+      "optional": true
+    },
+    "@next/swc-linux-arm64-gnu": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.2-canary.43.tgz",
+      "integrity": "sha512-KxEatuNa5q9cImU/Fk0Q0KN136L4WGWcuavPhodQW3zwHn+OKBARA6wmtPkqQhRj7slzVzn3mZ01pPxc4DhsVg==",
+      "optional": true
+    },
+    "@next/swc-linux-arm64-musl": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.2-canary.43.tgz",
+      "integrity": "sha512-KWaV7rrbE31L1GsHZ33+DkXMgnzcKaZxgA/eIaiJ3wdVse7MzrpCtJH2p3p1mvAPtKu/WG3Ntv4rLFdSzybjWA==",
+      "optional": true
+    },
+    "@next/swc-linux-x64-gnu": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.2-canary.43.tgz",
+      "integrity": "sha512-fE9zuIDCH48jCbw3/JBhdblZXTEepjaxH+I6A/Nml7Aex2OFAG8GkEdTJdRez3W3IFaMYIhqpGqQcd7VXDw6bw==",
+      "optional": true
+    },
+    "@next/swc-linux-x64-musl": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.2-canary.43.tgz",
+      "integrity": "sha512-KHXl4kDLjSA2BAKGY+jisaHWYkxDw2bI9j6eQunvkPnlwW5jwiJPQnehszt5CNwYTdoeqiAJE+BY4UnEIEkeNQ==",
+      "optional": true
+    },
+    "@next/swc-win32-arm64-msvc": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.2-canary.43.tgz",
+      "integrity": "sha512-QHU8bxXzkyjhwVNxLut1m4VRo3ZQlbkcidR7erH8WdSaVhYAWUdPZ6ux6aJLAk3yQwwgw0fSZO98iXdkDp6pvw==",
+      "optional": true
+    },
+    "@next/swc-win32-ia32-msvc": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.2-canary.43.tgz",
+      "integrity": "sha512-HyElqKE2rJeS0pb6NowKyIsQ9iK/Ct9hkH4fexmoMyMk4z86zu7F3PS9ThLtEDRyzeM5K3xMtFgD+IcYFLRzmA==",
+      "optional": true
+    },
+    "@next/swc-win32-x64-msvc": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.2-canary.43.tgz",
+      "integrity": "sha512-+0GA+qi1gS/w6QpHj58b4OOxNQ6kWmZuGdAnGuHzBbPmyBERnAWGU4+5DdjOebswM/sCV7ljTjxaHzZo1LN6Ng==",
+      "optional": true
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -36058,84 +35941,6 @@
           "resolved": "https://registry.npmjs.org/@next/env/-/env-12.3.2-canary.43.tgz",
           "integrity": "sha512-Sb+EIjatpJ6MGPxM4vbOu1Psq7ARCPtmJCDAFGSQMDz4PZbPK649pzdj8D7SlFgZNdKMcr33urKutbGR4s6hUQ=="
         },
-        "@next/swc-android-arm-eabi": {
-          "version": "12.3.2-canary.43",
-          "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.2-canary.43.tgz",
-          "integrity": "sha512-Y8tl1H9EXPAWPG4fkULYg2kqsrBNav5zNXvjlvqv83ZR2hrGHW7QyjAdyv0fjGMckrGA9fiqITT1/241gmGdHA==",
-          "optional": true
-        },
-        "@next/swc-android-arm64": {
-          "version": "12.3.2-canary.43",
-          "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.2-canary.43.tgz",
-          "integrity": "sha512-OuHmP9pEuC9j2IVvOwL0fVHTkhrzvkJO7Sbm9LQW6s0+FJxGjuoLjdOm+GRusnZFyzXRvVWEHd8Wu9aDTzoBGg==",
-          "optional": true
-        },
-        "@next/swc-darwin-arm64": {
-          "version": "12.3.2-canary.43",
-          "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.2-canary.43.tgz",
-          "integrity": "sha512-WJqEndZXTaqFDoaxE9NImrWavGoagpBQg0GCNQ3t/IIyG53mbEgegkEoMw7ZYVkQzQcd2b6Nxj6f9nU9T4ebfA==",
-          "optional": true
-        },
-        "@next/swc-darwin-x64": {
-          "version": "12.3.2-canary.43",
-          "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.2-canary.43.tgz",
-          "integrity": "sha512-cWrlfaIx2WkFfl5+TGf09zvgNsij8cTOJ5io1ILHzKt9rTOrr39tK5jk5HYfF5QhKVS4Dw2GHUj7L74xEKqznA==",
-          "optional": true
-        },
-        "@next/swc-freebsd-x64": {
-          "version": "12.3.2-canary.43",
-          "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.2-canary.43.tgz",
-          "integrity": "sha512-6Z8SnCxvgNWzp7QSQROHAUb8SZ+AD4etLaAj4LUhcCqQA/0RGUms2Vlet0RGNVorq3+8KweUAb3Ix+I4BgaP3w==",
-          "optional": true
-        },
-        "@next/swc-linux-arm-gnueabihf": {
-          "version": "12.3.2-canary.43",
-          "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.2-canary.43.tgz",
-          "integrity": "sha512-cl7P0uVxRDCbkC9jAs8NSk/g8O2JVjdWWb6cF/VCSUKZL7dZMly0ocqS58vwb9oTWAI+OFJrAczZPQbtkMU6aQ==",
-          "optional": true
-        },
-        "@next/swc-linux-arm64-gnu": {
-          "version": "12.3.2-canary.43",
-          "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.2-canary.43.tgz",
-          "integrity": "sha512-KxEatuNa5q9cImU/Fk0Q0KN136L4WGWcuavPhodQW3zwHn+OKBARA6wmtPkqQhRj7slzVzn3mZ01pPxc4DhsVg==",
-          "optional": true
-        },
-        "@next/swc-linux-arm64-musl": {
-          "version": "12.3.2-canary.43",
-          "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.2-canary.43.tgz",
-          "integrity": "sha512-KWaV7rrbE31L1GsHZ33+DkXMgnzcKaZxgA/eIaiJ3wdVse7MzrpCtJH2p3p1mvAPtKu/WG3Ntv4rLFdSzybjWA==",
-          "optional": true
-        },
-        "@next/swc-linux-x64-gnu": {
-          "version": "12.3.2-canary.43",
-          "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.2-canary.43.tgz",
-          "integrity": "sha512-fE9zuIDCH48jCbw3/JBhdblZXTEepjaxH+I6A/Nml7Aex2OFAG8GkEdTJdRez3W3IFaMYIhqpGqQcd7VXDw6bw==",
-          "optional": true
-        },
-        "@next/swc-linux-x64-musl": {
-          "version": "12.3.2-canary.43",
-          "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.2-canary.43.tgz",
-          "integrity": "sha512-KHXl4kDLjSA2BAKGY+jisaHWYkxDw2bI9j6eQunvkPnlwW5jwiJPQnehszt5CNwYTdoeqiAJE+BY4UnEIEkeNQ==",
-          "optional": true
-        },
-        "@next/swc-win32-arm64-msvc": {
-          "version": "12.3.2-canary.43",
-          "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.2-canary.43.tgz",
-          "integrity": "sha512-QHU8bxXzkyjhwVNxLut1m4VRo3ZQlbkcidR7erH8WdSaVhYAWUdPZ6ux6aJLAk3yQwwgw0fSZO98iXdkDp6pvw==",
-          "optional": true
-        },
-        "@next/swc-win32-ia32-msvc": {
-          "version": "12.3.2-canary.43",
-          "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.2-canary.43.tgz",
-          "integrity": "sha512-HyElqKE2rJeS0pb6NowKyIsQ9iK/Ct9hkH4fexmoMyMk4z86zu7F3PS9ThLtEDRyzeM5K3xMtFgD+IcYFLRzmA==",
-          "optional": true
-        },
-        "@next/swc-win32-x64-msvc": {
-          "version": "12.3.2-canary.43",
-          "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.2-canary.43.tgz",
-          "integrity": "sha512-+0GA+qi1gS/w6QpHj58b4OOxNQ6kWmZuGdAnGuHzBbPmyBERnAWGU4+5DdjOebswM/sCV7ljTjxaHzZo1LN6Ng==",
-          "optional": true
-        },
         "styled-jsx": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.0.tgz",
@@ -40824,84 +40629,6 @@
         "compress-commons": "^4.1.0",
         "readable-stream": "^3.6.0"
       }
-    },
-    "@next/swc-android-arm-eabi": {
-      "version": "12.3.2-canary.43",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.2-canary.43.tgz",
-      "integrity": "sha512-Y8tl1H9EXPAWPG4fkULYg2kqsrBNav5zNXvjlvqv83ZR2hrGHW7QyjAdyv0fjGMckrGA9fiqITT1/241gmGdHA==",
-      "optional": true
-    },
-    "@next/swc-android-arm64": {
-      "version": "12.3.2-canary.43",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.2-canary.43.tgz",
-      "integrity": "sha512-OuHmP9pEuC9j2IVvOwL0fVHTkhrzvkJO7Sbm9LQW6s0+FJxGjuoLjdOm+GRusnZFyzXRvVWEHd8Wu9aDTzoBGg==",
-      "optional": true
-    },
-    "@next/swc-darwin-arm64": {
-      "version": "12.3.2-canary.43",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.2-canary.43.tgz",
-      "integrity": "sha512-WJqEndZXTaqFDoaxE9NImrWavGoagpBQg0GCNQ3t/IIyG53mbEgegkEoMw7ZYVkQzQcd2b6Nxj6f9nU9T4ebfA==",
-      "optional": true
-    },
-    "@next/swc-darwin-x64": {
-      "version": "12.3.2-canary.43",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.2-canary.43.tgz",
-      "integrity": "sha512-cWrlfaIx2WkFfl5+TGf09zvgNsij8cTOJ5io1ILHzKt9rTOrr39tK5jk5HYfF5QhKVS4Dw2GHUj7L74xEKqznA==",
-      "optional": true
-    },
-    "@next/swc-freebsd-x64": {
-      "version": "12.3.2-canary.43",
-      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.2-canary.43.tgz",
-      "integrity": "sha512-6Z8SnCxvgNWzp7QSQROHAUb8SZ+AD4etLaAj4LUhcCqQA/0RGUms2Vlet0RGNVorq3+8KweUAb3Ix+I4BgaP3w==",
-      "optional": true
-    },
-    "@next/swc-linux-arm-gnueabihf": {
-      "version": "12.3.2-canary.43",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.2-canary.43.tgz",
-      "integrity": "sha512-cl7P0uVxRDCbkC9jAs8NSk/g8O2JVjdWWb6cF/VCSUKZL7dZMly0ocqS58vwb9oTWAI+OFJrAczZPQbtkMU6aQ==",
-      "optional": true
-    },
-    "@next/swc-linux-arm64-gnu": {
-      "version": "12.3.2-canary.43",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.2-canary.43.tgz",
-      "integrity": "sha512-KxEatuNa5q9cImU/Fk0Q0KN136L4WGWcuavPhodQW3zwHn+OKBARA6wmtPkqQhRj7slzVzn3mZ01pPxc4DhsVg==",
-      "optional": true
-    },
-    "@next/swc-linux-arm64-musl": {
-      "version": "12.3.2-canary.43",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.2-canary.43.tgz",
-      "integrity": "sha512-KWaV7rrbE31L1GsHZ33+DkXMgnzcKaZxgA/eIaiJ3wdVse7MzrpCtJH2p3p1mvAPtKu/WG3Ntv4rLFdSzybjWA==",
-      "optional": true
-    },
-    "@next/swc-linux-x64-gnu": {
-      "version": "12.3.2-canary.43",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.2-canary.43.tgz",
-      "integrity": "sha512-fE9zuIDCH48jCbw3/JBhdblZXTEepjaxH+I6A/Nml7Aex2OFAG8GkEdTJdRez3W3IFaMYIhqpGqQcd7VXDw6bw==",
-      "optional": true
-    },
-    "@next/swc-linux-x64-musl": {
-      "version": "12.3.2-canary.43",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.2-canary.43.tgz",
-      "integrity": "sha512-KHXl4kDLjSA2BAKGY+jisaHWYkxDw2bI9j6eQunvkPnlwW5jwiJPQnehszt5CNwYTdoeqiAJE+BY4UnEIEkeNQ==",
-      "optional": true
-    },
-    "@next/swc-win32-arm64-msvc": {
-      "version": "12.3.2-canary.43",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.2-canary.43.tgz",
-      "integrity": "sha512-QHU8bxXzkyjhwVNxLut1m4VRo3ZQlbkcidR7erH8WdSaVhYAWUdPZ6ux6aJLAk3yQwwgw0fSZO98iXdkDp6pvw==",
-      "optional": true
-    },
-    "@next/swc-win32-ia32-msvc": {
-      "version": "12.3.2-canary.43",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.2-canary.43.tgz",
-      "integrity": "sha512-HyElqKE2rJeS0pb6NowKyIsQ9iK/Ct9hkH4fexmoMyMk4z86zu7F3PS9ThLtEDRyzeM5K3xMtFgD+IcYFLRzmA==",
-      "optional": true
-    },
-    "@next/swc-win32-x64-msvc": {
-      "version": "12.3.2-canary.43",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.2-canary.43.tgz",
-      "integrity": "sha512-+0GA+qi1gS/w6QpHj58b4OOxNQ6kWmZuGdAnGuHzBbPmyBERnAWGU4+5DdjOebswM/sCV7ljTjxaHzZo1LN6Ng==",
-      "optional": true
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -23325,6 +23325,201 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/@next/swc-android-arm-eabi": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.2-canary.43.tgz",
+      "integrity": "sha512-Y8tl1H9EXPAWPG4fkULYg2kqsrBNav5zNXvjlvqv83ZR2hrGHW7QyjAdyv0fjGMckrGA9fiqITT1/241gmGdHA==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-android-arm64": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.2-canary.43.tgz",
+      "integrity": "sha512-OuHmP9pEuC9j2IVvOwL0fVHTkhrzvkJO7Sbm9LQW6s0+FJxGjuoLjdOm+GRusnZFyzXRvVWEHd8Wu9aDTzoBGg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.2-canary.43.tgz",
+      "integrity": "sha512-WJqEndZXTaqFDoaxE9NImrWavGoagpBQg0GCNQ3t/IIyG53mbEgegkEoMw7ZYVkQzQcd2b6Nxj6f9nU9T4ebfA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.2-canary.43.tgz",
+      "integrity": "sha512-cWrlfaIx2WkFfl5+TGf09zvgNsij8cTOJ5io1ILHzKt9rTOrr39tK5jk5HYfF5QhKVS4Dw2GHUj7L74xEKqznA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-freebsd-x64": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.2-canary.43.tgz",
+      "integrity": "sha512-6Z8SnCxvgNWzp7QSQROHAUb8SZ+AD4etLaAj4LUhcCqQA/0RGUms2Vlet0RGNVorq3+8KweUAb3Ix+I4BgaP3w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm-gnueabihf": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.2-canary.43.tgz",
+      "integrity": "sha512-cl7P0uVxRDCbkC9jAs8NSk/g8O2JVjdWWb6cF/VCSUKZL7dZMly0ocqS58vwb9oTWAI+OFJrAczZPQbtkMU6aQ==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.2-canary.43.tgz",
+      "integrity": "sha512-KxEatuNa5q9cImU/Fk0Q0KN136L4WGWcuavPhodQW3zwHn+OKBARA6wmtPkqQhRj7slzVzn3mZ01pPxc4DhsVg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.2-canary.43.tgz",
+      "integrity": "sha512-KWaV7rrbE31L1GsHZ33+DkXMgnzcKaZxgA/eIaiJ3wdVse7MzrpCtJH2p3p1mvAPtKu/WG3Ntv4rLFdSzybjWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.2-canary.43.tgz",
+      "integrity": "sha512-fE9zuIDCH48jCbw3/JBhdblZXTEepjaxH+I6A/Nml7Aex2OFAG8GkEdTJdRez3W3IFaMYIhqpGqQcd7VXDw6bw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.2-canary.43.tgz",
+      "integrity": "sha512-KHXl4kDLjSA2BAKGY+jisaHWYkxDw2bI9j6eQunvkPnlwW5jwiJPQnehszt5CNwYTdoeqiAJE+BY4UnEIEkeNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.2-canary.43.tgz",
+      "integrity": "sha512-QHU8bxXzkyjhwVNxLut1m4VRo3ZQlbkcidR7erH8WdSaVhYAWUdPZ6ux6aJLAk3yQwwgw0fSZO98iXdkDp6pvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.2-canary.43.tgz",
+      "integrity": "sha512-HyElqKE2rJeS0pb6NowKyIsQ9iK/Ct9hkH4fexmoMyMk4z86zu7F3PS9ThLtEDRyzeM5K3xMtFgD+IcYFLRzmA==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.2-canary.43.tgz",
+      "integrity": "sha512-+0GA+qi1gS/w6QpHj58b4OOxNQ6kWmZuGdAnGuHzBbPmyBERnAWGU4+5DdjOebswM/sCV7ljTjxaHzZo1LN6Ng==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   },
   "dependencies": {
@@ -40629,6 +40824,84 @@
         "compress-commons": "^4.1.0",
         "readable-stream": "^3.6.0"
       }
+    },
+    "@next/swc-android-arm-eabi": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.2-canary.43.tgz",
+      "integrity": "sha512-Y8tl1H9EXPAWPG4fkULYg2kqsrBNav5zNXvjlvqv83ZR2hrGHW7QyjAdyv0fjGMckrGA9fiqITT1/241gmGdHA==",
+      "optional": true
+    },
+    "@next/swc-android-arm64": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.2-canary.43.tgz",
+      "integrity": "sha512-OuHmP9pEuC9j2IVvOwL0fVHTkhrzvkJO7Sbm9LQW6s0+FJxGjuoLjdOm+GRusnZFyzXRvVWEHd8Wu9aDTzoBGg==",
+      "optional": true
+    },
+    "@next/swc-darwin-arm64": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.2-canary.43.tgz",
+      "integrity": "sha512-WJqEndZXTaqFDoaxE9NImrWavGoagpBQg0GCNQ3t/IIyG53mbEgegkEoMw7ZYVkQzQcd2b6Nxj6f9nU9T4ebfA==",
+      "optional": true
+    },
+    "@next/swc-darwin-x64": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.2-canary.43.tgz",
+      "integrity": "sha512-cWrlfaIx2WkFfl5+TGf09zvgNsij8cTOJ5io1ILHzKt9rTOrr39tK5jk5HYfF5QhKVS4Dw2GHUj7L74xEKqznA==",
+      "optional": true
+    },
+    "@next/swc-freebsd-x64": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.2-canary.43.tgz",
+      "integrity": "sha512-6Z8SnCxvgNWzp7QSQROHAUb8SZ+AD4etLaAj4LUhcCqQA/0RGUms2Vlet0RGNVorq3+8KweUAb3Ix+I4BgaP3w==",
+      "optional": true
+    },
+    "@next/swc-linux-arm-gnueabihf": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.2-canary.43.tgz",
+      "integrity": "sha512-cl7P0uVxRDCbkC9jAs8NSk/g8O2JVjdWWb6cF/VCSUKZL7dZMly0ocqS58vwb9oTWAI+OFJrAczZPQbtkMU6aQ==",
+      "optional": true
+    },
+    "@next/swc-linux-arm64-gnu": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.2-canary.43.tgz",
+      "integrity": "sha512-KxEatuNa5q9cImU/Fk0Q0KN136L4WGWcuavPhodQW3zwHn+OKBARA6wmtPkqQhRj7slzVzn3mZ01pPxc4DhsVg==",
+      "optional": true
+    },
+    "@next/swc-linux-arm64-musl": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.2-canary.43.tgz",
+      "integrity": "sha512-KWaV7rrbE31L1GsHZ33+DkXMgnzcKaZxgA/eIaiJ3wdVse7MzrpCtJH2p3p1mvAPtKu/WG3Ntv4rLFdSzybjWA==",
+      "optional": true
+    },
+    "@next/swc-linux-x64-gnu": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.2-canary.43.tgz",
+      "integrity": "sha512-fE9zuIDCH48jCbw3/JBhdblZXTEepjaxH+I6A/Nml7Aex2OFAG8GkEdTJdRez3W3IFaMYIhqpGqQcd7VXDw6bw==",
+      "optional": true
+    },
+    "@next/swc-linux-x64-musl": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.2-canary.43.tgz",
+      "integrity": "sha512-KHXl4kDLjSA2BAKGY+jisaHWYkxDw2bI9j6eQunvkPnlwW5jwiJPQnehszt5CNwYTdoeqiAJE+BY4UnEIEkeNQ==",
+      "optional": true
+    },
+    "@next/swc-win32-arm64-msvc": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.2-canary.43.tgz",
+      "integrity": "sha512-QHU8bxXzkyjhwVNxLut1m4VRo3ZQlbkcidR7erH8WdSaVhYAWUdPZ6ux6aJLAk3yQwwgw0fSZO98iXdkDp6pvw==",
+      "optional": true
+    },
+    "@next/swc-win32-ia32-msvc": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.2-canary.43.tgz",
+      "integrity": "sha512-HyElqKE2rJeS0pb6NowKyIsQ9iK/Ct9hkH4fexmoMyMk4z86zu7F3PS9ThLtEDRyzeM5K3xMtFgD+IcYFLRzmA==",
+      "optional": true
+    },
+    "@next/swc-win32-x64-msvc": {
+      "version": "12.3.2-canary.43",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.2-canary.43.tgz",
+      "integrity": "sha512-+0GA+qi1gS/w6QpHj58b4OOxNQ6kWmZuGdAnGuHzBbPmyBERnAWGU4+5DdjOebswM/sCV7ljTjxaHzZo1LN6Ng==",
+      "optional": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "typescript": "^4.3.4"
   },
   "dependencies": {
-    "next": "^12.3.0"
+    "next": "^12.3.2-canary.43"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -8,7 +8,7 @@
   ],
   "devDependencies": {
     "@types/node": "^17.0.25",
-    "next": "^12.3.0",
+    "next": "^12.3.2-canary.43",
     "npm-run-all": "^4.1.5",
     "typescript": "^4.6.3"
   },

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -40,7 +40,7 @@
     "@types/jest": "^27.4.1",
     "@types/merge-stream": "^1.1.2",
     "@types/node": "^17.0.25",
-    "next": "^12.3.0",
+    "next": "^12.3.2-canary.43",
     "npm-run-all": "^4.1.5",
     "typescript": "^4.6.3"
   },

--- a/packages/runtime/src/templates/edge/runtime.ts
+++ b/packages/runtime/src/templates/edge/runtime.ts
@@ -33,7 +33,7 @@ export interface RequestData {
     name?: string
     params?: { [key: string]: string }
   }
-  url: URL
+  url: string
   body?: ReadableStream<Uint8Array>
 }
 
@@ -82,7 +82,7 @@ const handler = async (req: Request, context: Context) => {
   const request: RequestData = {
     headers: Object.fromEntries(req.headers.entries()),
     geo,
-    url,
+    url: req.url,
     method: req.method,
     ip: context.ip,
     body: req.body ?? undefined,


### PR DESCRIPTION
### Summary

Updates the test sites and dependencies to Next 13 (actually 12.3.2-canary.43, but that is the same as next 13, which isn;t yet in npm)

### Test plan

1. Check the deploy previews and e2e tests!

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal
![image](https://user-images.githubusercontent.com/213306/197791357-898738e9-2a24-4f74-853d-11b28e70f3b6.png)

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
