### PR TITLE
fix: follow redirects when downloading a file from the CDN

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5238,9 +5238,9 @@
       "devOptional": true
     },
     "node_modules/@types/react": {
-      "version": "17.0.50",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.50.tgz",
-      "integrity": "sha512-ZCBHzpDb5skMnc1zFXAXnL3l1FAdi+xZvwxK+PkglMmBrwjpp9nKaWuEvrGnSifCJmBFGxZOOFuwC6KH/s0NuA==",
+      "version": "17.0.51",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.51.tgz",
+      "integrity": "sha512-YMddzAE+nSH04BiTJ5GydTxk0/3hckqyuOclg0s6zQYj/XzfRVNzHZAFwZb5SCSavkzTYUtcq/gwjLnvt2Y4cg==",
       "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
@@ -11882,6 +11882,25 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/for-in": {
@@ -23201,6 +23220,7 @@
         "chalk": "^4.1.2",
         "destr": "^1.1.1",
         "execa": "^5.1.1",
+        "follow-redirects": "^1.15.2",
         "fs-extra": "^10.0.0",
         "globby": "^11.0.4",
         "merge-stream": "^2.0.0",
@@ -26109,6 +26129,7 @@
         "chalk": "^4.1.2",
         "destr": "^1.1.1",
         "execa": "^5.1.1",
+        "follow-redirects": "^1.15.2",
         "fs-extra": "^10.0.0",
         "globby": "^11.0.4",
         "merge-stream": "^2.0.0",
@@ -26905,9 +26926,9 @@
       "devOptional": true
     },
     "@types/react": {
-      "version": "17.0.50",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.50.tgz",
-      "integrity": "sha512-ZCBHzpDb5skMnc1zFXAXnL3l1FAdi+xZvwxK+PkglMmBrwjpp9nKaWuEvrGnSifCJmBFGxZOOFuwC6KH/s0NuA==",
+      "version": "17.0.51",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.51.tgz",
+      "integrity": "sha512-YMddzAE+nSH04BiTJ5GydTxk0/3hckqyuOclg0s6zQYj/XzfRVNzHZAFwZb5SCSavkzTYUtcq/gwjLnvt2Y4cg==",
       "devOptional": true,
       "requires": {
         "@types/prop-types": "*",
@@ -32014,6 +32035,11 @@
       "requires": {
         "tslib": "^2.0.3"
       }
+    },
+    "follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
     },
     "for-in": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "postinstall": "run-s build install-husky",
     "install-husky": "if-env CI=1 || husky install node_modules/@netlify/eslint-config-node/.husky",
     "test": "run-s build:demo test:jest",
-    "test:jest": "jest",
+    "test:jest": "jest --watch",
     "test:jest:update": "jest --updateSnapshot",
     "test:update": "run-s build build:demo test:jest:update"
   },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "postinstall": "run-s build install-husky",
     "install-husky": "if-env CI=1 || husky install node_modules/@netlify/eslint-config-node/.husky",
     "test": "run-s build:demo test:jest",
-    "test:jest": "jest --watch",
+    "test:jest": "jest",
     "test:jest:update": "jest --updateSnapshot",
     "test:update": "run-s build build:demo test:jest:update"
   },

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -18,6 +18,7 @@
     "chalk": "^4.1.2",
     "destr": "^1.1.1",
     "execa": "^5.1.1",
+    "follow-redirects": "^1.15.2",
     "fs-extra": "^10.0.0",
     "globby": "^11.0.4",
     "merge-stream": "^2.0.0",

--- a/packages/runtime/src/templates/handlerUtils.ts
+++ b/packages/runtime/src/templates/handlerUtils.ts
@@ -1,10 +1,10 @@
 import fs, { createWriteStream, existsSync } from 'fs'
-import { http, https } from 'follow-redirects'
 import { tmpdir } from 'os'
 import path from 'path'
 import { pipeline } from 'stream'
 import { promisify } from 'util'
 
+import { http, https } from 'follow-redirects'
 import type NextNodeServer from 'next/dist/server/next-server'
 
 export type NextServerType = typeof NextNodeServer

--- a/packages/runtime/src/templates/handlerUtils.ts
+++ b/packages/runtime/src/templates/handlerUtils.ts
@@ -1,6 +1,5 @@
 import fs, { createWriteStream, existsSync } from 'fs'
-import http from 'http'
-import https from 'https'
+import { http, https } from 'follow-redirects'
 import { tmpdir } from 'os'
 import path from 'path'
 import { pipeline } from 'stream'

--- a/packages/runtime/src/templates/handlerUtils.ts
+++ b/packages/runtime/src/templates/handlerUtils.ts
@@ -21,7 +21,7 @@ export const downloadFile = async (url: string, destination: string): Promise<vo
   const httpx = url.startsWith('https') ? https : http
 
   await new Promise((resolve, reject) => {
-    const req = httpx.get(url, { timeout: 10000 }, (response) => {
+    const req = httpx.get(url, { timeout: 10000, maxRedirects: 1 }, (response) => {
       if (response.statusCode < 200 || response.statusCode > 299) {
         reject(new Error(`Failed to download ${url}: ${response.statusCode} ${response.statusMessage || ''}`))
         return


### PR DESCRIPTION
### Summary

Uses the `follow-redirects` library to make the `http` request for downloading a file from the CDN.

In cases we where needed to follow the redirect initially returned we were instead failing the request, leading to `500` errors regarding missing files as seen in #1679

### Test plan

* Visit https://ep-next-auth-investigation.netlify.app/auth/signin
* Open the network tab
* Confirm that the `signin.json` file request is returning a `200` response (might need to refresh the page
* Click 'sign in'
* The redirect should work as expected and there should be no `500` responses returned

Should be noted that the test site used above came from the [user who reported the issue](https://github.com/Joroze/next-netlify-starter-nextauth/pull/1), I just forked it.

I haven't added automated tests here because I'd be essentially testing the package itself rather than functionality we've added.

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal
Fixes #1679 

![signal-2022-10-17-21-04-17-223](https://user-images.githubusercontent.com/5655473/198107840-8012e527-1dd1-4644-836b-20ccea361706.jpg)