### PR TITLE
fix: better headers.getAll polyfill

### DIFF
--- a/packages/runtime/src/helpers/edge.ts
+++ b/packages/runtime/src/helpers/edge.ts
@@ -89,23 +89,18 @@ globalThis.process = { env: {...Deno.env.toObject(), NEXT_RUNTIME: 'edge', 'NEXT
 const self = {}
 let _ENTRIES = {}
 
-class Response extends globalThis.Response {
-  constructor(body, init) {
-    super(body, init);
-    // Next.js uses this extension to the Headers API implemented by Cloudflare workerd
-    this.headers.getAll = (name) => {
-      name = name.toLowerCase();
-      if (name !== "set-cookie") {
-        throw new Error("Headers.getAll is only supported for Set-Cookie");
-      }
-      return [...this.headers.entries()]
-        .filter(([key]) => key === name)
-        .map(([, value]) => value);
-    };
-  }
+// Next.js uses this extension to the Headers API implemented by Cloudflare workerd
+if(!('getAll' in Headers.prototype)) {
+  Headers.prototype.getAll = function getAll(name) {
+    name = name.toLowerCase();
+    if (name !== "set-cookie") {
+      throw new Error("Headers.getAll is only supported for Set-Cookie");
+    }
+    return [...this.entries()]
+      .filter(([key]) => key === name)
+      .map(([, value]) => value);
+  };
 }
-
-
 //  Next uses blob: urls to refer to local assets, so we need to intercept these
 const _fetch = globalThis.fetch
 const fetch = async (url, init) => {


### PR DESCRIPTION
### Summary

Last week I added [a polyfill for headers.getAll](https://github.com/netlify/next-runtime/pull/1766). However Next.js has now added a check to the edge function return value to see if it's an instanceof `Response`. This means that our polyfilled version wouldn;t match if the user returned e.g. `Response.redirect`, or `fetch()`. This PR changes the polyfill from a subclass to augmenting the prototype of `Headers`. 😬 

### Test plan

This was caught by the e2e tests PR, but it can be checked for regression by looking at the middleware deploy preview

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal
![capy gamer](https://user-images.githubusercontent.com/213306/203384194-5b360868-f513-41b3-9266-60e04417b19a.png)

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
