### PR TITLE
fix: polyfill headers.getAll

### DIFF
--- a/packages/runtime/src/helpers/edge.ts
+++ b/packages/runtime/src/helpers/edge.ts
@@ -89,6 +89,23 @@ globalThis.process = { env: {...Deno.env.toObject(), NEXT_RUNTIME: 'edge', 'NEXT
 const self = {}
 let _ENTRIES = {}
 
+class Response extends globalThis.Response {
+  constructor(body, init) {
+    super(body, init);
+    // Next.js uses this extension to the Headers API implemented by Cloudflare workerd
+    this.headers.getAll = (name) => {
+      name = name.toLowerCase();
+      if (name !== "set-cookie") {
+        throw new Error("Headers.getAll is only supported for Set-Cookie");
+      }
+      return [...this.headers.entries()]
+        .filter(([key]) => key === name)
+        .map(([, value]) => value);
+    };
+  }
+}
+
+
 //  Next uses blob: urls to refer to local assets, so we need to intercept these
 const _fetch = globalThis.fetch
 const fetch = async (url, init) => {


### PR DESCRIPTION
### Summary

Next.js uses the non-standard `headers.getAll`, which was removed from the spec but implemented by CLoudflare workerd just for `set-cookie` headers. This PR adds a polyfill for this to the edge runtime.

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal
Fixes #1732

![elon carrying a capybara into twitter HQ](https://user-images.githubusercontent.com/213306/201415051-6027f5f4-7264-4064-aeee-e6c7ed626d6e.png)
