### PR TITLE
chore: use api proxy for tv maze api

### DIFF
--- a/demos/default/pages/api/shows/[...params].js
+++ b/demos/default/pages/api/shows/[...params].js
@@ -10,7 +10,7 @@ export default async (req, res) => {
   const id = params[0]
 
   // Get the data
-  const fetchRes = await fetch(`https://api.tvmaze.com/shows/${id}`)
+  const fetchRes = await fetch(`https://tvproxy.netlify.app/shows/${id}`)
   const data = await fetchRes.json()
 
   // If show was found, return it

--- a/demos/default/pages/api/shows/[id].js
+++ b/demos/default/pages/api/shows/[id].js
@@ -7,7 +7,7 @@ export default async (req, res) => {
   const { id } = query
 
   // Get the data
-  const fetchRes = await fetch(`https://api.tvmaze.com/shows/${id}`)
+  const fetchRes = await fetch(`https://tvproxy.netlify.app/shows/${id}`)
   const data = await fetchRes.json()
 
   // If show was found, return it

--- a/demos/default/pages/deep/import.js
+++ b/demos/default/pages/deep/import.js
@@ -25,7 +25,7 @@ const Show = ({ show }) => (
 )
 
 export const getServerSideProps = async ({ params }) => {
-  const res = await fetch('https://api.tvmaze.com/shows/42')
+  const res = await fetch('https://tvproxy.netlify.app/shows/42')
   const data = await res.json()
 
   return {

--- a/demos/default/pages/getServerSideProps/[id].js
+++ b/demos/default/pages/getServerSideProps/[id].js
@@ -34,7 +34,7 @@ export const getServerSideProps = async ({ params }) => {
   // The ID to render
   const { id } = params
 
-  const res = await fetch(`https://api.tvmaze.com/shows/${id}`)
+  const res = await fetch(`https://tvproxy.netlify.app/shows/${id}`)
   const data = await res.json()
 
   // Set error code if show item could not be found

--- a/demos/default/pages/getServerSideProps/all/[[...slug]].js
+++ b/demos/default/pages/getServerSideProps/all/[[...slug]].js
@@ -34,7 +34,7 @@ export const getServerSideProps = async ({ params }) => {
   // The ID to render
   const { slug } = params
 
-  const res = await fetch(`https://api.tvmaze.com/shows/${slug[0]}`)
+  const res = await fetch(`https://tvproxy.netlify.app/shows/${slug[0]}`)
   const data = await res.json()
 
   // Set error code if show item could not be found

--- a/demos/default/pages/getServerSideProps/static.js
+++ b/demos/default/pages/getServerSideProps/static.js
@@ -22,7 +22,7 @@ const Show = ({ show }) => (
 )
 
 export const getServerSideProps = async ({ params }) => {
-  const res = await fetch('https://api.tvmaze.com/shows/42')
+  const res = await fetch('https://tvproxy.netlify.app/shows/42')
   const data = await res.json()
 
   return {

--- a/demos/default/pages/getStaticProps/[id].js
+++ b/demos/default/pages/getStaticProps/[id].js
@@ -28,7 +28,7 @@ export async function getStaticProps({ params }) {
   // The ID to render
   const { id } = params
 
-  const res = await fetch(`https://api.tvmaze.com/shows/${id}`)
+  const res = await fetch(`https://tvproxy.netlify.app/shows/${id}`)
   const data = await res.json()
   const time = new Date().toLocaleTimeString()
 

--- a/demos/default/pages/getStaticProps/static.js
+++ b/demos/default/pages/getStaticProps/static.js
@@ -16,7 +16,7 @@ const Show = ({ show }) => (
 )
 
 export async function getStaticProps(context) {
-  const res = await fetch(`https://api.tvmaze.com/shows/71`)
+  const res = await fetch(`https://tvproxy.netlify.app/shows/71`)
   const data = await res.json()
 
   return {

--- a/demos/default/pages/getStaticProps/with-revalidate.js
+++ b/demos/default/pages/getStaticProps/with-revalidate.js
@@ -16,7 +16,7 @@ const Show = ({ show }) => (
 )
 
 export async function getStaticProps(context) {
-  const res = await fetch(`https://api.tvmaze.com/shows/71`)
+  const res = await fetch(`https://tvproxy.netlify.app/shows/71`)
   const data = await res.json()
 
   return {

--- a/demos/default/pages/getStaticProps/withFallback/[...slug].js
+++ b/demos/default/pages/getStaticProps/withFallback/[...slug].js
@@ -42,7 +42,7 @@ export async function getStaticProps({ params }) {
   const { slug } = params
   const id = slug[slug.length - 1]
 
-  const res = await fetch(`https://api.tvmaze.com/shows/${id}`)
+  const res = await fetch(`https://tvproxy.netlify.app/shows/${id}`)
   const data = await res.json()
   const time = new Date().toLocaleTimeString()
 

--- a/demos/default/pages/getStaticProps/withFallback/[id].js
+++ b/demos/default/pages/getStaticProps/withFallback/[id].js
@@ -41,7 +41,7 @@ export async function getStaticProps({ params }) {
   // The ID to render
   const { id } = params
 
-  const res = await fetch(`https://api.tvmaze.com/shows/${id}`)
+  const res = await fetch(`https://tvproxy.netlify.app/shows/${id}`)
   const data = await res.json()
   const time = new Date().toLocaleTimeString()
 

--- a/demos/default/pages/getStaticProps/withFallbackBlocking/[id].js
+++ b/demos/default/pages/getStaticProps/withFallbackBlocking/[id].js
@@ -30,7 +30,7 @@ export async function getStaticProps({ params }) {
   // The ID to render
   const { id } = params
 
-  const res = await fetch(`https://api.tvmaze.com/shows/${id}`)
+  const res = await fetch(`https://tvproxy.netlify.app/shows/${id}`)
   const data = await res.json()
   const time = new Date().toLocaleTimeString()
 

--- a/demos/default/pages/getStaticProps/withRevalidate/[id].js
+++ b/demos/default/pages/getStaticProps/withRevalidate/[id].js
@@ -29,7 +29,7 @@ export async function getStaticProps({ params }) {
   // The ID to render
   const { id } = params
 
-  const res = await fetch(`https://api.tvmaze.com/shows/${id}`)
+  const res = await fetch(`https://tvproxy.netlify.app/shows/${id}`)
   const data = await res.json()
   const time = new Date().toLocaleTimeString()
 

--- a/demos/default/pages/getStaticProps/withRevalidate/withFallback/[id].js
+++ b/demos/default/pages/getStaticProps/withRevalidate/withFallback/[id].js
@@ -42,7 +42,7 @@ export async function getStaticProps({ params }) {
   // The ID to render
   const { id } = params
 
-  const res = await fetch(`https://api.tvmaze.com/shows/${id}`)
+  const res = await fetch(`https://tvproxy.netlify.app/shows/${id}`)
   const data = await res.json()
   const time = new Date().toLocaleTimeString()
 

--- a/demos/default/pages/getStaticProps/withRevalidate/withFallbackBlocking/[id].js
+++ b/demos/default/pages/getStaticProps/withRevalidate/withFallbackBlocking/[id].js
@@ -29,7 +29,7 @@ export async function getStaticProps({ params }) {
   // The ID to render
   const { id } = params
 
-  const res = await fetch(`https://api.tvmaze.com/shows/${id}`)
+  const res = await fetch(`https://tvproxy.netlify.app/shows/${id}`)
   const data = await res.json()
   const time = new Date().toLocaleTimeString()
 

--- a/demos/default/pages/index.js
+++ b/demos/default/pages/index.js
@@ -183,8 +183,8 @@ Index.getInitialProps = async function () {
   const randomPage = Math.floor(Math.random() * 100) + 1
   // FIXME: stub out in dev
   const server = dev
-    ? `https://api.tvmaze.com/shows?page=${randomPage}`
-    : `https://api.tvmaze.com/shows?page=${randomPage}`
+    ? `https://tvproxy.netlify.app/shows/page/${randomPage}`
+    : `https://tvproxy.netlify.app/shows/page/${randomPage}`
 
   // Get the data
   const res = await fetch(server)

--- a/demos/default/pages/shows/[...params].js
+++ b/demos/default/pages/shows/[...params].js
@@ -47,7 +47,7 @@ CatchAll.getInitialProps = async ({ res: req, query }) => {
   const id = params[0]
 
   // Get the data
-  const res = await fetch(`https://api.tvmaze.com/shows/${id}`)
+  const res = await fetch(`https://tvproxy.netlify.app/shows/${id}`)
   const data = await res.json()
 
   // Set error code if show item could not be found

--- a/demos/default/pages/shows/[id].js
+++ b/demos/default/pages/shows/[id].js
@@ -35,7 +35,7 @@ Show.getInitialProps = async ({ res: req, query }) => {
   const { id } = query
 
   // Get the data
-  const res = await fetch(`https://api.tvmaze.com/shows/${id}`)
+  const res = await fetch(`https://tvproxy.netlify.app/shows/${id}`)
   const data = await res.json()
 
   // Set error code if show item could not be found

--- a/demos/default/public/shows1.json
+++ b/demos/default/public/shows1.json
@@ -1,272 +1,278 @@
-[{
-  "id": 250,
-  "url": "https://www.tvmaze.com/shows/250/kirby-buckets",
-  "name": "Kirby Buckets",
-  "type": "Scripted",
-  "language": "English",
-  "genres": ["Comedy"],
-  "status": "Ended",
-  "runtime": 30,
-  "averageRuntime": 30,
-  "premiered": "2014-10-20",
-  "ended": "2017-02-02",
-  "officialSite": "http://disneyxd.disney.com/kirby-buckets",
-  "schedule": {
-    "time": "07:00",
-    "days": ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"]
-  },
-  "rating": {
-    "average": null
-  },
-  "weight": 69,
-  "network": {
-    "id": 25,
-    "name": "Disney XD",
-    "country": {
-      "name": "United States",
-      "code": "US",
-      "timezone": "America/New_York"
-    }
-  },
-  "webChannel": {
-    "id": 83,
-    "name": "DisneyNOW",
-    "country": {
-      "name": "United States",
-      "code": "US",
-      "timezone": "America/New_York"
-    }
-  },
-  "dvdCountry": null,
-  "externals": {
-    "tvrage": 37394,
-    "thetvdb": 278449,
-    "imdb": "tt3544772"
-  },
-  "image": {
-    "medium": "https://static.tvmaze.com/uploads/images/medium_portrait/1/4600.jpg",
-    "original": "https://static.tvmaze.com/uploads/images/original_untouched/1/4600.jpg"
-  },
-  "summary": "<p>The single-camera series that mixes live-action and animation stars Jacob Bertrand as the title character. <b>Kirby Buckets</b> introduces viewers to the vivid imagination of charismatic 13-year-old Kirby Buckets, who dreams of becoming a famous animator like his idol, Mac MacCallister. With his two best friends, Fish and Eli, by his side, Kirby navigates his eccentric town of Forest Hills where the trio usually find themselves trying to get out of a predicament before Kirby's sister, Dawn, and her best friend, Belinda, catch them. Along the way, Kirby is joined by his animated characters, each with their own vibrant personality that only he and viewers can see.</p>",
-  "updated": 1617744408,
-  "_links": {
-    "self": {
-      "href": "https://api.tvmaze.com/shows/250"
+[
+  {
+    "id": 250,
+    "url": "https://www.tvmaze.com/shows/250/kirby-buckets",
+    "name": "Kirby Buckets",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Comedy"],
+    "status": "Ended",
+    "runtime": 30,
+    "averageRuntime": 30,
+    "premiered": "2014-10-20",
+    "ended": "2017-02-02",
+    "officialSite": "http://disneyxd.disney.com/kirby-buckets",
+    "schedule": {
+      "time": "07:00",
+      "days": ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"]
     },
-    "previousepisode": {
-      "href": "https://api.tvmaze.com/episodes/1051658"
+    "rating": {
+      "average": null
+    },
+    "weight": 69,
+    "network": {
+      "id": 25,
+      "name": "Disney XD",
+      "country": {
+        "name": "United States",
+        "code": "US",
+        "timezone": "America/New_York"
+      }
+    },
+    "webChannel": {
+      "id": 83,
+      "name": "DisneyNOW",
+      "country": {
+        "name": "United States",
+        "code": "US",
+        "timezone": "America/New_York"
+      }
+    },
+    "dvdCountry": null,
+    "externals": {
+      "tvrage": 37394,
+      "thetvdb": 278449,
+      "imdb": "tt3544772"
+    },
+    "image": {
+      "medium": "https://static.tvmaze.com/uploads/images/medium_portrait/1/4600.jpg",
+      "original": "https://static.tvmaze.com/uploads/images/original_untouched/1/4600.jpg"
+    },
+    "summary": "<p>The single-camera series that mixes live-action and animation stars Jacob Bertrand as the title character. <b>Kirby Buckets</b> introduces viewers to the vivid imagination of charismatic 13-year-old Kirby Buckets, who dreams of becoming a famous animator like his idol, Mac MacCallister. With his two best friends, Fish and Eli, by his side, Kirby navigates his eccentric town of Forest Hills where the trio usually find themselves trying to get out of a predicament before Kirby's sister, Dawn, and her best friend, Belinda, catch them. Along the way, Kirby is joined by his animated characters, each with their own vibrant personality that only he and viewers can see.</p>",
+    "updated": 1617744408,
+    "_links": {
+      "self": {
+        "href": "https://tvproxy.netlify.app/shows/250"
+      },
+      "previousepisode": {
+        "href": "https://tvproxy.netlify.app/episodes/1051658"
+      }
+    }
+  },
+  {
+    "id": 251,
+    "url": "https://www.tvmaze.com/shows/251/downton-abbey",
+    "name": "Downton Abbey",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Family", "Romance"],
+    "status": "Ended",
+    "runtime": 60,
+    "averageRuntime": 71,
+    "premiered": "2010-09-26",
+    "ended": "2015-12-25",
+    "officialSite": "http://www.itv.com/downtonabbey",
+    "schedule": {
+      "time": "21:00",
+      "days": ["Sunday"]
+    },
+    "rating": {
+      "average": 9.1
+    },
+    "weight": 96,
+    "network": {
+      "id": 35,
+      "name": "ITV",
+      "country": {
+        "name": "United Kingdom",
+        "code": "GB",
+        "timezone": "Europe/London"
+      }
+    },
+    "webChannel": null,
+    "dvdCountry": null,
+    "externals": {
+      "tvrage": 26615,
+      "thetvdb": 193131,
+      "imdb": "tt1606375"
+    },
+    "image": {
+      "medium": "https://static.tvmaze.com/uploads/images/medium_portrait/1/4601.jpg",
+      "original": "https://static.tvmaze.com/uploads/images/original_untouched/1/4601.jpg"
+    },
+    "summary": "<p>The Downton Abbey estate stands a splendid example of confidence and mettle, its family enduring for generations and its staff a well-oiled machine of propriety. But change is afoot at Downton--change far surpassing the new electric lights and telephone. A crisis of inheritance threatens to displace the resident Crawley family, in spite of the best efforts of the noble and compassionate Earl, Robert Crawley; his American heiress wife, Cora his comically implacable, opinionated mother, Violet and his beautiful, eldest daughter, Mary, intent on charting her own course. Reluctantly, the family is forced to welcome its heir apparent, the self-made and proudly modern Matthew Crawley himself none too happy about the new arrangements. As Matthew's bristly relationship with Mary begins to crackle with electricity, hope for the future of Downton's dynasty takes shape. But when petty jealousies and ambitions grow among the family and the staff, scheming and secrets--both delicious and dangerous--threaten to derail the scramble to preserve Downton Abbey. <i>Downton Abbey</i> offers a spot-on portrait of a vanishing way of life.</p>",
+    "updated": 1627415536,
+    "_links": {
+      "self": {
+        "href": "https://tvproxy.netlify.app/shows/251"
+      },
+      "previousepisode": {
+        "href": "https://tvproxy.netlify.app/episodes/623237"
+      }
+    }
+  },
+  {
+    "id": 252,
+    "url": "https://www.tvmaze.com/shows/252/girl-meets-world",
+    "name": "Girl Meets World",
+    "type": "Scripted",
+    "language": "English",
+    "genres": ["Drama", "Comedy", "Family"],
+    "status": "Ended",
+    "runtime": 30,
+    "averageRuntime": 30,
+    "premiered": "2014-06-27",
+    "ended": "2017-01-20",
+    "officialSite": "http://disneychannel.disney.com/girl-meets-world",
+    "schedule": {
+      "time": "18:00",
+      "days": ["Friday"]
+    },
+    "rating": {
+      "average": 7.7
+    },
+    "weight": 72,
+    "network": {
+      "id": 78,
+      "name": "Disney Channel",
+      "country": {
+        "name": "United States",
+        "code": "US",
+        "timezone": "America/New_York"
+      }
+    },
+    "webChannel": {
+      "id": 83,
+      "name": "DisneyNOW",
+      "country": {
+        "name": "United States",
+        "code": "US",
+        "timezone": "America/New_York"
+      }
+    },
+    "dvdCountry": null,
+    "externals": {
+      "tvrage": 33436,
+      "thetvdb": 267777,
+      "imdb": "tt2543796"
+    },
+    "image": {
+      "medium": "https://static.tvmaze.com/uploads/images/medium_portrait/316/792450.jpg",
+      "original": "https://static.tvmaze.com/uploads/images/original_untouched/316/792450.jpg"
+    },
+    "summary": "<p><b>Girl Meets World</b> is based on ABC's hugely popular sitcom, Boy Meets World (1993). Set in New York City, the show tells the wonderfully funny heartfelt stories that Boy Meets World is renowned for - only this time from a tween girl's perspective - as the curious and bright 7th grader Riley Matthews and her quick-witted friend Maya Fox embark on an unforgettable middle school experience. But their plans for a carefree year will be adjusted slightly under the watchful eyes of Riley's parents - dad Cory, who's also a faculty member (and their new History teacher), and mom Topanga, who owns a trendy after school hangout that specializes in pudding.</p>",
+    "updated": 1621082326,
+    "_links": {
+      "self": {
+        "href": "https://tvproxy.netlify.app/shows/252"
+      },
+      "previousepisode": {
+        "href": "https://tvproxy.netlify.app/episodes/1011244"
+      }
+    }
+  },
+  {
+    "id": 253,
+    "url": "https://www.tvmaze.com/shows/253/hells-kitchen",
+    "name": "Hell's Kitchen",
+    "type": "Reality",
+    "language": "English",
+    "genres": ["Food"],
+    "status": "Running",
+    "runtime": 60,
+    "averageRuntime": 60,
+    "premiered": "2005-05-30",
+    "ended": null,
+    "officialSite": "https://www.fox.com/hells-kitchen",
+    "schedule": {
+      "time": "20:00",
+      "days": ["Monday"]
+    },
+    "rating": {
+      "average": 7.1
+    },
+    "weight": 93,
+    "network": {
+      "id": 4,
+      "name": "FOX",
+      "country": {
+        "name": "United States",
+        "code": "US",
+        "timezone": "America/New_York"
+      }
+    },
+    "webChannel": null,
+    "dvdCountry": null,
+    "externals": {
+      "tvrage": 3828,
+      "thetvdb": 74897,
+      "imdb": "tt0437005"
+    },
+    "image": {
+      "medium": "https://static.tvmaze.com/uploads/images/medium_portrait/324/811405.jpg",
+      "original": "https://static.tvmaze.com/uploads/images/original_untouched/324/811405.jpg"
+    },
+    "summary": "<p>In <b>Hell's Kitchen</b>, aspiring chefs are put through an intense culinary academy to prove they possess the right combination of ingredients to win a life-changing grand prize.</p>",
+    "updated": 1631607953,
+    "_links": {
+      "self": {
+        "href": "https://tvproxy.netlify.app/shows/253"
+      },
+      "previousepisode": {
+        "href": "https://tvproxy.netlify.app/episodes/2118484"
+      }
+    }
+  },
+  {
+    "id": 254,
+    "url": "https://www.tvmaze.com/shows/254/world-series-of-poker",
+    "name": "World Series of Poker",
+    "type": "Sports",
+    "language": "English",
+    "genres": [],
+    "status": "Running",
+    "runtime": 60,
+    "averageRuntime": 65,
+    "premiered": "2006-08-22",
+    "ended": null,
+    "officialSite": null,
+    "schedule": {
+      "time": "21:00",
+      "days": ["Monday", "Tuesday", "Sunday"]
+    },
+    "rating": {
+      "average": 9
+    },
+    "weight": 77,
+    "network": {
+      "id": 180,
+      "name": "ESPN2",
+      "country": {
+        "name": "United States",
+        "code": "US",
+        "timezone": "America/New_York"
+      }
+    },
+    "webChannel": null,
+    "dvdCountry": null,
+    "externals": {
+      "tvrage": 16764,
+      "thetvdb": 79028,
+      "imdb": "tt2733512"
+    },
+    "image": {
+      "medium": "https://static.tvmaze.com/uploads/images/medium_portrait/1/4656.jpg",
+      "original": "https://static.tvmaze.com/uploads/images/original_untouched/1/4656.jpg"
+    },
+    "summary": "<p>The <b>World Series of Poker</b> is where the world's best poker players battle for the title.</p>",
+    "updated": 1574298803,
+    "_links": {
+      "self": {
+        "href": "https://tvproxy.netlify.app/shows/254"
+      },
+      "previousepisode": {
+        "href": "https://tvproxy.netlify.app/episodes/1684225"
+      }
     }
   }
-}, {
-  "id": 251,
-  "url": "https://www.tvmaze.com/shows/251/downton-abbey",
-  "name": "Downton Abbey",
-  "type": "Scripted",
-  "language": "English",
-  "genres": ["Drama", "Family", "Romance"],
-  "status": "Ended",
-  "runtime": 60,
-  "averageRuntime": 71,
-  "premiered": "2010-09-26",
-  "ended": "2015-12-25",
-  "officialSite": "http://www.itv.com/downtonabbey",
-  "schedule": {
-    "time": "21:00",
-    "days": ["Sunday"]
-  },
-  "rating": {
-    "average": 9.1
-  },
-  "weight": 96,
-  "network": {
-    "id": 35,
-    "name": "ITV",
-    "country": {
-      "name": "United Kingdom",
-      "code": "GB",
-      "timezone": "Europe/London"
-    }
-  },
-  "webChannel": null,
-  "dvdCountry": null,
-  "externals": {
-    "tvrage": 26615,
-    "thetvdb": 193131,
-    "imdb": "tt1606375"
-  },
-  "image": {
-    "medium": "https://static.tvmaze.com/uploads/images/medium_portrait/1/4601.jpg",
-    "original": "https://static.tvmaze.com/uploads/images/original_untouched/1/4601.jpg"
-  },
-  "summary": "<p>The Downton Abbey estate stands a splendid example of confidence and mettle, its family enduring for generations and its staff a well-oiled machine of propriety. But change is afoot at Downton--change far surpassing the new electric lights and telephone. A crisis of inheritance threatens to displace the resident Crawley family, in spite of the best efforts of the noble and compassionate Earl, Robert Crawley; his American heiress wife, Cora his comically implacable, opinionated mother, Violet and his beautiful, eldest daughter, Mary, intent on charting her own course. Reluctantly, the family is forced to welcome its heir apparent, the self-made and proudly modern Matthew Crawley himself none too happy about the new arrangements. As Matthew's bristly relationship with Mary begins to crackle with electricity, hope for the future of Downton's dynasty takes shape. But when petty jealousies and ambitions grow among the family and the staff, scheming and secrets--both delicious and dangerous--threaten to derail the scramble to preserve Downton Abbey. <i>Downton Abbey</i> offers a spot-on portrait of a vanishing way of life.</p>",
-  "updated": 1627415536,
-  "_links": {
-    "self": {
-      "href": "https://api.tvmaze.com/shows/251"
-    },
-    "previousepisode": {
-      "href": "https://api.tvmaze.com/episodes/623237"
-    }
-  }
-}, {
-  "id": 252,
-  "url": "https://www.tvmaze.com/shows/252/girl-meets-world",
-  "name": "Girl Meets World",
-  "type": "Scripted",
-  "language": "English",
-  "genres": ["Drama", "Comedy", "Family"],
-  "status": "Ended",
-  "runtime": 30,
-  "averageRuntime": 30,
-  "premiered": "2014-06-27",
-  "ended": "2017-01-20",
-  "officialSite": "http://disneychannel.disney.com/girl-meets-world",
-  "schedule": {
-    "time": "18:00",
-    "days": ["Friday"]
-  },
-  "rating": {
-    "average": 7.7
-  },
-  "weight": 72,
-  "network": {
-    "id": 78,
-    "name": "Disney Channel",
-    "country": {
-      "name": "United States",
-      "code": "US",
-      "timezone": "America/New_York"
-    }
-  },
-  "webChannel": {
-    "id": 83,
-    "name": "DisneyNOW",
-    "country": {
-      "name": "United States",
-      "code": "US",
-      "timezone": "America/New_York"
-    }
-  },
-  "dvdCountry": null,
-  "externals": {
-    "tvrage": 33436,
-    "thetvdb": 267777,
-    "imdb": "tt2543796"
-  },
-  "image": {
-    "medium": "https://static.tvmaze.com/uploads/images/medium_portrait/316/792450.jpg",
-    "original": "https://static.tvmaze.com/uploads/images/original_untouched/316/792450.jpg"
-  },
-  "summary": "<p><b>Girl Meets World</b> is based on ABC's hugely popular sitcom, Boy Meets World (1993). Set in New York City, the show tells the wonderfully funny heartfelt stories that Boy Meets World is renowned for - only this time from a tween girl's perspective - as the curious and bright 7th grader Riley Matthews and her quick-witted friend Maya Fox embark on an unforgettable middle school experience. But their plans for a carefree year will be adjusted slightly under the watchful eyes of Riley's parents - dad Cory, who's also a faculty member (and their new History teacher), and mom Topanga, who owns a trendy after school hangout that specializes in pudding.</p>",
-  "updated": 1621082326,
-  "_links": {
-    "self": {
-      "href": "https://api.tvmaze.com/shows/252"
-    },
-    "previousepisode": {
-      "href": "https://api.tvmaze.com/episodes/1011244"
-    }
-  }
-}, {
-  "id": 253,
-  "url": "https://www.tvmaze.com/shows/253/hells-kitchen",
-  "name": "Hell's Kitchen",
-  "type": "Reality",
-  "language": "English",
-  "genres": ["Food"],
-  "status": "Running",
-  "runtime": 60,
-  "averageRuntime": 60,
-  "premiered": "2005-05-30",
-  "ended": null,
-  "officialSite": "https://www.fox.com/hells-kitchen",
-  "schedule": {
-    "time": "20:00",
-    "days": ["Monday"]
-  },
-  "rating": {
-    "average": 7.1
-  },
-  "weight": 93,
-  "network": {
-    "id": 4,
-    "name": "FOX",
-    "country": {
-      "name": "United States",
-      "code": "US",
-      "timezone": "America/New_York"
-    }
-  },
-  "webChannel": null,
-  "dvdCountry": null,
-  "externals": {
-    "tvrage": 3828,
-    "thetvdb": 74897,
-    "imdb": "tt0437005"
-  },
-  "image": {
-    "medium": "https://static.tvmaze.com/uploads/images/medium_portrait/324/811405.jpg",
-    "original": "https://static.tvmaze.com/uploads/images/original_untouched/324/811405.jpg"
-  },
-  "summary": "<p>In <b>Hell's Kitchen</b>, aspiring chefs are put through an intense culinary academy to prove they possess the right combination of ingredients to win a life-changing grand prize.</p>",
-  "updated": 1631607953,
-  "_links": {
-    "self": {
-      "href": "https://api.tvmaze.com/shows/253"
-    },
-    "previousepisode": {
-      "href": "https://api.tvmaze.com/episodes/2118484"
-    }
-  }
-}, {
-  "id": 254,
-  "url": "https://www.tvmaze.com/shows/254/world-series-of-poker",
-  "name": "World Series of Poker",
-  "type": "Sports",
-  "language": "English",
-  "genres": [],
-  "status": "Running",
-  "runtime": 60,
-  "averageRuntime": 65,
-  "premiered": "2006-08-22",
-  "ended": null,
-  "officialSite": null,
-  "schedule": {
-    "time": "21:00",
-    "days": ["Monday", "Tuesday", "Sunday"]
-  },
-  "rating": {
-    "average": 9
-  },
-  "weight": 77,
-  "network": {
-    "id": 180,
-    "name": "ESPN2",
-    "country": {
-      "name": "United States",
-      "code": "US",
-      "timezone": "America/New_York"
-    }
-  },
-  "webChannel": null,
-  "dvdCountry": null,
-  "externals": {
-    "tvrage": 16764,
-    "thetvdb": 79028,
-    "imdb": "tt2733512"
-  },
-  "image": {
-    "medium": "https://static.tvmaze.com/uploads/images/medium_portrait/1/4656.jpg",
-    "original": "https://static.tvmaze.com/uploads/images/original_untouched/1/4656.jpg"
-  },
-  "summary": "<p>The <b>World Series of Poker</b> is where the world's best poker players battle for the title.</p>",
-  "updated": 1574298803,
-  "_links": {
-    "self": {
-      "href": "https://api.tvmaze.com/shows/254"
-    },
-    "previousepisode": {
-      "href": "https://api.tvmaze.com/episodes/1684225"
-    }
-  }
-}]
+]

--- a/demos/middleware/pages/shows/[id].js
+++ b/demos/middleware/pages/shows/[id].js
@@ -33,7 +33,7 @@ export const getServerSideProps = async ({ params, req }) => {
   // The ID to render
   const { id } = params
   console.log(req.headers)
-  const res = await fetch(`https://api.tvmaze.com/shows/${id}`)
+  const res = await fetch(`https://tvproxy.netlify.app/shows/${id}`)
   const data = await res.json()
 
   // Set error code if show item could not be found

--- a/demos/middleware/pages/shows/static/[id].js
+++ b/demos/middleware/pages/shows/static/[id].js
@@ -40,7 +40,7 @@ export async function getStaticProps({ params }) {
   // The ID to render
   const { id } = params
 
-  const res = await fetch(`https://api.tvmaze.com/shows/${id}`)
+  const res = await fetch(`https://tvproxy.netlify.app/shows/${id}`)
   const data = await res.json()
 
   return {


### PR DESCRIPTION
### Summary

We occasionally run into rate limiting problems with the example API used for demos and testing. This is a particular issue for an upcoming PR that adds more demo pages that need to statically fetch data at build time.

This PR replaces all `api.tvmaze.com` references with our new API proxy at `tvproxy.netlify.app`

### Test plan

All tests on demo sites should run as before.

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

https://github.com/netlify/tvproxy