### PR TITLE
fix: only split extended routes to decrease build times

### DIFF
--- a/packages/runtime/src/helpers/functions.ts
+++ b/packages/runtime/src/helpers/functions.ts
@@ -165,9 +165,9 @@ export const setupImageFunction = async ({
 }
 
 /**
- * Look for API routes, and extract the config from the source file.
+ * Look for advanced API routes (background and scheduled functions), and extract the config from the source file.
  */
-export const getApiRouteConfigs = async (publish: string, baseDir: string): Promise<Array<ApiRouteConfig>> => {
+export const getAdvancedApiRouteConfigs = async (publish: string, baseDir: string): Promise<Array<ApiRouteConfig>> => {
   const pages = await readJSON(join(publish, 'server', 'pages-manifest.json'))
   const apiRoutes = Object.keys(pages).filter((page) => page.startsWith('/api/'))
   const pagesDir = join(baseDir, 'pages')
@@ -179,6 +179,7 @@ export const getApiRouteConfigs = async (publish: string, baseDir: string): Prom
     }),
   )
 
+  // We only want to return the API routes that are background or scheduled functions
   return settledApiRoutes.filter((apiRoute) => apiRoute.config.type !== undefined)
 }
 

--- a/packages/runtime/src/helpers/functions.ts
+++ b/packages/runtime/src/helpers/functions.ts
@@ -165,9 +165,9 @@ export const setupImageFunction = async ({
 }
 
 /**
- * Look for advanced API routes (background and scheduled functions), and extract the config from the source file.
+ * Look for extended API routes (background and scheduled functions) and extract the config from the source file.
  */
-export const getAdvancedApiRouteConfigs = async (publish: string, baseDir: string): Promise<Array<ApiRouteConfig>> => {
+export const getExtendedApiRouteConfigs = async (publish: string, baseDir: string): Promise<Array<ApiRouteConfig>> => {
   const pages = await readJSON(join(publish, 'server', 'pages-manifest.json'))
   const apiRoutes = Object.keys(pages).filter((page) => page.startsWith('/api/'))
   const pagesDir = join(baseDir, 'pages')

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -23,7 +23,7 @@ import {
   generateFunctions,
   setupImageFunction,
   generatePagesResolver,
-  getAdvancedApiRouteConfigs,
+  getExtendedApiRouteConfigs,
   warnOnApiRoutes,
 } from './helpers/functions'
 import { generateRedirects, generateStaticRedirects } from './helpers/redirects'
@@ -152,7 +152,7 @@ const plugin: NetlifyPlugin = {
     const buildId = readFileSync(join(publish, 'BUILD_ID'), 'utf8').trim()
 
     await configureHandlerFunctions({ netlifyConfig, ignore, publish: relative(process.cwd(), publish) })
-    const apiRoutes = await getAdvancedApiRouteConfigs(publish, appDir)
+    const apiRoutes = await getExtendedApiRouteConfigs(publish, appDir)
 
     await generateFunctions(constants, appDir, apiRoutes)
     await generatePagesResolver({ target, constants })

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -23,7 +23,7 @@ import {
   generateFunctions,
   setupImageFunction,
   generatePagesResolver,
-  getApiRouteConfigs,
+  getAdvancedApiRouteConfigs,
   warnOnApiRoutes,
 } from './helpers/functions'
 import { generateRedirects, generateStaticRedirects } from './helpers/redirects'
@@ -152,7 +152,7 @@ const plugin: NetlifyPlugin = {
     const buildId = readFileSync(join(publish, 'BUILD_ID'), 'utf8').trim()
 
     await configureHandlerFunctions({ netlifyConfig, ignore, publish: relative(process.cwd(), publish) })
-    const apiRoutes = await getApiRouteConfigs(publish, appDir)
+    const apiRoutes = await getAdvancedApiRouteConfigs(publish, appDir)
 
     await generateFunctions(constants, appDir, apiRoutes)
     await generatePagesResolver({ target, constants })

--- a/test/__snapshots__/index.js.snap
+++ b/test/__snapshots__/index.js.snap
@@ -1096,21 +1096,6 @@ Array [
     "to": "/.netlify/functions/___netlify-handler",
   },
   Object {
-    "from": "/api/enterPreview",
-    "status": 200,
-    "to": "/.netlify/functions/_api_enterPreview-handler",
-  },
-  Object {
-    "from": "/api/exitPreview",
-    "status": 200,
-    "to": "/.netlify/functions/_api_exitPreview-handler",
-  },
-  Object {
-    "from": "/api/hello",
-    "status": 200,
-    "to": "/.netlify/functions/_api_hello-handler",
-  },
-  Object {
     "from": "/api/hello-background",
     "status": 200,
     "to": "/.netlify/functions/_api_hello-background-background",
@@ -1119,21 +1104,6 @@ Array [
     "from": "/api/hello-scheduled",
     "status": 404,
     "to": "/404.html",
-  },
-  Object {
-    "from": "/api/og",
-    "status": 200,
-    "to": "/.netlify/functions/_api_og-handler",
-  },
-  Object {
-    "from": "/api/shows/:id",
-    "status": 200,
-    "to": "/.netlify/functions/_api_shows_id-PARAM-handler",
-  },
-  Object {
-    "from": "/api/shows/:params/*",
-    "status": 200,
-    "to": "/.netlify/functions/_api_shows_params-SPLAT-handler",
   },
   Object {
     "force": false,

--- a/test/index.js
+++ b/test/index.js
@@ -1627,27 +1627,15 @@ describe('api route file analysis', () => {
     // Using a Set means the order doesn't matter
     expect(new Set(configs)).toEqual(
       new Set([
-        { compiled: 'pages/api/enterPreview.js', config: {}, route: '/api/enterPreview' },
         {
           compiled: 'pages/api/hello-background.js',
           config: { type: 'experimental-background' },
           route: '/api/hello-background',
         },
-        { compiled: 'pages/api/exitPreview.js', config: {}, route: '/api/exitPreview' },
-        { compiled: 'pages/api/shows/[...params].js', config: {}, route: '/api/shows/[...params]' },
-        { compiled: 'pages/api/shows/[id].js', config: {}, route: '/api/shows/[id]' },
-        { compiled: 'pages/api/hello.js', config: {}, route: '/api/hello' },
         {
           compiled: 'pages/api/hello-scheduled.js',
           config: { schedule: '@hourly', type: 'experimental-scheduled' },
           route: '/api/hello-scheduled',
-        },
-        {
-          compiled: 'pages/api/og.js',
-          config: {
-            runtime: 'experimental-edge',
-          },
-          route: '/api/og',
         },
       ]),
     )

--- a/test/index.js
+++ b/test/index.js
@@ -13,7 +13,7 @@ const os = require('os')
 const cpy = require('cpy')
 const { dir: getTmpDir } = require('tmp-promise')
 const { downloadFile } = require('../packages/runtime/src/templates/handlerUtils')
-const { getAdvancedApiRouteConfigs } = require('../packages/runtime/src/helpers/functions')
+const { getExtendedApiRouteConfigs } = require('../packages/runtime/src/helpers/functions')
 const nextRuntimeFactory = require('../packages/runtime/src')
 const nextRuntime = nextRuntimeFactory({})
 
@@ -1623,7 +1623,7 @@ describe('function helpers', () => {
 describe('api route file analysis', () => {
   it('extracts correct route configs from source files', async () => {
     await moveNextDist()
-    const configs = await getAdvancedApiRouteConfigs('.next', process.cwd())
+    const configs = await getExtendedApiRouteConfigs('.next', process.cwd())
     // Using a Set means the order doesn't matter
     expect(new Set(configs)).toEqual(
       new Set([

--- a/test/index.js
+++ b/test/index.js
@@ -13,7 +13,7 @@ const os = require('os')
 const cpy = require('cpy')
 const { dir: getTmpDir } = require('tmp-promise')
 const { downloadFile } = require('../packages/runtime/src/templates/handlerUtils')
-const { getApiRouteConfigs } = require('../packages/runtime/src/helpers/functions')
+const { getAdvancedApiRouteConfigs } = require('../packages/runtime/src/helpers/functions')
 const nextRuntimeFactory = require('../packages/runtime/src')
 const nextRuntime = nextRuntimeFactory({})
 
@@ -1623,7 +1623,7 @@ describe('function helpers', () => {
 describe('api route file analysis', () => {
   it('extracts correct route configs from source files', async () => {
     await moveNextDist()
-    const configs = await getApiRouteConfigs('.next', process.cwd())
+    const configs = await getAdvancedApiRouteConfigs('.next', process.cwd())
     // Using a Set means the order doesn't matter
     expect(new Set(configs)).toEqual(
       new Set([


### PR DESCRIPTION
### Summary

Now we only create custom rewrites and Edge functions for background and scheduled functions. Prior to this PR, we were splitting all API routes and creating separate functions and rewrites for them. This should decrease build times drastically (back to normal) for folks not using extended API routes (scheduled and background functions), and for those who are, the build time should be what it was plus whatever amount of time it takes to build the functions for the advanced API routes.

### Test plan

From a user facing perspective nothing has changed, so all dmoe sites and their corresponding tests should pass.

As well, the logs for the default demo site deploy preview, https://deploy-preview-1731--netlify-plugin-nextjs-demo.netlify.app/, should only create the following functions (see https://app.netlify.com/sites/netlify-plugin-nextjs-demo/deploys/63619a9da96eb900081e6cdf#L824-L831)

```
────────────────────────────────────────────────────────────────
  4. Functions bundling                                         
────────────────────────────────────────────────────────────────

The Netlify Functions setting targets a non-existing directory: netlify/functions

Packaging Functions from .netlify/functions-internal directory:
 - ___netlify-handler/___netlify-handler.js
 - ___netlify-odb-handler/___netlify-odb-handler.js
 - _api_hello-background-background/_api_hello-background-background.js
 - _api_hello-scheduled-handler/_api_hello-scheduled-handler.js
 - _ipx/_ipx.js
 - 
 ```

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

Closes https://github.com/netlify/pod-ecosystem-frameworks/issues/284
Closes https://github.com/netlify/pod-ecosystem-frameworks/issues/282 potentially
Relates to #1495

Just a note that on my own site, these behave as expected

![CleanShot 2022-11-01 at 19 36 30](https://user-images.githubusercontent.com/833231/199361765-ce84cb2b-1be2-4611-ac1b-684fc1ec8f2d.png)

and these tests are still passing with the changes made.

https://github.com/netlify/next-runtime/blob/91ea2a67170bebee07db437d5496e58f2911e81e/cypress/integration/default/api.spec.ts#L9-L18

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [x] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

![Seth Meyers making hand gestures to indicate better](https://media.giphy.com/media/icJA0VF7ntoEL18Jez/giphy.gif)

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.


