### PR TITLE
fix: set up excluded versions in manifest

### DIFF
--- a/packages/runtime/manifest.yml
+++ b/packages/runtime/manifest.yml
@@ -1,1 +1,2 @@
 name: netlify-next-runtime-experimental
+excludedVersionsRange: '4.0.0 - 4.25.0'


### PR DESCRIPTION
### Summary

Sets excluded versions in manifest for the set up to [break builds](https://github.com/netlify/build/pull/4669) if unsupported versions of a plugin are present.

### Test plan

1. Visit the Deploy Preview ([insert link to specific page]()) ...

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
