### PR TITLE
docs: update broken link (large functions)

### DIFF
--- a/packages/runtime/src/helpers/verification.ts
+++ b/packages/runtime/src/helpers/verification.ts
@@ -148,7 +148,7 @@ export const checkZipSize = async (file: string, maxSize: number = LAMBDA_MAX_SI
   console.log(yellowBright`\n\nThese are the largest files in the zip:`)
   console.table(largest)
   console.log(
-    greenBright`\n\nFor more information on fixing this, see ${blueBright`https://ntl.fyi/large-next-functions`}`,
+    greenBright`\n\nFor more information on fixing this, see ${blueBright`https://docs.netlify.com/integrations/frameworks/next-js/troubleshooting/#troubleshooting-large-functions`}`,
   )
 }
 


### PR DESCRIPTION
### Summary

Looks like this link was missed when updating the documentation yesterday. https://github.com/netlify/next-runtime/pull/1908

Thank you for your work!

### Test plan

1. Verifiy link is correct

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal
![happy-red-panda-171399380-5b574325c9e77c005b690b41](https://user-images.githubusercontent.com/33156025/215841919-481ee0b9-3333-49df-a438-75f021e84ef0.jpg)

### Standard checks:

- [ ] Verify link is correct

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
