### PR TITLE
fix: added polyfill for process.env

### DIFF
--- a/packages/runtime/src/templates/edge/next-dev.js
+++ b/packages/runtime/src/templates/edge/next-dev.js
@@ -5,6 +5,7 @@ import { buildResponse } from '../edge-shared/utils.ts'
 
 globalThis.NFRequestContextMap ||= new Map()
 globalThis.__dirname = fromFileUrl(new URL('./', import.meta.url)).slice(0, -1)
+globalThis.process ||= { env: Deno.env.toObject() }
 
 // Next.js uses this extension to the Headers API implemented by Cloudflare workerd
 if (!('getAll' in Headers.prototype)) {


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guildines, https://github.com/netlify/next-runtime/blob/main/CONTRIBUTING.md. -->

### Summary

Using `process.env` to access env vars within an edge function currently returns an error when running `netlify dev`. Updated next-dev file within edge to now polyfill `process.env` and allow it to work within edge functions.

<!-- Provide a brief summary of the change. -->

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal
Fixes #1864 
### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary<!-- Please delete any options that reviewers shouldn't check. -->

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
