### PR TITLE
ci: increase test timeout

### DIFF
--- a/test/e2e/jest.config.js
+++ b/test/e2e/jest.config.js
@@ -14,7 +14,7 @@ const config = {
     '\\.[jt]sx?$': 'babel-jest',
   },
   verbose: true,
-  testTimeout: 60000,
+  testTimeout: 300000,
   moduleFileExtensions: ['js', 'jsx', 'ts', 'tsx'],
   moduleNameMapper: {
     'e2e-utils': '<rootDir>/next-test-lib/e2e-utils.ts',


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guildines, https://github.com/netlify/next-runtime/blob/main/CONTRIBUTING.md. -->

### Summary

Increase the default test timeout to 5 mins, to give time to deploy the demo site
