### PR TITLE
fix: merge Middleware and API route response cookies

### DIFF
--- a/packages/runtime/src/templates/edge-shared/utils.ts
+++ b/packages/runtime/src/templates/edge-shared/utils.ts
@@ -31,7 +31,7 @@ export const addMiddlewareHeaders = async (
   // We need to await the response to get the origin headers, then we can add the ones from middleware.
   const res = await originResponse
   const response = new Response(res.body, res)
-  let originCookies = response.headers.get('set-cookie')
+  const originCookies = response.headers.get('set-cookie')
   middlewareResponse.headers.forEach((value, key) => {
     response.headers.set(key, value)
     // Append origin cookies after middleware cookies

--- a/packages/runtime/src/templates/edge-shared/utils.ts
+++ b/packages/runtime/src/templates/edge-shared/utils.ts
@@ -31,8 +31,13 @@ export const addMiddlewareHeaders = async (
   // We need to await the response to get the origin headers, then we can add the ones from middleware.
   const res = await originResponse
   const response = new Response(res.body, res)
+  let originCookies = response.headers.get('set-cookie')
   middlewareResponse.headers.forEach((value, key) => {
     response.headers.set(key, value)
+    // Append origin cookies after middleware cookies
+    if (key == 'set-cookie' && originCookies) {
+      response.headers.append(key, originCookies)
+    }
   })
   return response
 }

--- a/packages/runtime/src/templates/edge-shared/utils.ts
+++ b/packages/runtime/src/templates/edge-shared/utils.ts
@@ -35,7 +35,7 @@ export const addMiddlewareHeaders = async (
   middlewareResponse.headers.forEach((value, key) => {
     response.headers.set(key, value)
     // Append origin cookies after middleware cookies
-    if (key == 'set-cookie' && originCookies) {
+    if (key === 'set-cookie' && originCookies) {
       response.headers.append(key, originCookies)
     }
   })

--- a/test/e2e/modified-tests/skip-trailing-slash-redirect/index.test.ts
+++ b/test/e2e/modified-tests/skip-trailing-slash-redirect/index.test.ts
@@ -47,16 +47,14 @@ describe('skip-trailing-slash-redirect', () => {
     expect(res.headers.get('x-from-middleware')).toBe('true')
     expect(await res.text()).toBe('hello from middleware')
   })
-  // NTL Skip
-  usuallySkip('should merge cookies from middleware and API routes correctly', async () => {
+  it('should merge cookies from middleware and API routes correctly', async () => {
     const res = await fetchViaHTTP(next.url, '/api/test-cookie', undefined, {
       redirect: 'manual',
     })
     expect(res.status).toBe(200)
     expect(res.headers.get('set-cookie')).toEqual('from-middleware=1; Path=/, hello=From API')
   })
-  // NTL Skip
-  usuallySkip('should merge cookies from middleware and edge API routes correctly', async () => {
+  it('should merge cookies from middleware and edge API routes correctly', async () => {
     const res = await fetchViaHTTP(next.url, '/api/test-cookie-edge', undefined, {
       redirect: 'manual',
     })


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guildines, https://github.com/netlify/next-runtime/blob/main/CONTRIBUTING.md. -->

### Summary
When adding the Middleware headers to the response we ended up overriding the cookies set by the API route and returning only the cookies set within middleware. This fix ensures that the cookies set within the Middleware and API route are merged, by using 'append' instead of 'set', and that they are in the correct order. 

<!-- Provide a brief summary of the change. -->


### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal
Fixes #1797 
### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
