### PR TITLE
fix: revert publish from subdirectory

### DIFF
--- a/packages/runtime/src/helpers/files.ts
+++ b/packages/runtime/src/helpers/files.ts
@@ -1,6 +1,7 @@
 /* eslint-disable max-lines */
 import { cpus } from 'os'
 
+import type { NetlifyConfig } from '@netlify/build'
 import { yellowBright } from 'chalk'
 import { existsSync, readJson, move, copy, writeJson, readFile, writeFile, ensureDir, readFileSync } from 'fs-extra'
 import globby from 'globby'
@@ -59,11 +60,11 @@ export const matchesRewrite = (file: string, rewrites: Rewrites): boolean => {
   return matchesRedirect(file, rewrites.beforeFiles)
 }
 
-export const getMiddleware = async (distDir: string): Promise<Array<string>> => {
+export const getMiddleware = async (publish: string): Promise<Array<string>> => {
   if (process.env.NEXT_DISABLE_NETLIFY_EDGE !== 'true' && process.env.NEXT_DISABLE_NETLIFY_EDGE !== '1') {
     return []
   }
-  const manifestPath = join(distDir, 'server', 'middleware-manifest.json')
+  const manifestPath = join(publish, 'server', 'middleware-manifest.json')
   if (existsSync(manifestPath)) {
     const manifest = await readJson(manifestPath, { throws: false })
     return manifest?.sortedMiddleware ?? []
@@ -73,28 +74,32 @@ export const getMiddleware = async (distDir: string): Promise<Array<string>> => 
 
 // eslint-disable-next-line max-lines-per-function
 export const moveStaticPages = async ({
-  distDir,
+  netlifyConfig,
+  target,
   i18n,
   basePath,
-  publishDir,
 }: {
-  distDir: string
+  netlifyConfig: NetlifyConfig
+  target: 'server' | 'serverless' | 'experimental-serverless-trace'
   i18n: NextConfig['i18n']
   basePath?: string
-  publishDir
 }): Promise<void> => {
   console.log('Moving static page files to serve from CDN...')
-  const outputDir = join(distDir, 'server')
+  const outputDir = join(netlifyConfig.build.publish, target === 'server' ? 'server' : 'serverless')
   const root = join(outputDir, 'pages')
-  const buildId = readFileSync(join(distDir, 'BUILD_ID'), 'utf8').trim()
+  const buildId = readFileSync(join(netlifyConfig.build.publish, 'BUILD_ID'), 'utf8').trim()
   const dataDir = join('_next', 'data', buildId)
-  await ensureDir(join(publishDir, dataDir))
+  await ensureDir(join(netlifyConfig.build.publish, dataDir))
   // Load the middleware manifest so we can check if a file matches it before moving
-  const middlewarePaths = await getMiddleware(distDir)
+  const middlewarePaths = await getMiddleware(netlifyConfig.build.publish)
   const middleware = middlewarePaths.map((path) => path.slice(1))
 
-  const prerenderManifest: PrerenderManifest = await readJson(join(distDir, 'prerender-manifest.json'))
-  const { redirects, rewrites }: RoutesManifest = await readJson(join(distDir, 'routes-manifest.json'))
+  const prerenderManifest: PrerenderManifest = await readJson(
+    join(netlifyConfig.build.publish, 'prerender-manifest.json'),
+  )
+  const { redirects, rewrites }: RoutesManifest = await readJson(
+    join(netlifyConfig.build.publish, 'routes-manifest.json'),
+  )
 
   const isrFiles = new Set<string>()
 
@@ -123,7 +128,7 @@ export const moveStaticPages = async ({
     files.push(file)
     filesManifest[file] = targetPath
 
-    const dest = join(publishDir, targetPath)
+    const dest = join(netlifyConfig.build.publish, targetPath)
 
     try {
       await move(source, dest)
@@ -237,10 +242,10 @@ export const moveStaticPages = async ({
   }
 
   // Write the manifest for use in the serverless functions
-  await writeJson(join(distDir, 'static-manifest.json'), Object.entries(filesManifest))
+  await writeJson(join(netlifyConfig.build.publish, 'static-manifest.json'), Object.entries(filesManifest))
 
   if (i18n?.defaultLocale) {
-    const rootPath = basePath ? join(publishDir, basePath) : publishDir
+    const rootPath = basePath ? join(netlifyConfig.build.publish, basePath) : netlifyConfig.build.publish
     // Copy the default locale into the root
     const defaultLocaleDir = join(rootPath, i18n.defaultLocale)
     if (existsSync(defaultLocaleDir)) {
@@ -422,13 +427,12 @@ export const unpatchNextFiles = async (root: string): Promise<void> => {
 export const movePublicFiles = async ({
   appDir,
   outdir,
-  publishDir,
+  publish,
 }: {
   appDir: string
   outdir?: string
-  publishDir: string
+  publish: string
 }): Promise<void> => {
-  await ensureDir(publishDir)
   // `outdir` is a config property added when using Next.js with Nx. It's typically
   // a relative path outside of the appDir, e.g. '../../dist/apps/<app-name>', and
   // the parent directory of the .next directory.
@@ -437,7 +441,7 @@ export const movePublicFiles = async ({
   // directory from the original app directory.
   const publicDir = outdir ? join(appDir, outdir, 'public') : join(appDir, 'public')
   if (existsSync(publicDir)) {
-    await copy(publicDir, `${publishDir}/`)
+    await copy(publicDir, `${publish}/`)
   }
 }
 /* eslint-enable max-lines */

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -4,7 +4,7 @@ import { join, relative } from 'path'
 import type { NetlifyPlugin } from '@netlify/build'
 import { bold, redBright } from 'chalk'
 import destr from 'destr'
-import { copy, ensureDir, existsSync, readFileSync } from 'fs-extra'
+import { existsSync, readFileSync } from 'fs-extra'
 import { outdent } from 'outdent'
 
 import { HANDLER_FUNCTION_NAME, ODB_FUNCTION_NAME } from './constants'
@@ -26,7 +26,7 @@ import {
   getExtendedApiRouteConfigs,
   warnOnApiRoutes,
 } from './helpers/functions'
-import { generateRedirects } from './helpers/redirects'
+import { generateRedirects, generateStaticRedirects } from './helpers/redirects'
 import { shouldSkip, isNextAuthInstalled, getCustomImageResponseHeaders, getRemotePatterns } from './helpers/utils'
 import {
   verifyNetlifyBuildVersion,
@@ -80,18 +80,12 @@ const plugin: NetlifyPlugin = {
 
     checkNextSiteHasBuilt({ publish, failBuild })
 
-    const { appDir, basePath, i18n, images, target, ignore, trailingSlash, outdir, experimental, distDir } =
-      await getNextConfig({
+    const { appDir, basePath, i18n, images, target, ignore, trailingSlash, outdir, experimental } = await getNextConfig(
+      {
         publish,
         failBuild,
-      })
-
-    const dotNextDir = join(appDir, distDir)
-
-    // This is the *generated* publish dir. The user specifies .next, be we actually use this subdirectory
-    const publishDir = join(dotNextDir, 'dist')
-    await ensureDir(publishDir)
-
+      },
+    )
     await cleanupEdgeFunctions(constants)
 
     const middlewareManifest = await loadMiddlewareManifest(netlifyConfig)
@@ -123,7 +117,7 @@ const plugin: NetlifyPlugin = {
     }
 
     if (isNextAuthInstalled()) {
-      const config = await getRequiredServerFiles(dotNextDir)
+      const config = await getRequiredServerFiles(publish)
 
       const userDefinedNextAuthUrl = config.config.env.NEXTAUTH_URL
 
@@ -140,7 +134,7 @@ const plugin: NetlifyPlugin = {
         )
         config.config.env.NEXTAUTH_URL = nextAuthUrl
 
-        await updateRequiredServerFiles(dotNextDir, config)
+        await updateRequiredServerFiles(publish, config)
       } else {
         // Using the deploy prime url in production leads to issues because the unique deploy ID is part of the generated URL
         // and will not match the expected URL in the callback URL of an OAuth application.
@@ -151,27 +145,30 @@ const plugin: NetlifyPlugin = {
         console.log(`NextAuth package detected, setting NEXTAUTH_URL environment variable to ${nextAuthUrl}`)
         config.config.env.NEXTAUTH_URL = nextAuthUrl
 
-        await updateRequiredServerFiles(dotNextDir, config)
+        await updateRequiredServerFiles(publish, config)
       }
     }
 
-    const buildId = readFileSync(join(dotNextDir, 'BUILD_ID'), 'utf8').trim()
+    const buildId = readFileSync(join(publish, 'BUILD_ID'), 'utf8').trim()
 
-    await configureHandlerFunctions({ netlifyConfig, ignore, publish: relative(process.cwd(), dotNextDir) })
-    const apiRoutes = await getExtendedApiRouteConfigs(dotNextDir, appDir)
+    await configureHandlerFunctions({ netlifyConfig, ignore, publish: relative(process.cwd(), publish) })
+    const apiRoutes = await getExtendedApiRouteConfigs(publish, appDir)
 
     await generateFunctions(constants, appDir, apiRoutes)
     await generatePagesResolver({ target, constants })
 
-    await movePublicFiles({ appDir, outdir, publishDir })
+    await movePublicFiles({ appDir, outdir, publish })
 
     await patchNextFiles(appDir)
 
     if (!destr(process.env.SERVE_STATIC_FILES_FROM_ORIGIN)) {
-      await moveStaticPages({ distDir: dotNextDir, i18n, basePath, publishDir })
+      await moveStaticPages({ target, netlifyConfig, i18n, basePath })
     }
 
-    await copy(join(dotNextDir, 'static'), join(publishDir, '_next', 'static'))
+    await generateStaticRedirects({
+      netlifyConfig,
+      nextConfig: { basePath, i18n },
+    })
 
     await setupImageFunction({
       constants,
@@ -193,16 +190,20 @@ const plugin: NetlifyPlugin = {
   },
 
   async onPostBuild({
-    netlifyConfig,
+    netlifyConfig: {
+      build: { publish },
+      redirects,
+      headers,
+    },
     utils: {
       status,
       cache,
       functions,
       build: { failBuild },
     },
-    constants: { FUNCTIONS_DIST, PUBLISH_DIR },
+    constants: { FUNCTIONS_DIST },
   }) {
-    await saveCache({ cache, publish: netlifyConfig.build.publish })
+    await saveCache({ cache, publish })
 
     if (shouldSkip()) {
       status.show({
@@ -218,16 +219,15 @@ const plugin: NetlifyPlugin = {
 
     await checkForOldFunctions({ functions })
     await checkZipSize(join(FUNCTIONS_DIST, `${ODB_FUNCTION_NAME}.zip`))
-    const nextConfig = await getNextConfig({ publish: netlifyConfig.build.publish, failBuild })
+    const nextConfig = await getNextConfig({ publish, failBuild })
 
     const { basePath, appDir } = nextConfig
 
-    generateCustomHeaders(nextConfig, netlifyConfig.headers)
+    generateCustomHeaders(nextConfig, headers)
 
-    warnForProblematicUserRewrites({ basePath, redirects: netlifyConfig.redirects })
+    warnForProblematicUserRewrites({ basePath, redirects })
     warnForRootRedirects({ appDir })
     await warnOnApiRoutes({ FUNCTIONS_DIST })
-    netlifyConfig.build.publish = join(PUBLISH_DIR, 'dist')
   },
 }
 // The types haven't been updated yet

--- a/test/__snapshots__/index.js.snap
+++ b/test/__snapshots__/index.js.snap
@@ -1087,6 +1087,16 @@ Array [
     "to": "/_ipx/w_:width,q_:quality/:url",
   },
   Object {
+    "from": "/_next/static/*",
+    "status": 200,
+    "to": "/static/:splat",
+  },
+  Object {
+    "from": "/:locale/_next/static/*",
+    "status": 200,
+    "to": "/static/:splat",
+  },
+  Object {
     "conditions": Object {
       "Cookie": Array [
         "__prerender_bypass",
@@ -1129,6 +1139,24 @@ Array [
     "from": "/broken-image",
     "status": 200,
     "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/BUILD_ID",
+    "status": 404,
+    "to": "/404.html",
+  },
+  Object {
+    "force": true,
+    "from": "/build-manifest.json",
+    "status": 404,
+    "to": "/404.html",
+  },
+  Object {
+    "force": true,
+    "from": "/cache/*",
+    "status": 404,
+    "to": "/404.html",
   },
   Object {
     "force": false,
@@ -1683,10 +1711,22 @@ Array [
     "to": "/.netlify/functions/___netlify-handler",
   },
   Object {
+    "force": true,
+    "from": "/prerender-manifest.json",
+    "status": 404,
+    "to": "/404.html",
+  },
+  Object {
     "force": false,
     "from": "/previewTest",
     "status": 200,
     "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/react-loadable-manifest.json",
+    "status": 404,
+    "to": "/404.html",
   },
   Object {
     "force": false,
@@ -1695,10 +1735,28 @@ Array [
     "to": "/.netlify/functions/___netlify-handler",
   },
   Object {
+    "force": true,
+    "from": "/routes-manifest.json",
+    "status": 404,
+    "to": "/404.html",
+  },
+  Object {
     "force": false,
     "from": "/script",
     "status": 200,
     "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/server/*",
+    "status": 404,
+    "to": "/404.html",
+  },
+  Object {
+    "force": true,
+    "from": "/serverless/*",
+    "status": 404,
+    "to": "/404.html",
   },
   Object {
     "force": false,
@@ -1723,6 +1781,18 @@ Array [
     "from": "/static/:id",
     "status": 200,
     "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/trace",
+    "status": 404,
+    "to": "/404.html",
+  },
+  Object {
+    "force": true,
+    "from": "/traces",
+    "status": 404,
+    "to": "/404.html",
   },
 ]
 `;


### PR DESCRIPTION
### Summary

This reverts #1756. There were issues with the change to publishing from a subdirectory, so we are backing it out for now.

<!-- Provide a brief summary of the change. -->

### Test plan

I have not been able to reproduce the failure, so I can't test this as a fix. However it is just a straight revert of the previous change, so should be relatively uncontroversial (famous last words). 

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal
![snoozy capy](https://user-images.githubusercontent.com/213306/201637608-24fc90a7-0d77-42ac-b513-7f8c2f947843.png)

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
