### PR TITLE
fix: getMaxAge is not used in APIHandlers

### DIFF
--- a/packages/runtime/src/templates/getApiHandler.ts
+++ b/packages/runtime/src/templates/getApiHandler.ts
@@ -129,7 +129,7 @@ export const getApiHandler = ({
   const { Server } = require("http");
   // We copy the file here rather than requiring from the node module
   const { Bridge } = require("./bridge");
-  const { getMaxAge, getMultiValueHeaders, getNextServer } = require('./handlerUtils')
+  const { getMultiValueHeaders, getNextServer } = require('./handlerUtils')
 
   ${config.type === ApiRouteType.SCHEDULED ? `const { schedule } = require("@netlify/functions")` : ''}
 


### PR DESCRIPTION
### Summary

It seems it was copied over when splitting APIHandlers from Handlers, but isn't actually used.

### Test plan

Tests

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

### Standard checks:

- [x] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
