### PR TITLE
fix: resolve _app deps in API routes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23723,7 +23723,7 @@
     },
     "packages/runtime": {
       "name": "@netlify/plugin-nextjs",
-      "version": "4.28.3",
+      "version": "4.28.4",
       "license": "MIT",
       "dependencies": {
         "@netlify/esbuild": "0.14.39",

--- a/packages/runtime/src/helpers/functions.ts
+++ b/packages/runtime/src/helpers/functions.ts
@@ -49,9 +49,13 @@ export const generateFunctions = async (
       join(__dirname, '..', '..', 'lib', 'templates', 'handlerUtils.js'),
       join(functionsDir, functionName, 'handlerUtils.js'),
     )
+
+    const resolveSourceFile = (file: string) => join(publish, 'server', file)
+
     const resolverSource = await getSinglePageResolver({
       functionsDir,
-      sourceFile: join(publish, 'server', compiled),
+      // These extra pages are always included by Next.js
+      sourceFiles: [compiled, 'pages/_app.js', 'pages/_document.js', 'pages/_error.js'].map(resolveSourceFile),
     })
     await writeFile(join(functionsDir, functionName, 'pages.js'), resolverSource)
   }

--- a/packages/runtime/src/templates/getPageResolver.ts
+++ b/packages/runtime/src/templates/getPageResolver.ts
@@ -39,16 +39,18 @@ export const getPageResolver = async ({ publish, target }: { publish: string; ta
  */
 export const getSinglePageResolver = async ({
   functionsDir,
-  sourceFile,
+  sourceFiles,
 }: {
   functionsDir: string
-  sourceFile: string
+  sourceFiles: Array<string>
 }) => {
-  const dependencies = await getDependenciesOfFile(sourceFile)
+  const dependencies = await Promise.all(sourceFiles.map((sourceFile) => getDependenciesOfFile(sourceFile)))
   // We don't need the actual name, just the relative path.
   const functionDir = resolve(functionsDir, 'functionName')
 
-  const pageFiles = [sourceFile, ...dependencies]
+  const deduped = [...new Set(dependencies.flat())]
+
+  const pageFiles = [...sourceFiles, ...deduped]
     .map((file) => `require.resolve('${relative(functionDir, file)}')`)
     .sort()
 

--- a/test/__snapshots__/index.js.snap
+++ b/test/__snapshots__/index.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`onBuild() generates a file referencing all page sources 1`] = `
+exports[`onBuild() generates a file referencing all API route sources 1`] = `
 "// This file is purely to allow nft to know about these pages. It should be temporary.
 exports.resolvePages = () => {
     try {
@@ -38,7 +38,7 @@ exports.resolvePages = () => {
 }"
 `;
 
-exports[`onBuild() generates a file referencing all page sources 2`] = `
+exports[`onBuild() generates a file referencing all API route sources 2`] = `
 "// This file is purely to allow nft to know about these pages. It should be temporary.
 exports.resolvePages = () => {
     try {
@@ -74,6 +74,35 @@ exports.resolvePages = () => {
         require.resolve('../../../.next/server/pages/shows/[id].js')
     } catch {}
 }"
+`;
+
+exports[`onBuild() generates a file referencing all page sources: for _api_hello-background-background 1`] = `
+"// This file is purely to allow nft to know about these pages. 
+  try {
+      require.resolve('../../../.next/server/package.json')
+        require.resolve('../../../.next/server/pages/_app.js')
+        require.resolve('../../../.next/server/pages/_document.js')
+        require.resolve('../../../.next/server/pages/_error.js')
+        require.resolve('../../../.next/server/pages/api/hello-background.js')
+        require.resolve('../../../.next/server/pages/chunks/274.js')
+        require.resolve('../../../.next/server/pages/webpack-api-runtime.js')
+        require.resolve('../../../.next/server/pages/webpack-runtime.js')
+  } catch {}"
+`;
+
+exports[`onBuild() generates a file referencing all page sources: for _api_hello-scheduled-handler 1`] = `
+"// This file is purely to allow nft to know about these pages. 
+  try {
+      require.resolve('../../../.next/package.json')
+        require.resolve('../../../.next/server/package.json')
+        require.resolve('../../../.next/server/pages/_app.js')
+        require.resolve('../../../.next/server/pages/_document.js')
+        require.resolve('../../../.next/server/pages/_error.js')
+        require.resolve('../../../.next/server/pages/api/hello-scheduled.js')
+        require.resolve('../../../.next/server/pages/chunks/274.js')
+        require.resolve('../../../.next/server/pages/webpack-api-runtime.js')
+        require.resolve('../../../.next/server/pages/webpack-runtime.js')
+  } catch {}"
 `;
 
 exports[`onBuild() generates a file referencing all when publish dir is a subdirectory 1`] = `

--- a/test/index.js
+++ b/test/index.js
@@ -533,7 +533,18 @@ describe('onBuild()', () => {
     expect(netlifyConfig.functions[ODB_FUNCTION_NAME].node_bundler).toEqual('nft')
   })
 
-  test('generates a file referencing all page sources', async () => {
+  it('generates a file referencing all page sources', async () => {
+    await moveNextDist()
+    await nextRuntime.onBuild(defaultArgs)
+
+    for (const route of ['_api_hello-background-background', '_api_hello-scheduled-handler']) {
+      const expected = path.resolve(constants.INTERNAL_FUNCTIONS_SRC, route, 'pages.js')
+      expect(existsSync(expected)).toBeTruthy()
+      expect(readFileSync(expected, 'utf8')).toMatchSnapshot(`for ${route}`)
+    }
+  })
+
+  test('generates a file referencing all API route sources', async () => {
     await moveNextDist()
     await nextRuntime.onBuild(defaultArgs)
     const handlerPagesFile = path.join(constants.INTERNAL_FUNCTIONS_SRC, HANDLER_FUNCTION_NAME, 'pages.js')


### PR DESCRIPTION
### Summary

`next/server`, in its wisdom, always loads `_app` and `_document`, even in API routes. This PR ensures that any dependencies of these files are included in the API routes bundle.

### Test plan

1. Visit the demo site that is using the published tagged version of this, and check the logs: https://app.netlify.com/sites/next-scheduled-test/functions/_api_scheduled-test-handler

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal
![image](https://user-images.githubusercontent.com/213306/200005831-ac7210fe-04bc-49dc-b08c-bd36adddfdd9.png)

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
