### PR TITLE
docs: added a link to the contributing guidelines in the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+<!-- Before opening a pull request, ensure you've read our contributing guildines, https://github.com/netlify/next-runtime/blob/main/CONTRIBUTING.md. -->
+
 ### Summary
 
 <!-- Provide a brief summary of the change. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,7 @@ help you and to help the maintainers gather information.
 Before working on an issue, ask to be assigned to it. This makes it clear to other potential contributors that someone
 is working on the issue.
 
-When creating a PR, please fill out the template to the best of your abilities. Do not delete it. The information in the
-template helps maintainers review your pull request.
+When creating a PR, please use the template. The information in the template helps maintainers review your pull request.```
 
 This project was made with ❤️. The simplest way to give back is by starring and sharing it online.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,12 +2,15 @@
 
 🎉 Thanks for considering contributing to this project! 🎉
 
-These guidelines will help you send a pull request.
+When contributing to this repository, please first discuss the change you wish to make via an
+[issue](https://github.com/netlify/next-runtime/issues/new/choose). Please use the issue templates. They are there to
+help you and to help the maintainers gather information.
 
-If you're submitting an issue instead, please skip this document.
+Before working on an issue, ask to be assigned to it. This makes it clear to other potential contributors that someone
+is working on the issue.
 
-If your pull request is related to a typo or the documentation being unclear, please click on the relevant page's `Edit`
-button (pencil icon) and directly suggest a correction instead.
+When creating a PR, please fill out the template to the best of your abilities. Do not delete it. The information in the
+template helps maintainers review your pull request.
 
 This project was made with ❤️. The simplest way to give back is by starring and sharing it online.
 
@@ -37,9 +40,9 @@ We use [Conventional Commit messages](https://www.conventionalcommits.org/) to a
 
 Most common commit message prefixes are:
 
-* `fix:` which represents bug fixes, and generate a patch release.
-* `feat:` which represents a new feature, and generate a minor release.
-* `feat!:`, `fix!:` or `refactor!:` and generate a major release.
+- `fix:` which represents bug fixes, and generate a patch release.
+- `feat:` which represents a new feature, and generate a minor release.
+- `feat!:`, `fix!:` or `refactor!:` and generate a major release.
 
 ## Releasing
 


### PR DESCRIPTION
### Summary

Updates our contributing guidelines to indicate that an issue must first be opened and discussed before submitting a PR.

### Test plan

N/A. This only updates documentation.

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

Closes #1807

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.


![An alpacca with sunglasses on](https://media.giphy.com/media/Pmrg6kkzogWW4T2qZH/giphy.gif)