### PR TITLE
feat: add next debug logging

### DIFF
--- a/packages/runtime/src/templates/getHandler.ts
+++ b/packages/runtime/src/templates/getHandler.ts
@@ -115,6 +115,14 @@ const makeHandler = (conf: NextConfig, app, pageRoot, staticManifest: Array<[str
 
     const multiValueHeaders = getMultiValueHeaders(headers)
 
+    if (event.headers['x-next-debug-logging']) {
+      const response = {
+        headers: multiValueHeaders,
+        statusCode: result.statusCode,
+      }
+      console.log('Origin response:', JSON.stringify(response, null, 2))
+    }
+
     if (multiValueHeaders['set-cookie']?.[0]?.includes('__prerender_bypass')) {
       delete multiValueHeaders.etag
       multiValueHeaders['cache-control'] = ['no-cache']


### PR DESCRIPTION
### Summary

Occasionally we run into situations where it would be useful to know more about the origin response from the Next server to our handler functions.

This PR writes the origin headers and status code to the function logs when the request includes the header `x-next-debug-logging`.

### Test plan

1. Visit an SSR/ISR page that is routed to a handler function and include the above request header
2. Observe the origin response in the function logs

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

<img src="https://i.ytimg.com/vi/etM_zG3_PCc/maxresdefault.jpg" width="600" alt="purple octopus" />