### PR TITLE
fix: output functions with cjs extension to be independent of site module type

### DIFF
--- a/packages/runtime/src/helpers/functions.ts
+++ b/packages/runtime/src/helpers/functions.ts
@@ -45,11 +45,11 @@ export const generateFunctions = async (
     })
     const functionName = getFunctionNameForPage(route, config.type === ApiRouteType.BACKGROUND)
     await ensureDir(join(functionsDir, functionName))
-    await writeFile(join(functionsDir, functionName, `${functionName}.js`), apiHandlerSource)
-    await copyFile(bridgeFile, join(functionsDir, functionName, 'bridge.js'))
+    await writeFile(join(functionsDir, functionName, `${functionName}.cjs`), apiHandlerSource)
+    await copyFile(bridgeFile, join(functionsDir, functionName, 'bridge.cjs'))
     await copyFile(
       join(__dirname, '..', '..', 'lib', 'templates', 'handlerUtils.js'),
-      join(functionsDir, functionName, 'handlerUtils.js'),
+      join(functionsDir, functionName, 'handlerUtils.cjs'),
     )
 
     const resolveSourceFile = (file: string) => join(publish, 'server', file)
@@ -65,11 +65,11 @@ export const generateFunctions = async (
   const writeHandler = async (functionName: string, isODB: boolean) => {
     const handlerSource = await getHandler({ isODB, publishDir, appDir: relative(functionDir, appDir) })
     await ensureDir(join(functionsDir, functionName))
-    await writeFile(join(functionsDir, functionName, `${functionName}.js`), handlerSource)
-    await copyFile(bridgeFile, join(functionsDir, functionName, 'bridge.js'))
+    await writeFile(join(functionsDir, functionName, `${functionName}.cjs`), handlerSource)
+    await copyFile(bridgeFile, join(functionsDir, functionName, 'bridge.cjs'))
     await copyFile(
       join(__dirname, '..', '..', 'lib', 'templates', 'handlerUtils.js'),
-      join(functionsDir, functionName, 'handlerUtils.js'),
+      join(functionsDir, functionName, 'handlerUtils.cjs'),
     )
   }
 
@@ -90,8 +90,8 @@ export const generatePagesResolver = async ({
 
   const jsSource = await getResolverForPages(PUBLISH_DIR)
 
-  await writeFile(join(functionsPath, ODB_FUNCTION_NAME, 'pages.js'), jsSource)
-  await writeFile(join(functionsPath, HANDLER_FUNCTION_NAME, 'pages.js'), jsSource)
+  await writeFile(join(functionsPath, ODB_FUNCTION_NAME, 'pages.cjs'), jsSource)
+  await writeFile(join(functionsPath, HANDLER_FUNCTION_NAME, 'pages.cjs'), jsSource)
 }
 
 // Move our next/image function into the correct functions directory
@@ -126,7 +126,7 @@ export const setupImageFunction = async ({
     }
   } else {
     const functionsPath = INTERNAL_FUNCTIONS_SRC || FUNCTIONS_SRC
-    const functionName = `${IMAGE_FUNCTION_NAME}.js`
+    const functionName = `${IMAGE_FUNCTION_NAME}.cjs`
     const functionDirectory = join(functionsPath, IMAGE_FUNCTION_NAME)
 
     await ensureDir(functionDirectory)

--- a/packages/runtime/src/helpers/functions.ts
+++ b/packages/runtime/src/helpers/functions.ts
@@ -59,7 +59,7 @@ export const generateFunctions = async (
       // These extra pages are always included by Next.js
       sourceFiles: [compiled, 'pages/_app.js', 'pages/_document.js', 'pages/_error.js'].map(resolveSourceFile),
     })
-    await writeFile(join(functionsDir, functionName, 'pages.js'), resolverSource)
+    await writeFile(join(functionsDir, functionName, 'pages.cjs'), resolverSource)
   }
 
   const writeHandler = async (functionName: string, isODB: boolean) => {

--- a/packages/runtime/src/templates/getApiHandler.ts
+++ b/packages/runtime/src/templates/getApiHandler.ts
@@ -37,7 +37,7 @@ const makeHandler = (conf: NextConfig, app, pageRoot, page) => {
   // This is just so nft knows about the page entrypoints. It's not actually used
   try {
     // eslint-disable-next-line n/no-missing-require
-    require.resolve('./pages.js')
+    require.resolve('./pages.cjs')
   } catch {}
 
   // React assumes you want development mode if NODE_ENV is unset.

--- a/packages/runtime/src/templates/getApiHandler.ts
+++ b/packages/runtime/src/templates/getApiHandler.ts
@@ -128,8 +128,8 @@ export const getApiHandler = ({
   javascript/* javascript */ `
   const { Server } = require("http");
   // We copy the file here rather than requiring from the node module
-  const { Bridge } = require("./bridge");
-  const { getMaxAge, getMultiValueHeaders, getNextServer } = require('./handlerUtils')
+  const { Bridge } = require("./bridge.cjs");
+  const { getMaxAge, getMultiValueHeaders, getNextServer } = require('./handlerUtils.cjs')
 
   ${config.type === ApiRouteType.SCHEDULED ? `const { schedule } = require("@netlify/functions")` : ''}
 

--- a/packages/runtime/src/templates/getHandler.ts
+++ b/packages/runtime/src/templates/getHandler.ts
@@ -44,7 +44,7 @@ const makeHandler = (conf: NextConfig, app, pageRoot, staticManifest: Array<[str
   // This is just so nft knows about the page entrypoints. It's not actually used
   try {
     // eslint-disable-next-line n/no-missing-require
-    require.resolve('./pages.js')
+    require.resolve('./pages.cjs')
   } catch {}
 
   const ONE_YEAR_IN_SECONDS = 31536000

--- a/packages/runtime/src/templates/getHandler.ts
+++ b/packages/runtime/src/templates/getHandler.ts
@@ -178,8 +178,8 @@ export const getHandler = ({ isODB = false, publishDir = '../../../.next', appDi
   const { Server } = require("http");
   const { promises } = require("fs");
   // We copy the file here rather than requiring from the node module
-  const { Bridge } = require("./bridge");
-  const { augmentFsModule, getMaxAge, getMultiValueHeaders, getPrefetchResponse, getNextServer, normalizePath } = require('./handlerUtils')
+  const { Bridge } = require("./bridge.cjs");
+  const { augmentFsModule, getMaxAge, getMultiValueHeaders, getPrefetchResponse, getNextServer, normalizePath } = require('./handlerUtils.cjs')
 
   ${isODB ? `const { builder } = require("@netlify/functions")` : ''}
   const { config }  = require("${publishDir}/required-server-files.json")

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -590,7 +590,7 @@ describe('onBuild()', () => {
     await nextRuntime.onBuild(defaultArgs)
 
     for (const route of ['_api_hello-background-background', '_api_hello-scheduled-handler']) {
-      const expected = path.resolve(constants.INTERNAL_FUNCTIONS_SRC, route, 'pages.js')
+      const expected = path.resolve(constants.INTERNAL_FUNCTIONS_SRC, route, 'pages.cjs')
       expect(existsSync(expected)).toBeTruthy()
       expect(normalizeChunkNames(readFileSync(expected, 'utf8'))).toMatchSnapshot(`for ${route}`)
     }
@@ -599,8 +599,8 @@ describe('onBuild()', () => {
   test('generates a file referencing all page sources', async () => {
     await moveNextDist()
     await nextRuntime.onBuild(defaultArgs)
-    const handlerPagesFile = path.join(constants.INTERNAL_FUNCTIONS_SRC, HANDLER_FUNCTION_NAME, 'pages.js')
-    const odbHandlerPagesFile = path.join(constants.INTERNAL_FUNCTIONS_SRC, ODB_FUNCTION_NAME, 'pages.js')
+    const handlerPagesFile = path.join(constants.INTERNAL_FUNCTIONS_SRC, HANDLER_FUNCTION_NAME, 'pages.cjs')
+    const odbHandlerPagesFile = path.join(constants.INTERNAL_FUNCTIONS_SRC, ODB_FUNCTION_NAME, 'pages.cjs')
     expect(existsSync(handlerPagesFile)).toBeTruthy()
     expect(existsSync(odbHandlerPagesFile)).toBeTruthy()
 
@@ -618,8 +618,8 @@ describe('onBuild()', () => {
       constants: { ...constants, PUBLISH_DIR: dir },
     }
     await nextRuntime.onBuild(config)
-    const handlerPagesFile = path.join(constants.INTERNAL_FUNCTIONS_SRC, HANDLER_FUNCTION_NAME, 'pages.js')
-    const odbHandlerPagesFile = path.join(constants.INTERNAL_FUNCTIONS_SRC, ODB_FUNCTION_NAME, 'pages.js')
+    const handlerPagesFile = path.join(constants.INTERNAL_FUNCTIONS_SRC, HANDLER_FUNCTION_NAME, 'pages.cjs')
+    const odbHandlerPagesFile = path.join(constants.INTERNAL_FUNCTIONS_SRC, ODB_FUNCTION_NAME, 'pages.cjs')
 
     expect(normalizeChunkNames(readFileSync(handlerPagesFile, 'utf8'))).toMatchSnapshot()
     expect(normalizeChunkNames(readFileSync(odbHandlerPagesFile, 'utf8'))).toMatchSnapshot()
@@ -632,9 +632,9 @@ describe('onBuild()', () => {
     const handlerFile = path.join(
       constants.INTERNAL_FUNCTIONS_SRC,
       HANDLER_FUNCTION_NAME,
-      `${HANDLER_FUNCTION_NAME}.js`,
+      `${HANDLER_FUNCTION_NAME}.cjs`,
     )
-    const odbHandlerFile = path.join(constants.INTERNAL_FUNCTIONS_SRC, ODB_FUNCTION_NAME, `${ODB_FUNCTION_NAME}.js`)
+    const odbHandlerFile = path.join(constants.INTERNAL_FUNCTIONS_SRC, ODB_FUNCTION_NAME, `${ODB_FUNCTION_NAME}.cjs`)
     expect(existsSync(handlerFile)).toBeTruthy()
     expect(existsSync(odbHandlerFile)).toBeTruthy()
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -444,12 +444,12 @@ describe('onBuild()', () => {
 
     await nextRuntime.onBuild(defaultArgs)
 
-    expect(existsSync(`.netlify/functions-internal/___netlify-handler/___netlify-handler.js`)).toBeTruthy()
-    expect(existsSync(`.netlify/functions-internal/___netlify-handler/bridge.js`)).toBeTruthy()
-    expect(existsSync(`.netlify/functions-internal/___netlify-handler/handlerUtils.js`)).toBeTruthy()
-    expect(existsSync(`.netlify/functions-internal/___netlify-odb-handler/___netlify-odb-handler.js`)).toBeTruthy()
-    expect(existsSync(`.netlify/functions-internal/___netlify-odb-handler/bridge.js`)).toBeTruthy()
-    expect(existsSync(`.netlify/functions-internal/___netlify-odb-handler/handlerUtils.js`)).toBeTruthy()
+    expect(existsSync(`.netlify/functions-internal/___netlify-handler/___netlify-handler.cjs`)).toBeTruthy()
+    expect(existsSync(`.netlify/functions-internal/___netlify-handler/bridge.cjs`)).toBeTruthy()
+    expect(existsSync(`.netlify/functions-internal/___netlify-handler/handlerUtils.cjs`)).toBeTruthy()
+    expect(existsSync(`.netlify/functions-internal/___netlify-odb-handler/___netlify-odb-handler.cjs`)).toBeTruthy()
+    expect(existsSync(`.netlify/functions-internal/___netlify-odb-handler/bridge.cjs`)).toBeTruthy()
+    expect(existsSync(`.netlify/functions-internal/___netlify-odb-handler/handlerUtils.cjs`)).toBeTruthy()
   })
 
   test('writes correct redirects to netlifyConfig', async () => {
@@ -687,14 +687,14 @@ describe('onBuild()', () => {
   test('generates an ipx function by default', async () => {
     await moveNextDist()
     await nextRuntime.onBuild(defaultArgs)
-    expect(existsSync(path.join('.netlify', 'functions-internal', '_ipx', '_ipx.js'))).toBeTruthy()
+    expect(existsSync(path.join('.netlify', 'functions-internal', '_ipx', '_ipx.cjs'))).toBeTruthy()
   })
 
   test('does not generate an ipx function when DISABLE_IPX is set', async () => {
     process.env.DISABLE_IPX = '1'
     await moveNextDist()
     await nextRuntime.onBuild(defaultArgs)
-    expect(existsSync(path.join('.netlify', 'functions-internal', '_ipx', '_ipx.js'))).toBeFalsy()
+    expect(existsSync(path.join('.netlify', 'functions-internal', '_ipx', '_ipx.cjs'))).toBeFalsy()
     delete process.env.DISABLE_IPX
   })
 


### PR DESCRIPTION
Part of netlify/pod-compute#149

Fixes #1456 
Fixes #1194 

### Summary

Outputs the functions with .cjs extension. Because of the recent changes to zip-it-and-ship-it the `cjs` extension will be kept and this in turn means that the functions are not affected by `type:module` in a sites `package.json`.

### Test plan

Tests pass

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

### Standard checks:

- [x] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
