### PR TITLE
fix: correctly handle ISR for appDir pages

### DIFF
--- a/.github/workflows/e2e-appdir.yml
+++ b/.github/workflows/e2e-appdir.yml
@@ -41,7 +41,6 @@ jobs:
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_BOT_AUTH_TOKEN }}
           NETLIFY_SITE_ID: 1d5a5c76-d445-4ae5-b694-b0d3f2e2c395
-          NEXT_TEST_VERSION: canary
       - uses: actions/upload-artifact@v3
         if: ${{ always() }}
         name: Upload test results

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,12 +15,6 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        node-version: [14, '*']
-        exclude:
-          - os: macOS-latest
-            node-version: 14
-          - os: windows-latest
-            node-version: 14
       fail-fast: false
 
     steps:
@@ -32,15 +26,8 @@ jobs:
           check-latest: true
       - name: NPM Install
         run: npm install
-      - name: Switching to Node.js ${{ matrix.node-version }} to run tests
-        uses: actions/setup-node@v2
-        if: "${{ matrix.node-version != 'lts/*' }}"
-        with:
-          node-version: ${{ matrix.node-version }}
-          check-latest: true
       - name: Linting
         run: npm run format:ci
-        if: "${{ matrix.node-version == 'lts/*' }}"
       - name: Run tests against next@latest
         run: npm test
   canary:
@@ -50,12 +37,6 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        node-version: [14, '*']
-        exclude:
-          - os: macOS-latest
-            node-version: 14
-          - os: windows-latest
-            node-version: 14
       fail-fast: false
 
     if: github.ref_name == 'main'
@@ -70,11 +51,5 @@ jobs:
         run: npm install
       - name: Install Next.js Canary
         run: npm install -D next@canary --legacy-peer-deps
-      - name: Switching to Node.js ${{ matrix.node-version }} to run tests
-        uses: actions/setup-node@v2
-        if: "${{ matrix.node-version != 'lts/*' }}"
-        with:
-          node-version: ${{ matrix.node-version }}
-          check-latest: true
       - name: Run tests against next@canary
         run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Installing with LTS Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 'lts/*'
+          node-version: 16
           check-latest: true
       - name: NPM Install
         run: npm install
@@ -45,7 +45,7 @@ jobs:
       - name: Installing with LTS Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 'lts/*'
+          node-version: 16
           check-latest: true
       - name: NPM Install
         run: npm install

--- a/cypress/integration/default/appdir.spec.ts
+++ b/cypress/integration/default/appdir.spec.ts
@@ -2,7 +2,7 @@ describe('appDir', () => {
   it('renders appdir pages using SSR', () => {
     cy.request('/blog/erica/first-post/').then((response) => {
       expect(response.headers).to.have.property('x-nf-render-mode', 'ssr')
-      expect(response.headers).to.have.property('context-type', 'text/html; charset=utf-8')
+      expect(response.headers).to.have.property('content-type', 'text/html; charset=utf-8')
     })
   })
 

--- a/cypress/integration/default/appdir.spec.ts
+++ b/cypress/integration/default/appdir.spec.ts
@@ -7,8 +7,9 @@ describe('appDir', () => {
   })
 
   it('returns RSC data for RSC requests', () => {
-    cy.request('/blog/erica/first-post/', {
-      Headers: {
+    cy.request({
+      url: '/blog/erica/first-post/',
+      headers: {
         RSC: '1',
       },
     }).then((response) => {

--- a/cypress/integration/default/appdir.spec.ts
+++ b/cypress/integration/default/appdir.spec.ts
@@ -1,11 +1,34 @@
 describe('appDir', () => {
-  it('renders appdir pages as HTML by default', () => {
+  it('renders ISR appdir pages as HTML by default', () => {
+    cy.request('/blog/erica/').then((response) => {
+      expect(response.headers['content-type']).to.match(/^text\/html/)
+    })
+  })
+
+  it('renders static appdir pages as HTML by default', () => {
     cy.request('/blog/erica/first-post/').then((response) => {
       expect(response.headers['content-type']).to.match(/^text\/html/)
     })
   })
 
-  it('returns RSC data for RSC requests', () => {
+  it('renders dynamic appdir pages as HTML by default', () => {
+    cy.request('/blog/erica/random-post/').then((response) => {
+      expect(response.headers['content-type']).to.match(/^text\/html/)
+    })
+  })
+
+  it('returns RSC data for RSC requests to ISR pages', () => {
+    cy.request({
+      url: '/blog/erica/',
+      headers: {
+        RSC: '1',
+      },
+    }).then((response) => {
+      expect(response.headers).to.have.property('content-type', 'application/octet-stream')
+    })
+  })
+
+  it('returns RSC data for RSC requests to static pages', () => {
     cy.request({
       url: '/blog/erica/first-post/',
       headers: {
@@ -13,6 +36,39 @@ describe('appDir', () => {
       },
     }).then((response) => {
       expect(response.headers).to.have.property('content-type', 'application/octet-stream')
+    })
+  })
+
+  it('returns RSC data for RSC requests to dynamic pages', () => {
+    cy.request({
+      url: '/blog/erica/random-post/',
+      headers: {
+        RSC: '1',
+      },
+    }).then((response) => {
+      expect(response.headers).to.have.property('content-type', 'application/octet-stream')
+    })
+  })
+
+  it('correctly redirects HTML requests for ISR pages', () => {
+    cy.request('/blog/erica').then((response) => {
+      expect(response.status).to.be('308')
+      expect(response.headers).to.have.property('location', '/blog/erica/')
+    })
+  })
+
+  // This needs trailing slash handling to be fixed
+  it.skip('correctly redirects HTML requests for static pages', () => {
+    cy.request('/blog/erica/first-post').then((response) => {
+      expect(response.status).to.be('308')
+      expect(response.headers).to.have.property('location', '/blog/erica/first-post/')
+    })
+  })
+
+  it('correctly redirects HTML requests for dynamic pages', () => {
+    cy.request('/blog/erica/random-post').then((response) => {
+      expect(response.status).to.be('308')
+      expect(response.headers).to.have.property('location', '/blog/erica/random-post/')
     })
   })
 })

--- a/cypress/integration/default/appdir.spec.ts
+++ b/cypress/integration/default/appdir.spec.ts
@@ -13,7 +13,7 @@ describe('appDir', () => {
       },
     }).then((response) => {
       expect(response.headers).to.have.property('x-nf-render-mode', 'ssr')
-      expect(response.headers).to.have.property('context-type', 'application/octet-stream')
+      expect(response.headers).to.have.property('content-type', 'application/octet-stream')
     })
   })
 })

--- a/cypress/integration/default/appdir.spec.ts
+++ b/cypress/integration/default/appdir.spec.ts
@@ -1,18 +1,18 @@
 describe('appDir', () => {
   it('renders ISR appdir pages as HTML by default', () => {
-    cy.request('/blog/erica/').then((response) => {
+    cy.request({ url: '/blog/erica/', followRedirect: false }).then((response) => {
       expect(response.headers['content-type']).to.match(/^text\/html/)
     })
   })
 
   it('renders static appdir pages as HTML by default', () => {
-    cy.request('/blog/erica/first-post/').then((response) => {
+    cy.request({ url: '/blog/erica/first-post/', followRedirect: false }).then((response) => {
       expect(response.headers['content-type']).to.match(/^text\/html/)
     })
   })
 
   it('renders dynamic appdir pages as HTML by default', () => {
-    cy.request('/blog/erica/random-post/').then((response) => {
+    cy.request({ url: '/blog/erica/random-post/', followRedirect: false }).then((response) => {
       expect(response.headers['content-type']).to.match(/^text\/html/)
     })
   })
@@ -23,6 +23,7 @@ describe('appDir', () => {
       headers: {
         RSC: '1',
       },
+      followRedirect: false,
     }).then((response) => {
       expect(response.headers).to.have.property('content-type', 'application/octet-stream')
     })
@@ -34,6 +35,7 @@ describe('appDir', () => {
       headers: {
         RSC: '1',
       },
+      followRedirect: false,
     }).then((response) => {
       expect(response.headers).to.have.property('content-type', 'application/octet-stream')
     })
@@ -45,29 +47,30 @@ describe('appDir', () => {
       headers: {
         RSC: '1',
       },
+      followRedirect: false,
     }).then((response) => {
       expect(response.headers).to.have.property('content-type', 'application/octet-stream')
     })
   })
 
   it('correctly redirects HTML requests for ISR pages', () => {
-    cy.request('/blog/erica').then((response) => {
-      expect(response.status).to.equal('308')
+    cy.request({ url: '/blog/erica', followRedirect: false }).then((response) => {
+      expect(response.status).to.equal(308)
       expect(response.headers).to.have.property('location', '/blog/erica/')
     })
   })
 
   // This needs trailing slash handling to be fixed
   it.skip('correctly redirects HTML requests for static pages', () => {
-    cy.request('/blog/erica/first-post').then((response) => {
-      expect(response.status).to.equal('308')
+    cy.request({ url: '/blog/erica/first-post', followRedirect: false }).then((response) => {
+      expect(response.status).to.equal(308)
       expect(response.headers).to.have.property('location', '/blog/erica/first-post/')
     })
   })
 
   it('correctly redirects HTML requests for dynamic pages', () => {
-    cy.request('/blog/erica/random-post').then((response) => {
-      expect(response.status).to.equal('308')
+    cy.request({ url: '/blog/erica/random-post', followRedirect: false }).then((response) => {
+      expect(response.status).to.equal(308)
       expect(response.headers).to.have.property('location', '/blog/erica/random-post/')
     })
   })

--- a/cypress/integration/default/appdir.spec.ts
+++ b/cypress/integration/default/appdir.spec.ts
@@ -52,7 +52,7 @@ describe('appDir', () => {
 
   it('correctly redirects HTML requests for ISR pages', () => {
     cy.request('/blog/erica').then((response) => {
-      expect(response.status).to.be('308')
+      expect(response.status).to.equal('308')
       expect(response.headers).to.have.property('location', '/blog/erica/')
     })
   })
@@ -60,7 +60,7 @@ describe('appDir', () => {
   // This needs trailing slash handling to be fixed
   it.skip('correctly redirects HTML requests for static pages', () => {
     cy.request('/blog/erica/first-post').then((response) => {
-      expect(response.status).to.be('308')
+      expect(response.status).to.equal('308')
       expect(response.headers).to.have.property('location', '/blog/erica/first-post/')
     })
   })

--- a/cypress/integration/default/appdir.spec.ts
+++ b/cypress/integration/default/appdir.spec.ts
@@ -67,7 +67,7 @@ describe('appDir', () => {
 
   it('correctly redirects HTML requests for dynamic pages', () => {
     cy.request('/blog/erica/random-post').then((response) => {
-      expect(response.status).to.be('308')
+      expect(response.status).to.equal('308')
       expect(response.headers).to.have.property('location', '/blog/erica/random-post/')
     })
   })

--- a/cypress/integration/default/appdir.spec.ts
+++ b/cypress/integration/default/appdir.spec.ts
@@ -1,8 +1,7 @@
 describe('appDir', () => {
-  it('renders appdir pages using SSR', () => {
+  it('renders appdir pages as HTML by default', () => {
     cy.request('/blog/erica/first-post/').then((response) => {
-      expect(response.headers).to.have.property('x-nf-render-mode', 'ssr')
-      expect(response.headers).to.have.property('content-type', 'text/html; charset=utf-8')
+      expect(response.headers['content-type']).to.match(/^text\/html/)
     })
   })
 
@@ -13,7 +12,6 @@ describe('appDir', () => {
         RSC: '1',
       },
     }).then((response) => {
-      expect(response.headers).to.have.property('x-nf-render-mode', 'ssr')
       expect(response.headers).to.have.property('content-type', 'application/octet-stream')
     })
   })

--- a/cypress/integration/default/appdir.spec.ts
+++ b/cypress/integration/default/appdir.spec.ts
@@ -1,0 +1,19 @@
+describe('appDir', () => {
+  it('renders appdir pages using SSR', () => {
+    cy.request('/blog/erica/first-post/').then((response) => {
+      expect(response.headers).to.have.property('x-nf-render-mode', 'ssr')
+      expect(response.headers).to.have.property('context-type', 'text/html; charset=utf-8')
+    })
+  })
+
+  it('returns RSC data for RSC requests', () => {
+    cy.request('/blog/erica/first-post/', {
+      Headers: {
+        RSC: '1',
+      },
+    }).then((response) => {
+      expect(response.headers).to.have.property('x-nf-render-mode', 'ssr')
+      expect(response.headers).to.have.property('context-type', 'application/octet-stream')
+    })
+  })
+})

--- a/demos/default/.vscode/settings.json
+++ b/demos/default/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "typescript.tsdk": "../../node_modules/typescript/lib",
+  "typescript.enablePromptUseWorkspaceTsdk": true
+}

--- a/demos/default/.vscode/settings.json
+++ b/demos/default/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-  "typescript.tsdk": "../../node_modules/typescript/lib",
-  "typescript.enablePromptUseWorkspaceTsdk": true
-}

--- a/demos/default/app/blog/[author]/[slug]/page.tsx
+++ b/demos/default/app/blog/[author]/[slug]/page.tsx
@@ -1,0 +1,60 @@
+import { notFound } from 'next/navigation'
+
+export const revalidate = null
+
+export const dynamicParams = true
+
+export default function Page({ params }) {
+  if (params.author === 'matt') {
+    return notFound()
+  }
+  return (
+    <>
+      <p id="page">/blog/[author]/[slug]</p>
+      <p id="params">{JSON.stringify(params)}</p>
+      <p id="date">{Date.now()}</p>
+    </>
+  )
+}
+
+export function generateStaticParams({ params }: any) {
+  console.log('/blog/[author]/[slug] generateStaticParams', JSON.stringify(params))
+
+  switch (params.author) {
+    case 'erica': {
+      return [
+        {
+          slug: 'first-post',
+        },
+      ]
+    }
+    case 'sarah': {
+      return [
+        {
+          slug: 'second-post',
+        },
+      ]
+    }
+    case 'nick': {
+      return [
+        {
+          slug: 'first-post',
+        },
+        {
+          slug: 'second-post',
+        },
+      ]
+    }
+    case 'rob': {
+      return [
+        {
+          slug: 'second-post',
+        },
+      ]
+    }
+
+    default: {
+      throw new Error(`unexpected author param received ${params.author}`)
+    }
+  }
+}

--- a/demos/default/app/blog/[author]/layout.js
+++ b/demos/default/app/blog/[author]/layout.js
@@ -1,0 +1,14 @@
+export default function Layout({ children, params }) {
+  return (
+    <>
+      <p id="author-layout-params">{JSON.stringify(params)}</p>
+      {children}
+    </>
+  )
+}
+
+export function generateStaticParams(params) {
+  console.log('/blog/[author] generateStaticParams', JSON.stringify(params))
+
+  return [{ author: 'nick' }, { author: 'sarah' }, { author: 'rob' }, { author: 'erica' }]
+}

--- a/demos/default/app/blog/[author]/page.js
+++ b/demos/default/app/blog/[author]/page.js
@@ -1,9 +1,7 @@
 import Link from 'next/link'
 
-export const dynamicParams = false
-
 export default async function Page({ params }) {
-  await fetch('https://example.vercel.sh', {
+  await fetch('http://example.com', {
     next: { revalidate: 10 },
   })
   return (

--- a/demos/default/app/blog/[author]/page.js
+++ b/demos/default/app/blog/[author]/page.js
@@ -1,0 +1,41 @@
+import Link from 'next/link'
+
+export const dynamicParams = false
+
+export default async function Page({ params }) {
+  await fetch('https://example.vercel.sh', {
+    next: { revalidate: 10 },
+  })
+  return (
+    <>
+      <p id="page">/blog/[author]</p>
+      <p id="params">{JSON.stringify(params)}</p>
+      <p id="date">{Date.now()}</p>
+      <Link href="/blog/erica" id="author-1">
+        /blog/erica
+      </Link>
+      <br />
+      <Link href="/blog/sarah" id="author-2">
+        /blog/sarah
+      </Link>
+      <br />
+      <Link href="/blog/nick" id="author-3">
+        /blog/nick
+      </Link>
+      <br />
+
+      <Link href="/blog/erica/first-post" id="author-1-post-1">
+        /blog/erica/first-post
+      </Link>
+      <br />
+      <Link href="/blog/sarah/second-post" id="author-2-post-1">
+        /blog/sarah/second-post
+      </Link>
+      <br />
+      <Link href="/blog/nick/first-post" id="author-3-post-1">
+        /blog/nick/first-post
+      </Link>
+      <br />
+    </>
+  )
+}

--- a/demos/default/app/layout.js
+++ b/demos/default/app/layout.js
@@ -1,0 +1,10 @@
+export default function Layout({ children }) {
+  return (
+    <html lang="en">
+      <head>
+        <title>my static blog</title>
+      </head>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/demos/default/next.config.js
+++ b/demos/default/next.config.js
@@ -84,5 +84,6 @@ module.exports = {
   },
   experimental: {
     optimizeCss: false,
+    appDir: true,
   },
 }

--- a/demos/default/pages/index.js
+++ b/demos/default/pages/index.js
@@ -158,6 +158,12 @@ const Index = ({ shows, nodeEnv }) => {
             <Link href="/rewriteToStatic">Rewrite to static (should show getStaticProps/1)</Link>
           </li>
         </ul>
+        <h4>appDir</h4>
+        <ul>
+          <li>
+            <Link href="/blog/erica">app dir page</Link>
+          </li>
+        </ul>
         <h4>Preview mode</h4>
         <p>Preview mode: </p>
         <ul>

--- a/demos/default/tsconfig.json
+++ b/demos/default/tsconfig.json
@@ -11,12 +11,18 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve"
+    "jsx": "preserve",
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
   "include": [
     "next-env.d.ts",
     "**/*.ts",
-    "**/*.tsx"
+    "**/*.tsx",
+    ".next/types/**/*.ts"
   ],
   "exclude": [
     "node_modules"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5580,13 +5580,13 @@
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@types/react": {
       "version": "18.0.26",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.26.tgz",
       "integrity": "sha512-hCR3PJQsAIXyxhTNSiDFY//LhnMZWpNNr5etoCqx/iUfGc5gXWtQR2Phl908jVR6uPXacojQWTg4qRpkxTuGug==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -5612,7 +5612,7 @@
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@types/semver": {
       "version": "7.3.13",
@@ -9399,7 +9399,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
       "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/custom-routes": {
       "resolved": "demos/custom-routes",
@@ -13729,7 +13729,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
       "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -27757,7 +27757,7 @@
       "requires": {
         "@netlify/edge-functions": "^2.0.0",
         "@types/node": "^17.0.25",
-        "next": "^13.0.6",
+        "next": "^13.0.7",
         "npm-run-all": "^4.1.5",
         "typescript": "^4.6.3"
       }
@@ -27789,7 +27789,7 @@
         "globby": "^11.0.4",
         "merge-stream": "^2.0.0",
         "moize": "^6.1.0",
-        "next": "^13.0.6",
+        "next": "^13.0.7",
         "node-fetch": "^2.6.6",
         "node-stream-zip": "^1.15.0",
         "npm-run-all": "^4.1.5",
@@ -28587,13 +28587,13 @@
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-      "devOptional": true
+      "dev": true
     },
     "@types/react": {
       "version": "18.0.26",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.26.tgz",
       "integrity": "sha512-hCR3PJQsAIXyxhTNSiDFY//LhnMZWpNNr5etoCqx/iUfGc5gXWtQR2Phl908jVR6uPXacojQWTg4qRpkxTuGug==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -28619,7 +28619,7 @@
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-      "devOptional": true
+      "dev": true
     },
     "@types/semver": {
       "version": "7.3.13",
@@ -28939,8 +28939,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -28997,8 +28996,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
       "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ansi-align": {
       "version": "3.0.1",
@@ -29605,7 +29603,7 @@
         "@types/node": "^17.0.25",
         "husky": "^7.0.4",
         "if-env": "^1.0.4",
-        "next": "^13.0.6",
+        "next": "^13.0.7",
         "npm-run-all": "^4.1.5",
         "typescript": "^4.6.3"
       }
@@ -30986,8 +30984,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.2.0.tgz",
       "integrity": "sha512-NkANeMnaHrlaSSlpKGyvn2R4rqUDeE/9E5YHx+b4nwo0R8dZyAqcih8/gxpCZvqWP9Vf6xuLpMSzSgdVEIM78g==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "cp-file": {
       "version": "10.0.0",
@@ -31510,7 +31507,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
       "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
-      "devOptional": true
+      "dev": true
     },
     "custom-routes": {
       "version": "file:demos/custom-routes",
@@ -31523,7 +31520,7 @@
         "@types/react": "^18.0.25",
         "husky": "^7.0.4",
         "if-env": "^1.0.4",
-        "next": "^13.0.6",
+        "next": "^13.0.7",
         "npm-run-all": "^4.1.5",
         "typescript": "^4.7.4"
       }
@@ -31810,7 +31807,7 @@
         "critters": "^0.0.16",
         "husky": "^7.0.4",
         "if-env": "^1.0.4",
-        "next": "^13.0.6",
+        "next": "^13.0.7",
         "npm-run-all": "^4.1.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -32673,15 +32670,13 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
       "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-config-standard": {
       "version": "17.0.0",
       "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-17.0.0.tgz",
       "integrity": "sha512-/2ks1GKyqSOkH7JFvXJicu0iMpoojkwB+f5Du/1SC0PtBL+s8v30k9njRZ21pm2drKYm2342jFnGWzttxPmZVg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-formatter-codeframe": {
       "version": "7.32.1",
@@ -33127,8 +33122,7 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.1.1.tgz",
       "integrity": "sha512-tjqWDwVZQo7UIPMeDReOpUgHCmCiH+ePnVT+5zVapL0uuHnegBUs2smM13CzOs2Xb5+MHMRFTs9v24yjba4Oig==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-plugin-react": {
       "version": "7.31.10",
@@ -33186,8 +33180,7 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
       "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-plugin-unicorn": {
       "version": "43.0.2",
@@ -34779,7 +34772,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
       "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ==",
-      "devOptional": true
+      "dev": true
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -35950,8 +35943,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "27.5.1",
@@ -37666,7 +37658,7 @@
         "@types/react": "^18.0.25",
         "husky": "^7.0.4",
         "isomorphic-unfetch": "^3.1.0",
-        "next": "^13.0.6",
+        "next": "^13.0.7",
         "npm-run-all": "^4.1.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -38193,7 +38185,7 @@
         "@types/node": "^17.0.14",
         "@types/react": "^18.0.0",
         "husky": "^7.0.4",
-        "next": "^13.0.6",
+        "next": "^13.0.7",
         "next-auth": "^4.15.0",
         "nodemailer": "^6.6.3",
         "npm-run-all": "^4.1.5",
@@ -38212,7 +38204,7 @@
         "@types/node": "^17.0.25",
         "husky": "^7.0.4",
         "if-env": "^1.0.4",
-        "next": "^13.0.6",
+        "next": "^13.0.7",
         "npm-run-all": "^4.1.5",
         "typescript": "^4.6.3"
       }
@@ -38220,7 +38212,7 @@
     "next-with-edge-functions": {
       "version": "file:demos/next-with-edge-functions",
       "requires": {
-        "next": "^13.0.3",
+        "next": "^13.0.7",
         "react": "^18.0.2",
         "react-dom": "^18.0.2"
       }
@@ -41208,7 +41200,7 @@
         "@types/node": "^17.0.25",
         "husky": "^7.0.4",
         "if-env": "^1.0.4",
-        "next": "^13.0.6",
+        "next": "^13.0.7",
         "npm-run-all": "^4.1.5",
         "typescript": "^4.6.3"
       }
@@ -42223,8 +42215,7 @@
         "ws": {
           "version": "8.11.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-          "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
-          "requires": {}
+          "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg=="
         }
       }
     },
@@ -42729,8 +42720,7 @@
       "version": "7.5.9",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
       "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "xdg-basedir": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24528,6 +24528,201 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/@next/swc-android-arm-eabi": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.0.7.tgz",
+      "integrity": "sha512-QTEamOK/LCwBf05GZ261rULMbZEpE3TYdjHlXfznV+nXwTztzkBNFXwP67gv2wW44BROzgi/vrR9H8oP+J5jxg==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-android-arm64": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.0.7.tgz",
+      "integrity": "sha512-wcy2H0Tl9ME8vKy2GnJZ7Mybwys+43F/Eh2Pvph7mSDpMbYBJ6iA0zeY62iYYXxlZhnAID3+h79FUqUEakkClw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.0.7.tgz",
+      "integrity": "sha512-F/mU7csN1/J2cqXJPMgTQ6MwAbc1pJ6sp6W+X0z5JEY4IFDzxKd3wRc3pCiNF7j8xW381JlNpWxhjCctnNmfaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.0.7.tgz",
+      "integrity": "sha512-636AuRQynCPnIPRVzcCk5B7OMq9XjaYam2T0HeWUCE6y7EqEO3kxiuZ4QmN81T7A6Ydb+JnivYrLelHXmgdj6A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-freebsd-x64": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-13.0.7.tgz",
+      "integrity": "sha512-92XAMzNgQazowZ9t7uZmHRA5VdBl/SwEdrf5UybdfRovsxB4r3+yJWEvFaqYpSEp0gwndbwLokJdpz7OwFdL3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm-gnueabihf": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-13.0.7.tgz",
+      "integrity": "sha512-3r1CWl5P6I5n5Yxip8EXv/Rfu2Cp6wVmIOpvmczyUR82j+bcMkwPAcUjNkG/vMCagS4xV7NElrcdGb39iFmfLg==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.0.7.tgz",
+      "integrity": "sha512-RXo8tt6ppiwyS6hpDw3JdAjKcdVewsefxnxk9xOH4mRhMyq9V2lQx0e24X/dRiZqkx3jnWReR2WRrUlgN1UkSQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.0.7.tgz",
+      "integrity": "sha512-RWpnW+bmfXyxyY7iARbueYDGuIF+BEp3etLeYh/RUNHb9PhOHLDgJOG8haGSykud3a6CcyBI8hEjqOhoObaDpw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.0.7.tgz",
+      "integrity": "sha512-/ygUIiMMTYnbKlFs5Ba9J5k/tNxFWy8eI1bBF8UuMTvV8QJHl/aLDiA5dwsei2kk99/cu3eay62JnJXkSk3RSQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.0.7.tgz",
+      "integrity": "sha512-dLzr6AL77USJN0ejgx5AS8O8SbFlbYTzs0XwAWag4oQpUG2p3ARvxwQgYQ0Z+6EP0zIRZ/XfLkN/mhsyi3m4PA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.0.7.tgz",
+      "integrity": "sha512-+vFIVa82AwqFkpFClKT+n73fGxrhAZ2u1u3mDYEBdxO6c9U4Pj3S5tZFsGFK9kLT/bFvf/eeVOICSLCC7MSgJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.0.7.tgz",
+      "integrity": "sha512-RNLXIhp+assD39dQY9oHhDxw+/qSJRARKhOFsHfOtf8yEfCHqcKkn3X/L+ih60ntaEqK294y1WkMk6ylotsxwA==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.0.7.tgz",
+      "integrity": "sha512-kvdnlLcrnEq72ZP0lqe2Z5NqvB9N5uSCvtXJ0PhKvNncWWd0fEG9Ec9erXgwCmVlM2ytw41k9/uuQ+SVw4Pihw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   },
   "dependencies": {
@@ -42723,6 +42918,84 @@
         "compress-commons": "^4.1.0",
         "readable-stream": "^3.6.0"
       }
+    },
+    "@next/swc-android-arm-eabi": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.0.7.tgz",
+      "integrity": "sha512-QTEamOK/LCwBf05GZ261rULMbZEpE3TYdjHlXfznV+nXwTztzkBNFXwP67gv2wW44BROzgi/vrR9H8oP+J5jxg==",
+      "optional": true
+    },
+    "@next/swc-android-arm64": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.0.7.tgz",
+      "integrity": "sha512-wcy2H0Tl9ME8vKy2GnJZ7Mybwys+43F/Eh2Pvph7mSDpMbYBJ6iA0zeY62iYYXxlZhnAID3+h79FUqUEakkClw==",
+      "optional": true
+    },
+    "@next/swc-darwin-arm64": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.0.7.tgz",
+      "integrity": "sha512-F/mU7csN1/J2cqXJPMgTQ6MwAbc1pJ6sp6W+X0z5JEY4IFDzxKd3wRc3pCiNF7j8xW381JlNpWxhjCctnNmfaw==",
+      "optional": true
+    },
+    "@next/swc-darwin-x64": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.0.7.tgz",
+      "integrity": "sha512-636AuRQynCPnIPRVzcCk5B7OMq9XjaYam2T0HeWUCE6y7EqEO3kxiuZ4QmN81T7A6Ydb+JnivYrLelHXmgdj6A==",
+      "optional": true
+    },
+    "@next/swc-freebsd-x64": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-13.0.7.tgz",
+      "integrity": "sha512-92XAMzNgQazowZ9t7uZmHRA5VdBl/SwEdrf5UybdfRovsxB4r3+yJWEvFaqYpSEp0gwndbwLokJdpz7OwFdL3Q==",
+      "optional": true
+    },
+    "@next/swc-linux-arm-gnueabihf": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-13.0.7.tgz",
+      "integrity": "sha512-3r1CWl5P6I5n5Yxip8EXv/Rfu2Cp6wVmIOpvmczyUR82j+bcMkwPAcUjNkG/vMCagS4xV7NElrcdGb39iFmfLg==",
+      "optional": true
+    },
+    "@next/swc-linux-arm64-gnu": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.0.7.tgz",
+      "integrity": "sha512-RXo8tt6ppiwyS6hpDw3JdAjKcdVewsefxnxk9xOH4mRhMyq9V2lQx0e24X/dRiZqkx3jnWReR2WRrUlgN1UkSQ==",
+      "optional": true
+    },
+    "@next/swc-linux-arm64-musl": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.0.7.tgz",
+      "integrity": "sha512-RWpnW+bmfXyxyY7iARbueYDGuIF+BEp3etLeYh/RUNHb9PhOHLDgJOG8haGSykud3a6CcyBI8hEjqOhoObaDpw==",
+      "optional": true
+    },
+    "@next/swc-linux-x64-gnu": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.0.7.tgz",
+      "integrity": "sha512-/ygUIiMMTYnbKlFs5Ba9J5k/tNxFWy8eI1bBF8UuMTvV8QJHl/aLDiA5dwsei2kk99/cu3eay62JnJXkSk3RSQ==",
+      "optional": true
+    },
+    "@next/swc-linux-x64-musl": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.0.7.tgz",
+      "integrity": "sha512-dLzr6AL77USJN0ejgx5AS8O8SbFlbYTzs0XwAWag4oQpUG2p3ARvxwQgYQ0Z+6EP0zIRZ/XfLkN/mhsyi3m4PA==",
+      "optional": true
+    },
+    "@next/swc-win32-arm64-msvc": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.0.7.tgz",
+      "integrity": "sha512-+vFIVa82AwqFkpFClKT+n73fGxrhAZ2u1u3mDYEBdxO6c9U4Pj3S5tZFsGFK9kLT/bFvf/eeVOICSLCC7MSgJQ==",
+      "optional": true
+    },
+    "@next/swc-win32-ia32-msvc": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.0.7.tgz",
+      "integrity": "sha512-RNLXIhp+assD39dQY9oHhDxw+/qSJRARKhOFsHfOtf8yEfCHqcKkn3X/L+ih60ntaEqK294y1WkMk6ylotsxwA==",
+      "optional": true
+    },
+    "@next/swc-win32-x64-msvc": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.0.7.tgz",
+      "integrity": "sha512-kvdnlLcrnEq72ZP0lqe2Z5NqvB9N5uSCvtXJ0PhKvNncWWd0fEG9Ec9erXgwCmVlM2ytw41k9/uuQ+SVw4Pihw==",
+      "optional": true
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "demos/next-with-edge-functions"
       ],
       "dependencies": {
-        "moize": "^6.1.0",
         "next": "^13.0.7"
       },
       "devDependencies": {
@@ -21404,7 +21403,7 @@
       "version": "1.56.2",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.56.2.tgz",
       "integrity": "sha512-ciEJhnyCRwzlBCB+h5cCPM6ie/6f8HrhZMQOf5vlU60Y1bI1rx5Zb0vlDZvaycHsg/MqFfF1Eq2eokAa32iw8w==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -40343,7 +40342,7 @@
       "version": "1.56.2",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.56.2.tgz",
       "integrity": "sha512-ciEJhnyCRwzlBCB+h5cCPM6ie/6f8HrhZMQOf5vlU60Y1bI1rx5Zb0vlDZvaycHsg/MqFfF1Eq2eokAa32iw8w==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test:next": "jest -c test/e2e/jest.config.js",
     "test:next:disabled": "RUN_SKIPPED_TESTS=1 jest -c test/e2e/jest.config.disabled.js",
     "test:next:all": "RUN_SKIPPED_TESTS=1 jest -c test/e2e/jest.config.all.js",
-    "test:next:appdir": "NEXT_TEST_VERSION=canary jest -c test/e2e/jest.config.appdir.js",
+    "test:next:appdir": "jest -c test/e2e/jest.config.appdir.js",
     "test:jest": "jest",
     "playwright:install": "playwright install --with-deps chromium",
     "test:jest:update": "jest --updateSnapshot",

--- a/packages/runtime/src/helpers/edge.ts
+++ b/packages/runtime/src/helpers/edge.ts
@@ -74,8 +74,10 @@ const maybeLoadJson = <T>(path: string): Promise<T> | null => {
 export const isStaticAppDirRoute = ({ srcRoute }: SsgRoute, manifest: Record<string, string> | null): boolean =>
   Boolean(manifest) && Object.values(manifest).includes(srcRoute)
 
-export const isDynamicAppDirRoute = ({ page }: DynamicRoute, manifest: Record<string, string> | null): boolean =>
-  Boolean(manifest) && Object.values(manifest).includes(page)
+export const isDynamicAppDirRoute = (
+  { page }: Pick<DynamicRoute, 'page'>,
+  manifest: Record<string, string> | null,
+): boolean => Boolean(manifest) && Object.values(manifest).includes(page)
 
 export const loadMiddlewareManifest = (netlifyConfig: NetlifyConfig): Promise<MiddlewareManifest | null> =>
   maybeLoadJson(resolve(netlifyConfig.build.publish, 'server', 'middleware-manifest.json'))

--- a/packages/runtime/src/helpers/edge.ts
+++ b/packages/runtime/src/helpers/edge.ts
@@ -4,8 +4,8 @@ import { resolve, join } from 'path'
 import type { NetlifyConfig, NetlifyPluginConstants } from '@netlify/build'
 import { greenBright } from 'chalk'
 import destr from 'destr'
-import { copy, copyFile, emptyDir, ensureDir, readJson, writeJSON, writeJson } from 'fs-extra'
-import type { SsgRoute } from 'next/dist/build'
+import { copy, copyFile, emptyDir, ensureDir, readJSON, readJson, writeJSON, writeJson } from 'fs-extra'
+import type { PrerenderManifest, SsgRoute } from 'next/dist/build'
 import type { MiddlewareManifest } from 'next/dist/build/webpack/plugins/middleware-plugin'
 import type { RouteHas } from 'next/dist/lib/load-custom-routes'
 import { outdent } from 'outdent'
@@ -82,6 +82,9 @@ export const loadMiddlewareManifest = (netlifyConfig: NetlifyConfig): Promise<Mi
 
 export const loadAppPathRoutesManifest = (netlifyConfig: NetlifyConfig): Promise<Record<string, string> | null> =>
   maybeLoadJson(resolve(netlifyConfig.build.publish, 'app-path-routes-manifest.json'))
+
+export const loadPrerenderManifest = (netlifyConfig: NetlifyConfig): Promise<PrerenderManifest> =>
+  readJSON(resolve(netlifyConfig.build.publish, 'prerender-manifest.json'))
 
 /**
  * Convert the Next middleware name into a valid Edge Function name
@@ -300,6 +303,41 @@ export const writeDevEdgeFunction = async ({
 }
 
 /**
+ * Writes an edge function that routes RSC data requests to the `.rsc` route
+ */
+
+export const writeRscDataEdgeFunction = async ({
+  prerenderManifest,
+  appPathRoutesManifest,
+}: {
+  prerenderManifest?: PrerenderManifest
+  appPathRoutesManifest?: Record<string, string>
+}): Promise<FunctionManifest['functions']> => {
+  if (!prerenderManifest || !appPathRoutesManifest) {
+    return []
+  }
+  const staticAppdirRoutes: Array<string> = []
+  for (const [path, route] of Object.entries(prerenderManifest.routes)) {
+    if (isStaticAppDirRoute(route, appPathRoutesManifest)) {
+      staticAppdirRoutes.push(path, route.dataRoute)
+    }
+  }
+  if (staticAppdirRoutes.length === 0) {
+    return []
+  }
+
+  const edgeFunctionDir = resolve('.netlify', 'edge-functions', 'rsc-data')
+  await ensureDir(edgeFunctionDir)
+  await copyEdgeSourceFile({ edgeFunctionDir, file: 'rsc-data.ts' })
+
+  return staticAppdirRoutes.map((path) => ({
+    function: 'rsc-data',
+    name: 'RSC data routing',
+    path,
+  }))
+}
+
+/**
  * Writes Edge Functions for the Next middleware
  */
 export const writeEdgeFunctions = async ({
@@ -321,8 +359,10 @@ export const writeEdgeFunctions = async ({
   const nextConfigFile = await getRequiredServerFiles(publish)
   const nextConfig = nextConfigFile.config
   const usesAppDir = nextConfig.experimental?.appDir
+
   await copy(getEdgeTemplatePath('../edge-shared'), join(edgeFunctionRoot, 'edge-shared'))
   await writeJSON(join(edgeFunctionRoot, 'edge-shared', 'nextConfig.json'), nextConfig)
+  await copy(join(publish, 'prerender-manifest.json'), join(edgeFunctionRoot, 'edge-shared', 'prerender-manifest.json'))
 
   if (
     !destr(process.env.NEXT_DISABLE_EDGE_IMAGES) &&
@@ -346,6 +386,13 @@ export const writeEdgeFunctions = async ({
     })
   }
   if (!destr(process.env.NEXT_DISABLE_NETLIFY_EDGE)) {
+    const rscFunctions = await writeRscDataEdgeFunction({
+      prerenderManifest: await loadPrerenderManifest(netlifyConfig),
+      appPathRoutesManifest: await loadAppPathRoutesManifest(netlifyConfig),
+    })
+
+    manifest.functions.push(...rscFunctions)
+
     const middlewareManifest = await loadMiddlewareManifest(netlifyConfig)
     if (!middlewareManifest) {
       console.error("Couldn't find the middleware manifest")

--- a/packages/runtime/src/helpers/edge.ts
+++ b/packages/runtime/src/helpers/edge.ts
@@ -5,6 +5,7 @@ import type { NetlifyConfig, NetlifyPluginConstants } from '@netlify/build'
 import { greenBright } from 'chalk'
 import destr from 'destr'
 import { copy, copyFile, emptyDir, ensureDir, readJson, writeJSON, writeJson } from 'fs-extra'
+import type { SsgRoute } from 'next/dist/build'
 import type { MiddlewareManifest } from 'next/dist/build/webpack/plugins/middleware-plugin'
 import type { RouteHas } from 'next/dist/lib/load-custom-routes'
 import { outdent } from 'outdent'
@@ -69,6 +70,9 @@ const maybeLoadJson = <T>(path: string): Promise<T> | null => {
     return readJson(path)
   }
 }
+
+export const isAppDirRoute = ({ srcRoute }: SsgRoute, manifest: Record<string, string> | null): boolean =>
+  Boolean(manifest) && Object.values(manifest).includes(srcRoute)
 
 export const loadMiddlewareManifest = (netlifyConfig: NetlifyConfig): Promise<MiddlewareManifest | null> =>
   maybeLoadJson(resolve(netlifyConfig.build.publish, 'server', 'middleware-manifest.json'))

--- a/packages/runtime/src/helpers/edge.ts
+++ b/packages/runtime/src/helpers/edge.ts
@@ -12,7 +12,7 @@ import { outdent } from 'outdent'
 
 import { getRequiredServerFiles, NextConfig } from './config'
 import { makeLocaleOptional, stripLookahead } from './matchers'
-import { RoutesManifest } from './types'
+import { DynamicRoute, RoutesManifest } from './types'
 
 // This is the format as of next@12.2
 interface EdgeFunctionDefinitionV1 {
@@ -71,8 +71,11 @@ const maybeLoadJson = <T>(path: string): Promise<T> | null => {
   }
 }
 
-export const isAppDirRoute = ({ srcRoute }: SsgRoute, manifest: Record<string, string> | null): boolean =>
+export const isStaticAppDirRoute = ({ srcRoute }: SsgRoute, manifest: Record<string, string> | null): boolean =>
   Boolean(manifest) && Object.values(manifest).includes(srcRoute)
+
+export const isDynamicAppDirRoute = ({ page }: DynamicRoute, manifest: Record<string, string> | null): boolean =>
+  Boolean(manifest) && Object.values(manifest).includes(page)
 
 export const loadMiddlewareManifest = (netlifyConfig: NetlifyConfig): Promise<MiddlewareManifest | null> =>
   maybeLoadJson(resolve(netlifyConfig.build.publish, 'server', 'middleware-manifest.json'))

--- a/packages/runtime/src/helpers/files.ts
+++ b/packages/runtime/src/helpers/files.ts
@@ -13,7 +13,7 @@ import slash from 'slash'
 import { MINIMUM_REVALIDATE_SECONDS, DIVIDER } from '../constants'
 
 import { NextConfig } from './config'
-import { isAppDirRoute, loadAppPathRoutesManifest } from './edge'
+import { isStaticAppDirRoute, loadAppPathRoutesManifest } from './edge'
 import { Rewrites, RoutesManifest } from './types'
 import { findModuleFromBase } from './utils'
 
@@ -108,12 +108,15 @@ export const moveStaticPages = async ({
 
   Object.entries(prerenderManifest.routes).forEach(([route, ssgRoute]) => {
     const { initialRevalidateSeconds } = ssgRoute
-    if (initialRevalidateSeconds) {
+    const trimmedPath = route === '/' ? 'index' : route.slice(1)
+
+    if (isStaticAppDirRoute(ssgRoute, appPathRoutes)) {
+      isrFiles.add(`${trimmedPath}.html`)
+    } else if (initialRevalidateSeconds) {
       // Find all files used by ISR routes
-      const trimmedPath = route === '/' ? 'index' : route.slice(1)
       isrFiles.add(`${trimmedPath}.html`)
       isrFiles.add(`${trimmedPath}.json`)
-      if (initialRevalidateSeconds < MINIMUM_REVALIDATE_SECONDS && !isAppDirRoute(ssgRoute, appPathRoutes)) {
+      if (initialRevalidateSeconds < MINIMUM_REVALIDATE_SECONDS) {
         shortRevalidateRoutes.push({ Route: route, Revalidate: initialRevalidateSeconds })
       }
     }

--- a/packages/runtime/src/helpers/redirects.ts
+++ b/packages/runtime/src/helpers/redirects.ts
@@ -233,9 +233,10 @@ const generateDynamicRewrites = ({
             route: route.page,
             buildId,
             basePath,
-            to: HANDLER_FUNCTION_PATH,
+            to: ODB_FUNCTION_PATH,
             i18n,
-            withData: false,
+            dataRoute: prerenderedDynamicRoutes[route.page].dataRoute,
+            withData: true,
           }),
         )
       } else if (prerenderedDynamicRoutes[route.page].fallback === false && !is404Isr) {

--- a/packages/runtime/src/helpers/redirects.ts
+++ b/packages/runtime/src/helpers/redirects.ts
@@ -8,7 +8,7 @@ import { join } from 'pathe'
 
 import { HANDLER_FUNCTION_PATH, HIDDEN_PATHS, ODB_FUNCTION_PATH } from '../constants'
 
-import { isDynamicAppDirRoute, isStaticAppDirRoute, loadAppPathRoutesManifest } from './edge'
+import { isAppDirRoute, loadAppPathRoutesManifest } from './edge'
 import { getMiddleware } from './files'
 import { ApiRouteConfig } from './functions'
 import { RoutesManifest } from './types'
@@ -135,8 +135,7 @@ const generateStaticIsrRewrites = ({
   const staticIsrRoutesThatMatchMiddleware: Array<string> = []
   const staticRoutePaths = new Set<string>()
   const staticIsrRewrites: NetlifyConfig['redirects'] = []
-  staticRouteEntries.forEach(([route, ssgRoute]) => {
-    const { initialRevalidateSeconds, dataRoute } = ssgRoute
+  staticRouteEntries.forEach(([route, { initialRevalidateSeconds, dataRoute, srcRoute }]) => {
     if (isApiRoute(route) || is404Route(route, i18n)) {
       return
     }
@@ -147,7 +146,7 @@ const generateStaticIsrRewrites = ({
       return
     }
     // appDir routes are a different format, so we need to handle them differently
-    const isAppDir = isStaticAppDirRoute(ssgRoute, appPathRoutes)
+    const isAppDir = isAppDirRoute(srcRoute, appPathRoutes)
     // The default locale is served from the root, not the localised path
     if (i18n?.defaultLocale && route.startsWith(`/${i18n.defaultLocale}/`)) {
       route = route.slice(i18n.defaultLocale.length + 1)
@@ -227,7 +226,7 @@ const generateDynamicRewrites = ({
     if (route.page in prerenderedDynamicRoutes) {
       if (matchesMiddleware(middleware, route.page)) {
         dynamicRoutesThatMatchMiddleware.push(route.page)
-      } else if (isDynamicAppDirRoute(route, appPathRoutes)) {
+      } else if (isAppDirRoute(route.page, appPathRoutes)) {
         dynamicRewrites.push(
           ...redirectsForNextRoute({
             route: route.page,

--- a/packages/runtime/src/helpers/redirects.ts
+++ b/packages/runtime/src/helpers/redirects.ts
@@ -8,6 +8,7 @@ import { join } from 'pathe'
 
 import { HANDLER_FUNCTION_PATH, HIDDEN_PATHS, ODB_FUNCTION_PATH } from '../constants'
 
+import { isAppDirRoute, loadAppPathRoutesManifest } from './edge'
 import { getMiddleware } from './files'
 import { ApiRouteConfig } from './functions'
 import { RoutesManifest } from './types'
@@ -265,7 +266,12 @@ export const generateRedirects = async ({
 
   netlifyConfig.redirects.push(...generateMiddlewareRewrites({ basePath, i18n, middleware, buildId }))
 
-  const staticRouteEntries = Object.entries(prerenderedStaticRoutes)
+  const appPathRoutes = await loadAppPathRoutesManifest(netlifyConfig)
+
+  // appDir routes don't use ISR
+  const staticRouteEntries = Object.entries(prerenderedStaticRoutes).filter(
+    ([, route]) => !isAppDirRoute(route, appPathRoutes),
+  )
 
   const is404Isr = staticRouteEntries.some(
     ([route, { initialRevalidateSeconds }]) => is404Route(route, i18n) && initialRevalidateSeconds !== false,

--- a/packages/runtime/src/helpers/utils.ts
+++ b/packages/runtime/src/helpers/utils.ts
@@ -52,6 +52,13 @@ export const toNetlifyRoute = (nextRoute: string): Array<string> => {
     netlifyRoutes.unshift(netlifyRoute)
   }
 
+  // RSC data routes get an extra route with `/index.rsc` so that the router
+  // can match a different URL with and without a trailing slash
+  if (nextRoute.endsWith('.rsc')) {
+    const rscIndexRoute = nextRoute.replace(/\.rsc$/, '/index.rsc')
+    netlifyRoutes.push(rscIndexRoute)
+  }
+
   return netlifyRoutes.map((route) =>
     route
       // Replace catch-all, e.g., [...slug]

--- a/packages/runtime/src/helpers/utils.ts
+++ b/packages/runtime/src/helpers/utils.ts
@@ -83,6 +83,10 @@ export const generateNetlifyRoutes = ({
 export const routeToDataRoute = (route: string, buildId: string, locale?: string) =>
   `/_next/data/${buildId}${locale ? `/${locale}` : ''}${route === '/' ? '/index' : route}.json`
 
+// Default locale is served from root, not localized
+export const localizeRoute = (route: string, locale: string, defaultLocale: string) =>
+  locale === defaultLocale ? route : `/${locale}${route}`
+
 const netlifyRoutesForNextRoute = ({
   route,
   buildId,
@@ -107,13 +111,14 @@ const netlifyRoutesForNextRoute = ({
   const { locales, defaultLocale } = i18n
   const routes = []
   locales.forEach((locale) => {
-    // Data route is always localized
-    const localizedDataRoute = dataRoute || routeToDataRoute(route, buildId, locale)
+    // Data route is always localized, except for appDir
+    const localizedDataRoute = dataRoute
+      ? localizeRoute(dataRoute, locale, defaultLocale)
+      : routeToDataRoute(route, buildId, locale)
 
     routes.push(
-      // Default locale is served from root, not localized
       ...generateNetlifyRoutes({
-        route: locale === defaultLocale ? route : `/${locale}${route}`,
+        route: localizeRoute(route, locale, defaultLocale),
         dataRoute: localizedDataRoute,
         withData,
       }).map((redirect) => ({

--- a/packages/runtime/src/helpers/utils.ts
+++ b/packages/runtime/src/helpers/utils.ts
@@ -52,13 +52,6 @@ export const toNetlifyRoute = (nextRoute: string): Array<string> => {
     netlifyRoutes.unshift(netlifyRoute)
   }
 
-  // RSC data routes get an extra route with `/index.rsc` so that the router
-  // can match a different URL with and without a trailing slash
-  if (nextRoute.endsWith('.rsc')) {
-    const rscIndexRoute = nextRoute.replace(/\.rsc$/, '/index.rsc')
-    netlifyRoutes.push(rscIndexRoute)
-  }
-
   return netlifyRoutes.map((route) =>
     route
       // Replace catch-all, e.g., [...slug]

--- a/packages/runtime/src/templates/edge-shared/nextConfig.json
+++ b/packages/runtime/src/templates/edge-shared/nextConfig.json
@@ -1,0 +1,3 @@
+{
+  "trailingSlash": true
+}

--- a/packages/runtime/src/templates/edge-shared/prerender-manifest.json
+++ b/packages/runtime/src/templates/edge-shared/prerender-manifest.json
@@ -1,0 +1,7 @@
+{
+  "version": 3,
+  "routes": {},
+  "dynamicRoutes": {},
+  "notFoundRoutes": [],
+  "preview": {}
+}

--- a/packages/runtime/src/templates/edge-shared/rsc-data.ts
+++ b/packages/runtime/src/templates/edge-shared/rsc-data.ts
@@ -41,7 +41,7 @@ export const getRscDataRouter = ({ routes: staticRoutes, dynamicRoutes }: Preren
 
   const dynamicRouteMatcher = Object.values(dynamicRoutes)
     .filter(({ dataRoute }) => dataRoute.endsWith('.rsc'))
-    .map(({ dataRouteRegex }) => new RegExp(dataRouteRegex))
+    .map(({ routeRegex }) => new RegExp(routeRegex))
 
   const matchesDynamicRscDataRoute = (pathname: string) => {
     return dynamicRouteMatcher.some((matcher) => matcher.test(pathname))

--- a/packages/runtime/src/templates/edge-shared/rsc-data.ts
+++ b/packages/runtime/src/templates/edge-shared/rsc-data.ts
@@ -27,7 +27,7 @@ const noop = () => {}
 // Ensure that routes with and without a trailing slash map to different ODB paths
 const rscifyPath = (route: string) => {
   if (route.endsWith('/')) {
-    return route + 'index.rsc'
+    return route.slice(0, -1) + '.rsc/'
   }
   return route + '.rsc'
 }

--- a/packages/runtime/src/templates/edge-shared/rsc-data.ts
+++ b/packages/runtime/src/templates/edge-shared/rsc-data.ts
@@ -6,7 +6,10 @@ interface PrerenderedRoute {
   dataRoute: string | null
 }
 
-export const getRscDataRouter = (prerenderedRoutes: Record<string, PrerenderedRoute>): EdgeFunction => {
+export const getRscDataRouter = (
+  prerenderedRoutes: Record<string, PrerenderedRoute>,
+  trailingSlash: boolean,
+): EdgeFunction => {
   const routeEntries: Array<[string, PrerenderedRoute]> = Object.entries(prerenderedRoutes)
   const routes = new Map(routeEntries)
 
@@ -30,8 +33,8 @@ export const getRscDataRouter = (prerenderedRoutes: Record<string, PrerenderedRo
       const route = routes.get(pathname)
       if (route?.dataRoute) {
         log('Rewriting to data route', route.dataRoute)
-        // Set the original route, without the trimmed slash
-        request.headers.set('x-rsc-route', url.pathname)
+        // We need the correct slash here so we don't get a 308
+        request.headers.set('x-rsc-route', trailingSlash ? `${pathname}/` : pathname)
         return context.rewrite(new URL(route.dataRoute, request.url))
       }
     } else if (rscDataRoutes.has(pathname)) {

--- a/packages/runtime/src/templates/edge-shared/rsc-data.ts
+++ b/packages/runtime/src/templates/edge-shared/rsc-data.ts
@@ -1,40 +1,74 @@
 import type { EdgeFunction } from 'https://edge.netlify.com'
 
-interface PrerenderedRoute {
+export declare type SsgRoute = {
   initialRevalidateSeconds: number | false
   srcRoute: string | null
-  dataRoute: string | null
+  dataRoute: string
+}
+export declare type DynamicSsgRoute = {
+  routeRegex: string
+  fallback: string | null | false
+  dataRoute: string
+  dataRouteRegex: string
+}
+export declare type PrerenderManifest = {
+  version: 3
+  routes: {
+    [route: string]: SsgRoute
+  }
+  dynamicRoutes: {
+    [route: string]: DynamicSsgRoute
+  }
+  notFoundRoutes: string[]
 }
 
-export const getRscDataRouter = (prerenderedRoutes: Record<string, PrerenderedRoute>): EdgeFunction => {
-  const routeEntries: Array<[string, PrerenderedRoute]> = Object.entries(prerenderedRoutes)
-  const routes = new Map(routeEntries)
+const noop = () => {}
 
-  const rscDataRoutes = new Set(
-    routeEntries.map(([, { dataRoute }]) => dataRoute).filter((dataRoute) => dataRoute?.endsWith('.rsc')),
+// Ensure that routes with and without a trailing slash map to different ODB paths
+const rscifyPath = (route: string) => {
+  if (route.endsWith('/')) {
+    return route + 'index.rsc'
+  }
+  return route + '.rsc'
+}
+
+export const getRscDataRouter = ({ routes: staticRoutes, dynamicRoutes }: PrerenderManifest): EdgeFunction => {
+  const staticRouteSet = new Set(
+    Object.entries(staticRoutes)
+      .filter(([, { dataRoute }]) => dataRoute.endsWith('.rsc'))
+      .map(([route]) => route),
   )
+
+  const dynamicRouteMatcher = Object.values(dynamicRoutes)
+    .filter(({ dataRoute }) => dataRoute.endsWith('.rsc'))
+    .map(({ dataRouteRegex }) => new RegExp(dataRouteRegex))
+
+  const matchesDynamicRscDataRoute = (pathname: string) => {
+    return dynamicRouteMatcher.some((matcher) => matcher.test(pathname))
+  }
+
+  const matchesStaticRscDataRoute = (pathname: string) => {
+    const key = pathname.endsWith('/') ? pathname.slice(0, -1) : pathname
+    return staticRouteSet.has(key)
+  }
+
+  const matchesRscRoute = (pathname: string) => {
+    return matchesStaticRscDataRoute(pathname) || matchesDynamicRscDataRoute(pathname)
+  }
 
   return (request, context) => {
     const debug = request.headers.has('x-next-debug-logging')
-    const log = (...args: unknown[]) => {
-      if (debug) {
-        console.log(...args)
-      }
-    }
+    const log = debug ? (...args: unknown[]) => console.log(...args) : noop
     const url = new URL(request.url)
-    // Manifest always has the route without a trailing slash
-    const pathname = url.pathname.endsWith('/') ? url.pathname.slice(0, -1) : url.pathname
     // If this is a static RSC request, rewrite to the data route
     if (request.headers.get('rsc') === '1') {
       log('Is rsc request')
-      const route = routes.get(pathname)
-      if (route?.dataRoute) {
+      if (matchesRscRoute(url.pathname)) {
         request.headers.set('x-rsc-route', url.pathname)
-        return context.rewrite(new URL(route.dataRoute, request.url))
+        const target = rscifyPath(url.pathname)
+        log('Rewriting to', target)
+        return context.rewrite(target)
       }
-    } else if (rscDataRoutes.has(pathname)) {
-      log('Is rsc data request. Adding rsc header')
-      request.headers.set('rsc', '1')
     }
   }
 }

--- a/packages/runtime/src/templates/edge-shared/rsc-data.ts
+++ b/packages/runtime/src/templates/edge-shared/rsc-data.ts
@@ -1,0 +1,42 @@
+import type { EdgeFunction } from 'https://edge.netlify.com'
+
+interface PrerenderedRoute {
+  initialRevalidateSeconds: number | false
+  srcRoute: string | null
+  dataRoute: string | null
+}
+
+export const getRscDataRouter = (prerenderedRoutes: Record<string, PrerenderedRoute>): EdgeFunction => {
+  const routeEntries: Array<[string, PrerenderedRoute]> = Object.entries(prerenderedRoutes)
+  const routes = new Map(routeEntries)
+
+  const rscDataRoutes = new Set(
+    routeEntries.map(([, { dataRoute }]) => dataRoute).filter((dataRoute) => dataRoute?.endsWith('.rsc')),
+  )
+
+  return (request, context) => {
+    const debug = request.headers.has('x-next-debug-logging')
+    const log = (...args: unknown[]) => {
+      if (debug) {
+        console.log(...args)
+      }
+    }
+    const url = new URL(request.url)
+    // Manifest always has the route without a trailing slash
+    const pathname = url.pathname.endsWith('/') ? url.pathname.slice(0, -1) : url.pathname
+    // If this is a static RSC request, rewrite to the data route
+    if (request.headers.get('rsc') === '1') {
+      log('Is rsc request')
+      const route = routes.get(pathname)
+      if (route?.dataRoute) {
+        log('Rewriting to data route', route.dataRoute)
+        // Set the original route, without the trimmed slash
+        request.headers.set('x-rsc-route', url.pathname)
+        return context.rewrite(new URL(route.dataRoute, request.url))
+      }
+    } else if (rscDataRoutes.has(pathname)) {
+      log('Is rsc data request. Adding rsc header')
+      request.headers.set('rsc', '1')
+    }
+  }
+}

--- a/packages/runtime/src/templates/edge-shared/rsc-data.ts
+++ b/packages/runtime/src/templates/edge-shared/rsc-data.ts
@@ -6,10 +6,7 @@ interface PrerenderedRoute {
   dataRoute: string | null
 }
 
-export const getRscDataRouter = (
-  prerenderedRoutes: Record<string, PrerenderedRoute>,
-  trailingSlash: boolean,
-): EdgeFunction => {
+export const getRscDataRouter = (prerenderedRoutes: Record<string, PrerenderedRoute>): EdgeFunction => {
   const routeEntries: Array<[string, PrerenderedRoute]> = Object.entries(prerenderedRoutes)
   const routes = new Map(routeEntries)
 
@@ -32,9 +29,7 @@ export const getRscDataRouter = (
       log('Is rsc request')
       const route = routes.get(pathname)
       if (route?.dataRoute) {
-        log('Rewriting to data route', route.dataRoute)
-        // We need the correct slash here so we don't get a 308
-        request.headers.set('x-rsc-route', trailingSlash ? `${pathname}/` : pathname)
+        request.headers.set('x-rsc-route', url.pathname)
         return context.rewrite(new URL(route.dataRoute, request.url))
       }
     } else if (rscDataRoutes.has(pathname)) {

--- a/packages/runtime/src/templates/edge/rsc-data.ts
+++ b/packages/runtime/src/templates/edge/rsc-data.ts
@@ -1,5 +1,6 @@
 import prerenderManifest from '../edge-shared/prerender-manifest.json' assert { type: 'json' }
+import nextConfig from '../edge-shared/nextConfig.json' assert { type: 'json' }
 import { getRscDataRouter } from '../edge-shared/rsc-data.ts'
 
-const handler = getRscDataRouter(prerenderManifest.routes)
+const handler = getRscDataRouter(prerenderManifest.routes, nextConfig.trailingSlash)
 export default handler

--- a/packages/runtime/src/templates/edge/rsc-data.ts
+++ b/packages/runtime/src/templates/edge/rsc-data.ts
@@ -1,5 +1,5 @@
 import prerenderManifest from '../edge-shared/prerender-manifest.json' assert { type: 'json' }
-import { getRscDataRouter } from '../edge-shared/rsc-data.ts'
+import { getRscDataRouter, PrerenderManifest } from '../edge-shared/rsc-data.ts'
 
-const handler = getRscDataRouter(prerenderManifest.routes)
+const handler = getRscDataRouter(prerenderManifest as PrerenderManifest)
 export default handler

--- a/packages/runtime/src/templates/edge/rsc-data.ts
+++ b/packages/runtime/src/templates/edge/rsc-data.ts
@@ -1,0 +1,5 @@
+import prerenderManifest from '../edge-shared/prerender-manifest.json' assert { type: 'json' }
+import { getRscDataRouter } from '../edge-shared/rsc-data.ts'
+
+const handler = getRscDataRouter(prerenderManifest.routes)
+export default handler

--- a/packages/runtime/src/templates/edge/rsc-data.ts
+++ b/packages/runtime/src/templates/edge/rsc-data.ts
@@ -1,6 +1,5 @@
 import prerenderManifest from '../edge-shared/prerender-manifest.json' assert { type: 'json' }
-import nextConfig from '../edge-shared/nextConfig.json' assert { type: 'json' }
 import { getRscDataRouter } from '../edge-shared/rsc-data.ts'
 
-const handler = getRscDataRouter(prerenderManifest.routes, nextConfig.trailingSlash)
+const handler = getRscDataRouter(prerenderManifest.routes)
 export default handler

--- a/packages/runtime/src/templates/getHandler.ts
+++ b/packages/runtime/src/templates/getHandler.ts
@@ -23,6 +23,7 @@ const {
   getMultiValueHeaders,
   getPrefetchResponse,
   getNextServer,
+  normalizePath,
 } = require('./handlerUtils')
 /* eslint-enable @typescript-eslint/no-var-requires */
 
@@ -103,8 +104,9 @@ const makeHandler = (conf: NextConfig, app, pageRoot, staticManifest: Array<[str
     if (prefetchResponse) {
       return prefetchResponse
     }
-    // Ensure that paths are encoded - but don't double-encode them
-    event.path = new URL(event.rawUrl).pathname
+
+    event.path = normalizePath(event)
+
     // Next expects to be able to parse the query from the URL
     const query = new URLSearchParams(event.queryStringParameters).toString()
     event.path = query ? `${event.path}?${query}` : event.path
@@ -177,7 +179,7 @@ export const getHandler = ({ isODB = false, publishDir = '../../../.next', appDi
   const { promises } = require("fs");
   // We copy the file here rather than requiring from the node module
   const { Bridge } = require("./bridge");
-  const { augmentFsModule, getMaxAge, getMultiValueHeaders, getPrefetchResponse, getNextServer } = require('./handlerUtils')
+  const { augmentFsModule, getMaxAge, getMultiValueHeaders, getPrefetchResponse, getNextServer, normalizePath } = require('./handlerUtils')
 
   ${isODB ? `const { builder } = require("@netlify/functions")` : ''}
   const { config }  = require("${publishDir}/required-server-files.json")

--- a/packages/runtime/src/templates/getHandler.ts
+++ b/packages/runtime/src/templates/getHandler.ts
@@ -32,7 +32,7 @@ type Mutable<T> = {
 }
 
 // We return a function and then call `toString()` on it to serialise it as the launcher function
-// eslint-disable-next-line max-params
+// eslint-disable-next-line max-params, max-lines-per-function
 const makeHandler = (conf: NextConfig, app, pageRoot, staticManifest: Array<[string, string]> = [], mode = 'ssr') => {
   // Change working directory into the site root, unless using Nx, which moves the
   // dist directory and handles this itself
@@ -103,6 +103,9 @@ const makeHandler = (conf: NextConfig, app, pageRoot, staticManifest: Array<[str
     const prefetchResponse = getPrefetchResponse(event, mode)
     if (prefetchResponse) {
       return prefetchResponse
+    }
+    if (event.headers['x-next-debug-logging']) {
+      console.log(event.path, event.headers)
     }
 
     event.path = normalizePath(event)

--- a/packages/runtime/src/templates/getHandler.ts
+++ b/packages/runtime/src/templates/getHandler.ts
@@ -32,7 +32,7 @@ type Mutable<T> = {
 }
 
 // We return a function and then call `toString()` on it to serialise it as the launcher function
-// eslint-disable-next-line max-params, max-lines-per-function
+// eslint-disable-next-line max-params
 const makeHandler = (conf: NextConfig, app, pageRoot, staticManifest: Array<[string, string]> = [], mode = 'ssr') => {
   // Change working directory into the site root, unless using Nx, which moves the
   // dist directory and handles this itself

--- a/packages/runtime/src/templates/getHandler.ts
+++ b/packages/runtime/src/templates/getHandler.ts
@@ -104,9 +104,6 @@ const makeHandler = (conf: NextConfig, app, pageRoot, staticManifest: Array<[str
     if (prefetchResponse) {
       return prefetchResponse
     }
-    if (event.headers['x-next-debug-logging']) {
-      console.log(event.path, event.headers)
-    }
 
     event.path = normalizePath(event)
 
@@ -133,7 +130,7 @@ const makeHandler = (conf: NextConfig, app, pageRoot, staticManifest: Array<[str
         headers: multiValueHeaders,
         statusCode: result.statusCode,
       }
-      console.log('Origin response:', JSON.stringify(response, null, 2))
+      console.log('Next server response:', JSON.stringify(response, null, 2))
     }
 
     if (multiValueHeaders['set-cookie']?.[0]?.includes('__prerender_bypass')) {

--- a/packages/runtime/src/templates/handlerUtils.ts
+++ b/packages/runtime/src/templates/handlerUtils.ts
@@ -208,3 +208,17 @@ export const getPrefetchResponse = (event: HandlerEvent, mode: string): HandlerR
   }
   return false
 }
+
+export const normalizePath = (event: HandlerEvent) => {
+  if (event.headers?.rsc) {
+    const originalPath = event.headers['x-rsc-route']
+    if (originalPath) {
+      if (event.headers['x-next-debug-logging']) {
+        console.log('Original path:', originalPath)
+      }
+      return originalPath
+    }
+  }
+  // Ensure that paths are encoded - but don't double-encode them
+  return new URL(event.rawUrl).pathname
+}

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -327,6 +327,46 @@ exports.resolvePages = () => {
 exports[`onBuild() generates static files manifest 1`] = `
 Array [
   Array [
+    "app/blog/erica/first-post.html",
+    "blog/erica/first-post.html",
+  ],
+  Array [
+    "app/blog/erica/first-post.rsc",
+    "blog/erica/first-post.rsc",
+  ],
+  Array [
+    "app/blog/nick/first-post.html",
+    "blog/nick/first-post.html",
+  ],
+  Array [
+    "app/blog/nick/first-post.rsc",
+    "blog/nick/first-post.rsc",
+  ],
+  Array [
+    "app/blog/nick/second-post.html",
+    "blog/nick/second-post.html",
+  ],
+  Array [
+    "app/blog/nick/second-post.rsc",
+    "blog/nick/second-post.rsc",
+  ],
+  Array [
+    "app/blog/rob/second-post.html",
+    "blog/rob/second-post.html",
+  ],
+  Array [
+    "app/blog/rob/second-post.rsc",
+    "blog/rob/second-post.rsc",
+  ],
+  Array [
+    "app/blog/sarah/second-post.html",
+    "blog/sarah/second-post.html",
+  ],
+  Array [
+    "app/blog/sarah/second-post.rsc",
+    "blog/sarah/second-post.rsc",
+  ],
+  Array [
     "pages/en/broken-image.html",
     "en/broken-image.html",
   ],
@@ -1299,13 +1339,109 @@ Array [
     "force": false,
     "from": "/blog/:author",
     "status": 200,
-    "to": "/.netlify/functions/___netlify-handler",
+    "to": "/.netlify/builders/___netlify-odb-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/blog/:author.rsc",
+    "status": 200,
+    "to": "/.netlify/builders/___netlify-odb-handler",
   },
   Object {
     "force": false,
     "from": "/blog/:author/:slug",
     "status": 200,
-    "to": "/.netlify/functions/___netlify-handler",
+    "to": "/.netlify/builders/___netlify-odb-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/blog/:author/:slug.rsc",
+    "status": 200,
+    "to": "/.netlify/builders/___netlify-odb-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/blog/:author/:slug/index.rsc",
+    "status": 200,
+    "to": "/.netlify/builders/___netlify-odb-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/blog/:author/index.rsc",
+    "status": 200,
+    "to": "/.netlify/builders/___netlify-odb-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/blog/erica",
+    "status": 200,
+    "to": "/.netlify/builders/___netlify-odb-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/blog/erica.rsc",
+    "status": 200,
+    "to": "/.netlify/builders/___netlify-odb-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/blog/erica/index.rsc",
+    "status": 200,
+    "to": "/.netlify/builders/___netlify-odb-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/blog/nick",
+    "status": 200,
+    "to": "/.netlify/builders/___netlify-odb-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/blog/nick.rsc",
+    "status": 200,
+    "to": "/.netlify/builders/___netlify-odb-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/blog/nick/index.rsc",
+    "status": 200,
+    "to": "/.netlify/builders/___netlify-odb-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/blog/rob",
+    "status": 200,
+    "to": "/.netlify/builders/___netlify-odb-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/blog/rob.rsc",
+    "status": 200,
+    "to": "/.netlify/builders/___netlify-odb-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/blog/rob/index.rsc",
+    "status": 200,
+    "to": "/.netlify/builders/___netlify-odb-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/blog/sarah",
+    "status": 200,
+    "to": "/.netlify/builders/___netlify-odb-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/blog/sarah.rsc",
+    "status": 200,
+    "to": "/.netlify/builders/___netlify-odb-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/blog/sarah/index.rsc",
+    "status": 200,
+    "to": "/.netlify/builders/___netlify-odb-handler",
   },
   Object {
     "force": false,
@@ -1365,13 +1501,37 @@ Array [
     "force": false,
     "from": "/es/blog/:author",
     "status": 200,
-    "to": "/.netlify/functions/___netlify-handler",
+    "to": "/.netlify/builders/___netlify-odb-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/es/blog/:author.rsc",
+    "status": 200,
+    "to": "/.netlify/builders/___netlify-odb-handler",
   },
   Object {
     "force": false,
     "from": "/es/blog/:author/:slug",
     "status": 200,
-    "to": "/.netlify/functions/___netlify-handler",
+    "to": "/.netlify/builders/___netlify-odb-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/es/blog/:author/:slug.rsc",
+    "status": 200,
+    "to": "/.netlify/builders/___netlify-odb-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/es/blog/:author/:slug/index.rsc",
+    "status": 200,
+    "to": "/.netlify/builders/___netlify-odb-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/es/blog/:author/index.rsc",
+    "status": 200,
+    "to": "/.netlify/builders/___netlify-odb-handler",
   },
   Object {
     "force": false,
@@ -1581,13 +1741,37 @@ Array [
     "force": false,
     "from": "/fr/blog/:author",
     "status": 200,
-    "to": "/.netlify/functions/___netlify-handler",
+    "to": "/.netlify/builders/___netlify-odb-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/fr/blog/:author.rsc",
+    "status": 200,
+    "to": "/.netlify/builders/___netlify-odb-handler",
   },
   Object {
     "force": false,
     "from": "/fr/blog/:author/:slug",
     "status": 200,
-    "to": "/.netlify/functions/___netlify-handler",
+    "to": "/.netlify/builders/___netlify-odb-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/fr/blog/:author/:slug.rsc",
+    "status": 200,
+    "to": "/.netlify/builders/___netlify-odb-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/fr/blog/:author/:slug/index.rsc",
+    "status": 200,
+    "to": "/.netlify/builders/___netlify-odb-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/fr/blog/:author/index.rsc",
+    "status": 200,
+    "to": "/.netlify/builders/___netlify-odb-handler",
   },
   Object {
     "force": false,

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -3,11 +3,17 @@
 exports[`function helpers config dependency tracing extracts a list of all dependencies 1`] = `
 Array [
   ".next/package.json",
+  ".next/server/app/blog/[author]/[slug]/page.js",
+  ".next/server/app/blog/[author]/page.js",
+  ".next/server/chunks/1090.js",
   ".next/server/chunks/274.js",
-  ".next/server/chunks/4271.js",
+  ".next/server/chunks/3374.js",
+  ".next/server/chunks/4428.js",
   ".next/server/chunks/5237.js",
-  ".next/server/chunks/7016.js",
+  ".next/server/chunks/6316.js",
   ".next/server/chunks/7590.js",
+  ".next/server/chunks/8685.js",
+  ".next/server/chunks/8864.js",
   ".next/server/chunks/9097.js",
   ".next/server/chunks/header.js",
   ".next/server/pages/_app.js",
@@ -55,8 +61,8 @@ exports.resolvePages = () => {
     try {
         require.resolve('../../../.next/package.json')
         require.resolve('../../../.next/server/chunks/274.js')
-        require.resolve('../../../.next/server/chunks/7016.js')
         require.resolve('../../../.next/server/chunks/7590.js')
+        require.resolve('../../../.next/server/chunks/8685.js')
         require.resolve('../../../.next/server/pages/_app.js')
         require.resolve('../../../.next/server/pages/_document.js')
         require.resolve('../../../.next/server/pages/_error.js')
@@ -73,8 +79,8 @@ exports.resolvePages = () => {
     try {
         require.resolve('../../../.next/package.json')
         require.resolve('../../../.next/server/chunks/274.js')
-        require.resolve('../../../.next/server/chunks/7016.js')
         require.resolve('../../../.next/server/chunks/7590.js')
+        require.resolve('../../../.next/server/chunks/8685.js')
         require.resolve('../../../.next/server/pages/_app.js')
         require.resolve('../../../.next/server/pages/_document.js')
         require.resolve('../../../.next/server/pages/_error.js')
@@ -91,11 +97,17 @@ exports[`onBuild() generates a file referencing all page sources 1`] = `
 exports.resolvePages = () => {
     try {
         require.resolve('../../../.next/package.json')
+        require.resolve('../../../.next/server/app/blog/[author]/[slug]/page.js')
+        require.resolve('../../../.next/server/app/blog/[author]/page.js')
+        require.resolve('../../../.next/server/chunks/1090.js')
         require.resolve('../../../.next/server/chunks/274.js')
-        require.resolve('../../../.next/server/chunks/4271.js')
+        require.resolve('../../../.next/server/chunks/3374.js')
+        require.resolve('../../../.next/server/chunks/4428.js')
         require.resolve('../../../.next/server/chunks/5237.js')
-        require.resolve('../../../.next/server/chunks/7016.js')
+        require.resolve('../../../.next/server/chunks/6316.js')
         require.resolve('../../../.next/server/chunks/7590.js')
+        require.resolve('../../../.next/server/chunks/8685.js')
+        require.resolve('../../../.next/server/chunks/8864.js')
         require.resolve('../../../.next/server/chunks/9097.js')
         require.resolve('../../../.next/server/chunks/header.js')
         require.resolve('../../../.next/server/pages/_app.js')
@@ -143,11 +155,17 @@ exports[`onBuild() generates a file referencing all page sources 2`] = `
 exports.resolvePages = () => {
     try {
         require.resolve('../../../.next/package.json')
+        require.resolve('../../../.next/server/app/blog/[author]/[slug]/page.js')
+        require.resolve('../../../.next/server/app/blog/[author]/page.js')
+        require.resolve('../../../.next/server/chunks/1090.js')
         require.resolve('../../../.next/server/chunks/274.js')
-        require.resolve('../../../.next/server/chunks/4271.js')
+        require.resolve('../../../.next/server/chunks/3374.js')
+        require.resolve('../../../.next/server/chunks/4428.js')
         require.resolve('../../../.next/server/chunks/5237.js')
-        require.resolve('../../../.next/server/chunks/7016.js')
+        require.resolve('../../../.next/server/chunks/6316.js')
         require.resolve('../../../.next/server/chunks/7590.js')
+        require.resolve('../../../.next/server/chunks/8685.js')
+        require.resolve('../../../.next/server/chunks/8864.js')
         require.resolve('../../../.next/server/chunks/9097.js')
         require.resolve('../../../.next/server/chunks/header.js')
         require.resolve('../../../.next/server/pages/_app.js')
@@ -195,11 +213,17 @@ exports[`onBuild() generates a file referencing all when publish dir is a subdir
 exports.resolvePages = () => {
     try {
         require.resolve('../../../web/.next/package.json')
+        require.resolve('../../../web/.next/server/app/blog/[author]/[slug]/page.js')
+        require.resolve('../../../web/.next/server/app/blog/[author]/page.js')
+        require.resolve('../../../web/.next/server/chunks/1090.js')
         require.resolve('../../../web/.next/server/chunks/274.js')
-        require.resolve('../../../web/.next/server/chunks/4271.js')
+        require.resolve('../../../web/.next/server/chunks/3374.js')
+        require.resolve('../../../web/.next/server/chunks/4428.js')
         require.resolve('../../../web/.next/server/chunks/5237.js')
-        require.resolve('../../../web/.next/server/chunks/7016.js')
+        require.resolve('../../../web/.next/server/chunks/6316.js')
         require.resolve('../../../web/.next/server/chunks/7590.js')
+        require.resolve('../../../web/.next/server/chunks/8685.js')
+        require.resolve('../../../web/.next/server/chunks/8864.js')
         require.resolve('../../../web/.next/server/chunks/9097.js')
         require.resolve('../../../web/.next/server/chunks/header.js')
         require.resolve('../../../web/.next/server/pages/_app.js')
@@ -247,11 +271,17 @@ exports[`onBuild() generates a file referencing all when publish dir is a subdir
 exports.resolvePages = () => {
     try {
         require.resolve('../../../web/.next/package.json')
+        require.resolve('../../../web/.next/server/app/blog/[author]/[slug]/page.js')
+        require.resolve('../../../web/.next/server/app/blog/[author]/page.js')
+        require.resolve('../../../web/.next/server/chunks/1090.js')
         require.resolve('../../../web/.next/server/chunks/274.js')
-        require.resolve('../../../web/.next/server/chunks/4271.js')
+        require.resolve('../../../web/.next/server/chunks/3374.js')
+        require.resolve('../../../web/.next/server/chunks/4428.js')
         require.resolve('../../../web/.next/server/chunks/5237.js')
-        require.resolve('../../../web/.next/server/chunks/7016.js')
+        require.resolve('../../../web/.next/server/chunks/6316.js')
         require.resolve('../../../web/.next/server/chunks/7590.js')
+        require.resolve('../../../web/.next/server/chunks/8685.js')
+        require.resolve('../../../web/.next/server/chunks/8864.js')
         require.resolve('../../../web/.next/server/chunks/9097.js')
         require.resolve('../../../web/.next/server/chunks/header.js')
         require.resolve('../../../web/.next/server/pages/_app.js')
@@ -1267,6 +1297,18 @@ Array [
   },
   Object {
     "force": false,
+    "from": "/blog/:author",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/blog/:author/:slug",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
     "from": "/broken-image",
     "status": 200,
     "to": "/.netlify/functions/___netlify-handler",
@@ -1316,6 +1358,18 @@ Array [
   Object {
     "force": false,
     "from": "/es/500",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/es/blog/:author",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/es/blog/:author/:slug",
     "status": 200,
     "to": "/.netlify/functions/___netlify-handler",
   },
@@ -1520,6 +1574,18 @@ Array [
   Object {
     "force": false,
     "from": "/fr/500",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/fr/blog/:author",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/fr/blog/:author/:slug",
     "status": 200,
     "to": "/.netlify/functions/___netlify-handler",
   },

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -1360,18 +1360,6 @@ Array [
     "to": "/.netlify/builders/___netlify-odb-handler",
   },
   Object {
-    "force": false,
-    "from": "/blog/:author/:slug/index.rsc",
-    "status": 200,
-    "to": "/.netlify/builders/___netlify-odb-handler",
-  },
-  Object {
-    "force": false,
-    "from": "/blog/:author/index.rsc",
-    "status": 200,
-    "to": "/.netlify/builders/___netlify-odb-handler",
-  },
-  Object {
     "force": true,
     "from": "/blog/erica",
     "status": 200,
@@ -1380,12 +1368,6 @@ Array [
   Object {
     "force": true,
     "from": "/blog/erica.rsc",
-    "status": 200,
-    "to": "/.netlify/builders/___netlify-odb-handler",
-  },
-  Object {
-    "force": true,
-    "from": "/blog/erica/index.rsc",
     "status": 200,
     "to": "/.netlify/builders/___netlify-odb-handler",
   },
@@ -1403,12 +1385,6 @@ Array [
   },
   Object {
     "force": true,
-    "from": "/blog/nick/index.rsc",
-    "status": 200,
-    "to": "/.netlify/builders/___netlify-odb-handler",
-  },
-  Object {
-    "force": true,
     "from": "/blog/rob",
     "status": 200,
     "to": "/.netlify/builders/___netlify-odb-handler",
@@ -1421,12 +1397,6 @@ Array [
   },
   Object {
     "force": true,
-    "from": "/blog/rob/index.rsc",
-    "status": 200,
-    "to": "/.netlify/builders/___netlify-odb-handler",
-  },
-  Object {
-    "force": true,
     "from": "/blog/sarah",
     "status": 200,
     "to": "/.netlify/builders/___netlify-odb-handler",
@@ -1434,12 +1404,6 @@ Array [
   Object {
     "force": true,
     "from": "/blog/sarah.rsc",
-    "status": 200,
-    "to": "/.netlify/builders/___netlify-odb-handler",
-  },
-  Object {
-    "force": true,
-    "from": "/blog/sarah/index.rsc",
     "status": 200,
     "to": "/.netlify/builders/___netlify-odb-handler",
   },
@@ -1518,18 +1482,6 @@ Array [
   Object {
     "force": false,
     "from": "/es/blog/:author/:slug.rsc",
-    "status": 200,
-    "to": "/.netlify/builders/___netlify-odb-handler",
-  },
-  Object {
-    "force": false,
-    "from": "/es/blog/:author/:slug/index.rsc",
-    "status": 200,
-    "to": "/.netlify/builders/___netlify-odb-handler",
-  },
-  Object {
-    "force": false,
-    "from": "/es/blog/:author/index.rsc",
     "status": 200,
     "to": "/.netlify/builders/___netlify-odb-handler",
   },
@@ -1758,18 +1710,6 @@ Array [
   Object {
     "force": false,
     "from": "/fr/blog/:author/:slug.rsc",
-    "status": 200,
-    "to": "/.netlify/builders/___netlify-odb-handler",
-  },
-  Object {
-    "force": false,
-    "from": "/fr/blog/:author/:slug/index.rsc",
-    "status": 200,
-    "to": "/.netlify/builders/___netlify-odb-handler",
-  },
-  Object {
-    "force": false,
-    "from": "/fr/blog/:author/index.rsc",
     "status": 200,
     "to": "/.netlify/builders/___netlify-odb-handler",
   },

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -5,16 +5,16 @@ Array [
   ".next/package.json",
   ".next/server/app/blog/[author]/[slug]/page.js",
   ".next/server/app/blog/[author]/page.js",
-  ".next/server/chunks/1090.js",
-  ".next/server/chunks/274.js",
-  ".next/server/chunks/3374.js",
-  ".next/server/chunks/4428.js",
-  ".next/server/chunks/5237.js",
-  ".next/server/chunks/6316.js",
-  ".next/server/chunks/7590.js",
-  ".next/server/chunks/8685.js",
-  ".next/server/chunks/8864.js",
-  ".next/server/chunks/9097.js",
+  ".next/server/chunks/CHUNK_ID.js",
+  ".next/server/chunks/CHUNK_ID.js",
+  ".next/server/chunks/CHUNK_ID.js",
+  ".next/server/chunks/CHUNK_ID.js",
+  ".next/server/chunks/CHUNK_ID.js",
+  ".next/server/chunks/CHUNK_ID.js",
+  ".next/server/chunks/CHUNK_ID.js",
+  ".next/server/chunks/CHUNK_ID.js",
+  ".next/server/chunks/CHUNK_ID.js",
+  ".next/server/chunks/CHUNK_ID.js",
   ".next/server/chunks/header.js",
   ".next/server/pages/_app.js",
   ".next/server/pages/_document.js",
@@ -60,9 +60,9 @@ exports[`onBuild() generates a file referencing all API route sources: for _api_
 exports.resolvePages = () => {
     try {
         require.resolve('../../../.next/package.json')
-        require.resolve('../../../.next/server/chunks/274.js')
-        require.resolve('../../../.next/server/chunks/7590.js')
-        require.resolve('../../../.next/server/chunks/8685.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
         require.resolve('../../../.next/server/pages/_app.js')
         require.resolve('../../../.next/server/pages/_document.js')
         require.resolve('../../../.next/server/pages/_error.js')
@@ -78,9 +78,9 @@ exports[`onBuild() generates a file referencing all API route sources: for _api_
 exports.resolvePages = () => {
     try {
         require.resolve('../../../.next/package.json')
-        require.resolve('../../../.next/server/chunks/274.js')
-        require.resolve('../../../.next/server/chunks/7590.js')
-        require.resolve('../../../.next/server/chunks/8685.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
         require.resolve('../../../.next/server/pages/_app.js')
         require.resolve('../../../.next/server/pages/_document.js')
         require.resolve('../../../.next/server/pages/_error.js')
@@ -99,16 +99,16 @@ exports.resolvePages = () => {
         require.resolve('../../../.next/package.json')
         require.resolve('../../../.next/server/app/blog/[author]/[slug]/page.js')
         require.resolve('../../../.next/server/app/blog/[author]/page.js')
-        require.resolve('../../../.next/server/chunks/1090.js')
-        require.resolve('../../../.next/server/chunks/274.js')
-        require.resolve('../../../.next/server/chunks/3374.js')
-        require.resolve('../../../.next/server/chunks/4428.js')
-        require.resolve('../../../.next/server/chunks/5237.js')
-        require.resolve('../../../.next/server/chunks/6316.js')
-        require.resolve('../../../.next/server/chunks/7590.js')
-        require.resolve('../../../.next/server/chunks/8685.js')
-        require.resolve('../../../.next/server/chunks/8864.js')
-        require.resolve('../../../.next/server/chunks/9097.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
         require.resolve('../../../.next/server/chunks/header.js')
         require.resolve('../../../.next/server/pages/_app.js')
         require.resolve('../../../.next/server/pages/_document.js')
@@ -157,16 +157,16 @@ exports.resolvePages = () => {
         require.resolve('../../../.next/package.json')
         require.resolve('../../../.next/server/app/blog/[author]/[slug]/page.js')
         require.resolve('../../../.next/server/app/blog/[author]/page.js')
-        require.resolve('../../../.next/server/chunks/1090.js')
-        require.resolve('../../../.next/server/chunks/274.js')
-        require.resolve('../../../.next/server/chunks/3374.js')
-        require.resolve('../../../.next/server/chunks/4428.js')
-        require.resolve('../../../.next/server/chunks/5237.js')
-        require.resolve('../../../.next/server/chunks/6316.js')
-        require.resolve('../../../.next/server/chunks/7590.js')
-        require.resolve('../../../.next/server/chunks/8685.js')
-        require.resolve('../../../.next/server/chunks/8864.js')
-        require.resolve('../../../.next/server/chunks/9097.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
         require.resolve('../../../.next/server/chunks/header.js')
         require.resolve('../../../.next/server/pages/_app.js')
         require.resolve('../../../.next/server/pages/_document.js')
@@ -215,16 +215,16 @@ exports.resolvePages = () => {
         require.resolve('../../../web/.next/package.json')
         require.resolve('../../../web/.next/server/app/blog/[author]/[slug]/page.js')
         require.resolve('../../../web/.next/server/app/blog/[author]/page.js')
-        require.resolve('../../../web/.next/server/chunks/1090.js')
-        require.resolve('../../../web/.next/server/chunks/274.js')
-        require.resolve('../../../web/.next/server/chunks/3374.js')
-        require.resolve('../../../web/.next/server/chunks/4428.js')
-        require.resolve('../../../web/.next/server/chunks/5237.js')
-        require.resolve('../../../web/.next/server/chunks/6316.js')
-        require.resolve('../../../web/.next/server/chunks/7590.js')
-        require.resolve('../../../web/.next/server/chunks/8685.js')
-        require.resolve('../../../web/.next/server/chunks/8864.js')
-        require.resolve('../../../web/.next/server/chunks/9097.js')
+        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
         require.resolve('../../../web/.next/server/chunks/header.js')
         require.resolve('../../../web/.next/server/pages/_app.js')
         require.resolve('../../../web/.next/server/pages/_document.js')
@@ -273,16 +273,16 @@ exports.resolvePages = () => {
         require.resolve('../../../web/.next/package.json')
         require.resolve('../../../web/.next/server/app/blog/[author]/[slug]/page.js')
         require.resolve('../../../web/.next/server/app/blog/[author]/page.js')
-        require.resolve('../../../web/.next/server/chunks/1090.js')
-        require.resolve('../../../web/.next/server/chunks/274.js')
-        require.resolve('../../../web/.next/server/chunks/3374.js')
-        require.resolve('../../../web/.next/server/chunks/4428.js')
-        require.resolve('../../../web/.next/server/chunks/5237.js')
-        require.resolve('../../../web/.next/server/chunks/6316.js')
-        require.resolve('../../../web/.next/server/chunks/7590.js')
-        require.resolve('../../../web/.next/server/chunks/8685.js')
-        require.resolve('../../../web/.next/server/chunks/8864.js')
-        require.resolve('../../../web/.next/server/chunks/9097.js')
+        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
         require.resolve('../../../web/.next/server/chunks/header.js')
         require.resolve('../../../web/.next/server/pages/_app.js')
         require.resolve('../../../web/.next/server/pages/_document.js')

--- a/test/e2e/app-dir/app-alias.test.ts
+++ b/test/e2e/app-dir/app-alias.test.ts
@@ -6,10 +6,10 @@ import path from 'path'
 import { readJSON } from 'fs-extra'
 
 describe('app-dir alias handling', () => {
-  //if ((global as any).isNextDeploy) {
-  //  it('should skip next deploy for now', () => {})
-  //  return
-  //}
+  if (!process.env.RUN_SKIPPED_TESTS) {
+    it('should skip for now', () => {})
+    return
+  }
 
   let next: NextInstance
 

--- a/test/e2e/app-dir/app-alias/package.json
+++ b/test/e2e/app-dir/app-alias/package.json
@@ -1,3 +1,0 @@
-{
-  "type": "module"
-}

--- a/test/e2e/app-dir/app-static.test.ts
+++ b/test/e2e/app-dir/app-static.test.ts
@@ -9,6 +9,8 @@ import webdriver from 'next-webdriver'
 
 const glob = promisify(globOrig)
 
+const usuallySkip = process.env.RUN_SKIPPED_TESTS ? it : it.skip
+
 describe('app-dir static/dynamic handling', () => {
   const isDev = (global as any).isNextDev
 
@@ -196,7 +198,7 @@ describe('app-dir static/dynamic handling', () => {
     }
   })
 
-  it('should honor dynamic = "force-static" correctly', async () => {
+  usuallySkip('should honor dynamic = "force-static" correctly', async () => {
     const res = await fetchViaHTTP(next.url, '/force-static/first')
     expect(res.status).toBe(200)
 
@@ -218,7 +220,7 @@ describe('app-dir static/dynamic handling', () => {
     }
   })
 
-  it('should honor dynamic = "force-static" correctly (lazy)', async () => {
+  usuallySkip('should honor dynamic = "force-static" correctly (lazy)', async () => {
     const res = await fetchViaHTTP(next.url, '/force-static/random')
     expect(res.status).toBe(200)
 

--- a/test/e2e/app-dir/app-static.test.ts
+++ b/test/e2e/app-dir/app-static.test.ts
@@ -198,7 +198,7 @@ describe('app-dir static/dynamic handling', () => {
     }
   })
 
-  usuallySkip('should honor dynamic = "force-static" correctly', async () => {
+  it('should honor dynamic = "force-static" correctly', async () => {
     const res = await fetchViaHTTP(next.url, '/force-static/first')
     expect(res.status).toBe(200)
 

--- a/test/e2e/app-dir/asset-prefix.test.ts
+++ b/test/e2e/app-dir/asset-prefix.test.ts
@@ -36,9 +36,7 @@ describe('app-dir assetPrefix handling', () => {
         redirect: 'manual',
       },
     )
-    // NTL - uses 301 instead of 308
-    expect(res.status).toBe(301)
-    // expect(res.status).toBe(308)
+    expect(res.status).toBe(308)
     expect(res.headers.get('location')).toBe(next.url + '/a')
   })
 

--- a/test/e2e/app-dir/asset-prefix.test.ts
+++ b/test/e2e/app-dir/asset-prefix.test.ts
@@ -38,10 +38,8 @@ describe('app-dir assetPrefix handling', () => {
     )
     // NTL - uses 301 instead of 308
     expect(res.status).toBe(301)
-    expect(res.headers.get('location')).toBe('/a')
-
     // expect(res.status).toBe(308)
-    // expect(res.headers.get('location')).toBe(next.url + '/a')
+    expect(res.headers.get('location')).toBe(next.url + '/a')
   })
 
   it('should render link', async () => {

--- a/test/e2e/app-dir/asset-prefix.test.ts
+++ b/test/e2e/app-dir/asset-prefix.test.ts
@@ -36,8 +36,12 @@ describe('app-dir assetPrefix handling', () => {
         redirect: 'manual',
       },
     )
-    expect(res.status).toBe(308)
-    expect(res.headers.get('location')).toBe(next.url + '/a')
+    // NTL - uses 301 instead of 308
+    expect(res.status).toBe(301)
+    expect(res.headers.get('location')).toBe('/a')
+
+    // expect(res.status).toBe(308)
+    // expect(res.headers.get('location')).toBe(next.url + '/a')
   })
 
   it('should render link', async () => {

--- a/test/e2e/disabled-tests/app-dir/app-alias.test.ts
+++ b/test/e2e/disabled-tests/app-dir/app-alias.test.ts
@@ -6,10 +6,10 @@ import path from 'path'
 import { readJSON } from 'fs-extra'
 
 describe('app-dir alias handling', () => {
-  if (!process.env.RUN_SKIPPED_TESTS) {
-    it('should skip for now', () => {})
-    return
-  }
+  //if ((global as any).isNextDeploy) {
+  //  it('should skip next deploy for now', () => {})
+  //  return
+  //}
 
   let next: NextInstance
 

--- a/test/e2e/disabled-tests/app-dir/app-alias/next.config.js
+++ b/test/e2e/disabled-tests/app-dir/app-alias/next.config.js
@@ -1,0 +1,5 @@
+export default {
+  experimental: {
+    appDir: true,
+  },
+}

--- a/test/e2e/disabled-tests/app-dir/app-alias/src/app/button/page.tsx
+++ b/test/e2e/disabled-tests/app-dir/app-alias/src/app/button/page.tsx
@@ -1,0 +1,10 @@
+import Button from '@/ui/button'
+import React from 'react'
+
+export default function page() {
+  if ('useState' in React) {
+    throw new Error('React is not resolved correctly.')
+  }
+
+  return <Button>click</Button>
+}

--- a/test/e2e/disabled-tests/app-dir/app-alias/src/app/layout.tsx
+++ b/test/e2e/disabled-tests/app-dir/app-alias/src/app/layout.tsx
@@ -1,0 +1,10 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>
+        <header>top bar</header>
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/disabled-tests/app-dir/app-alias/src/app/typing/page.tsx
+++ b/test/e2e/disabled-tests/app-dir/app-alias/src/app/typing/page.tsx
@@ -1,0 +1,11 @@
+// Typing test
+// eslint-disable-next-line
+function noop() {
+  fetch('/button', { next: { revalidate: 0 } })
+  const request = new Request('/button', { next: { revalidate: 0 } })
+  fetch(request)
+}
+
+export default function page() {
+  return 'typing'
+}

--- a/test/e2e/disabled-tests/app-dir/app-alias/tsconfig.json
+++ b/test/e2e/disabled-tests/app-dir/app-alias/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/ui/*": ["ui/*"]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/test/e2e/disabled-tests/app-dir/app-alias/ui/button.tsx
+++ b/test/e2e/disabled-tests/app-dir/app-alias/ui/button.tsx
@@ -1,0 +1,5 @@
+import styles from './style.module.css'
+
+export default function Button(props: any) {
+  return <button {...props} className={styles.button} />
+}

--- a/test/e2e/disabled-tests/app-dir/app-alias/ui/style.module.css
+++ b/test/e2e/disabled-tests/app-dir/app-alias/ui/style.module.css
@@ -1,0 +1,3 @@
+.button {
+  font-size: 50px;
+}

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -59,6 +59,8 @@ const utils = {
   },
 }
 
+const normalizeChunkNames = (source) => source.replaceAll(/\/chunks\/\d+\.js/g, '/chunks/CHUNK_ID.js')
+
 const REDIRECTS = [
   {
     source: '/:file((?!\\.well-known(?:/.*)?)(?:[^/]+/)*[^/]+\\.\\w+)/',
@@ -590,7 +592,7 @@ describe('onBuild()', () => {
     for (const route of ['_api_hello-background-background', '_api_hello-scheduled-handler']) {
       const expected = path.resolve(constants.INTERNAL_FUNCTIONS_SRC, route, 'pages.js')
       expect(existsSync(expected)).toBeTruthy()
-      expect(readFileSync(expected, 'utf8')).toMatchSnapshot(`for ${route}`)
+      expect(normalizeChunkNames(readFileSync(expected, 'utf8'))).toMatchSnapshot(`for ${route}`)
     }
   })
 
@@ -602,8 +604,8 @@ describe('onBuild()', () => {
     expect(existsSync(handlerPagesFile)).toBeTruthy()
     expect(existsSync(odbHandlerPagesFile)).toBeTruthy()
 
-    expect(readFileSync(handlerPagesFile, 'utf8')).toMatchSnapshot()
-    expect(readFileSync(odbHandlerPagesFile, 'utf8')).toMatchSnapshot()
+    expect(normalizeChunkNames(readFileSync(handlerPagesFile, 'utf8'))).toMatchSnapshot()
+    expect(normalizeChunkNames(readFileSync(odbHandlerPagesFile, 'utf8'))).toMatchSnapshot()
   })
 
   test('generates a file referencing all when publish dir is a subdirectory', async () => {
@@ -619,8 +621,8 @@ describe('onBuild()', () => {
     const handlerPagesFile = path.join(constants.INTERNAL_FUNCTIONS_SRC, HANDLER_FUNCTION_NAME, 'pages.js')
     const odbHandlerPagesFile = path.join(constants.INTERNAL_FUNCTIONS_SRC, ODB_FUNCTION_NAME, 'pages.js')
 
-    expect(readFileSync(handlerPagesFile, 'utf8')).toMatchSnapshot()
-    expect(readFileSync(odbHandlerPagesFile, 'utf8')).toMatchSnapshot()
+    expect(normalizeChunkNames(readFileSync(handlerPagesFile, 'utf8'))).toMatchSnapshot()
+    expect(normalizeChunkNames(readFileSync(odbHandlerPagesFile, 'utf8'))).toMatchSnapshot()
   })
 
   test('generates entrypoints with correct references', async () => {
@@ -1279,7 +1281,7 @@ describe('function helpers', () => {
         await moveNextDist()
         await nextRuntime.onBuild(defaultArgs)
         const dependencies = await getAllPageDependencies(constants.PUBLISH_DIR)
-        expect(dependencies.map((dep) => relative(process.cwd(), dep))).toMatchSnapshot()
+        expect(dependencies.map((dep) => normalizeChunkNames(relative(process.cwd(), dep)))).toMatchSnapshot()
       })
 
       it('extracts dependencies that exist', async () => {


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guildines, https://github.com/netlify/next-runtime/blob/main/CONTRIBUTING.md. -->

### Summary
Data routes are handled differently for appDir pages. Instead of a JSON file in `/_next/data`, the request is made to the same path, passing the `RSC` header. This returns the RSC data to stream the update. The fact this varies on a header means we can't use simple ODB handling for these pages, because it will lead to errors like #1844, where the RSC data is returned when HTML is requested, or vice versa. 

This PR fixes this by adding an edge function which routes appDir requests that include the `rsc` header to the appropriate `.rsc` path instead. The original request path is put into a header, which then replaces the `.rsc` path in the handler. These are real files but not normally requested directly. The reason for doing this is so that these requests have unique URLs, meaning they're cached separately as ODBs. 

There's a final extra part that is needed, which is to handle trailing slashes. If we normalise all of the requests to the matching `.rsc` file, then there will be no difference to requests with and without the trailing slash. This is a problem, because depending on whether the version with or without the slash is requested first, we may cache the redirect instead of the actual data (or vice versa). To handle this, we do a bit of trickery. If the request has a trailing slash, we include a trailing slash on the rewritten `.rsc`path. For example, while an rsc request to `/blog` will be rewritten to `/blog.rsc`, a request for `/blog/` (with trailing slash) will be rewritten to `/blog.rsc/`. This means that it will be treated as a separate ODB path, and will be cached differently.

Basically, all of this is to implement `Vary` in ODBs. 🤷🏻 

### Test plan

1. Visit [an appDir page on the default demo site](https://deploy-preview-1855--netlify-plugin-nextjs-demo.netlify.app/blog/erica/). Navigate around, checking in the network panel that SPA data requests are correctly returning `application/octet-stream` RSC data. 
2. Load any of the `/blog` pages directly and ensure that HTML is returned
3. Try loading them with and without the trailing slash and see if they redirect correctly.

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal
Fixes #1844

![capy wants an apple](https://user-images.githubusercontent.com/213306/212292611-cd822b62-48c8-414f-9f7d-210123e67095.png)

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
