### PR TITLE
fix: handle v1 edge function definition

### DIFF
--- a/packages/runtime/src/helpers/edge.ts
+++ b/packages/runtime/src/helpers/edge.ts
@@ -348,12 +348,12 @@ export const writeRscDataEdgeFunction = async ({
   ]
 }
 
-const getEdgeFunctionPatternForPage = ({
+export const getEdgeFunctionPatternForPage = ({
   edgeFunctionDefinition,
   pageRegexMap,
   appPathRoutesManifest,
 }: {
-  edgeFunctionDefinition: EdgeFunctionDefinitionV2
+  edgeFunctionDefinition: EdgeFunctionDefinition
   pageRegexMap: Map<string, string>
   appPathRoutesManifest?: Record<string, string>
 }): string => {
@@ -361,8 +361,14 @@ const getEdgeFunctionPatternForPage = ({
 
   // appDir functions have a name that _isn't_ the route name, but rather the route with `/page` appended
   const regexp = pageRegexMap.get(appPathRoutesManifest?.[edgeFunctionDefinition.page] ?? edgeFunctionDefinition.page)
+  if (regexp) {
+    return regexp
+  }
+  if ('regexp' in edgeFunctionDefinition) {
+    return edgeFunctionDefinition.regexp.replace(/([^/])\$$/, '$1/?$')
+  }
   // If we need to fall back to the matcher, we need to add an optional trailing slash
-  return regexp ?? edgeFunctionDefinition.matchers[0].regexp.replace(/([^/])\$$/, '$1/?$')
+  return edgeFunctionDefinition.matchers?.[0].regexp.replace(/([^/])\$$/, '$1/?$')
 }
 
 /**


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guildines, https://github.com/netlify/next-runtime/blob/main/CONTRIBUTING.md. -->

### Summary

Follow me, if you will, back to the summer of 2022.  Next.js middleware had gone to GA, which included updating the manifest format to include `functions` as well as `middleware`. Shortly after (the next patch release) they added support for middleware matchers, replacing the `regex` key on middleware defintions with an array of matchers, and doing the same for the new functions because why not add a new feature and make a breaking change to a format in a patch release. Anyway, for that brief period in June there was support for functions but no matchers. This PR makes those work.

### Test plan

1. Ensure the new unit tests pass. I'm not adding a demo site for a manifest format that was around for less time than the British prime minister who was running for office at that time. A unit test will have to do.

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal
![image](https://user-images.githubusercontent.com/213306/214281949-97a0b329-9541-49cc-abb2-53fa5b9b7153.png)

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
