### PR TITLE
refactor: extract edge runtime shims into separate file

### DIFF
--- a/packages/runtime/src/helpers/edge.ts
+++ b/packages/runtime/src/helpers/edge.ts
@@ -105,7 +105,7 @@ const getMiddlewareBundle = async ({
 }): Promise<string> => {
   const { publish } = netlifyConfig.build
 
-  const shims = await fs.readFile(getEdgeTemplatePath('shims.ts'), 'utf8')
+  const shims = await fs.readFile(getEdgeTemplatePath('shims.js'), 'utf8')
 
   const chunks: Array<string> = [shims]
 

--- a/packages/runtime/src/templates/edge/shims.js
+++ b/packages/runtime/src/templates/edge/shims.js
@@ -1,3 +1,4 @@
+// @ts-check
 // deno-lint-ignore-file no-var prefer-const no-unused-vars no-explicit-any
 import { decode as _base64Decode } from 'https://deno.land/std@0.175.0/encoding/base64.ts'
 import { AsyncLocalStorage as ALSCompat } from 'https://deno.land/std@0.175.0/node/async_hooks.ts'
@@ -7,17 +8,9 @@ import { AsyncLocalStorage as ALSCompat } from 'https://deno.land/std@0.175.0/no
  * This file isn't imported, but is instead inlined along with other chunks into the edge bundle.
  */
 
-declare global {
-  var process: {
-    env: Record<string, string>
-  }
-  var EdgeRuntime: string
-  var AsyncLocalStorage: typeof ALSCompat
-  var _ASSETS: Record<string, string>
-}
-
 // Deno defines "window", but naughty libraries think this means it's a browser
-delete (globalThis as Omit<typeof globalThis, 'window'> & Pick<Partial<typeof globalThis>, 'window'>).window
+// @ts-ignore
+delete globalThis.window
 globalThis.process = {
   env: { ...Deno.env.toObject(), NEXT_RUNTIME: 'edge', NEXT_PRIVATE_MINIMAL_MODE: '1' },
 }
@@ -29,7 +22,8 @@ globalThis.AsyncLocalStorage = ALSCompat
 
 // Next.js uses this extension to the Headers API implemented by Cloudflare workerd
 if (!('getAll' in Headers.prototype)) {
-  ;(Headers as any).prototype.getAll = function getAll(name: string) {
+  // @ts-ignore
+  Headers.prototype.getAll = function getAll(name) {
     name = name.toLowerCase()
     if (name !== 'set-cookie') {
       throw new Error('Headers.getAll is only supported for Set-Cookie')
@@ -39,7 +33,7 @@ if (!('getAll' in Headers.prototype)) {
 }
 //  Next uses blob: urls to refer to local assets, so we need to intercept these
 const _fetch = globalThis.fetch
-const fetch: typeof globalThis.fetch = async (url, init) => {
+const fetch /* type {typeof globalThis.fetch} */ = async (url, init) => {
   try {
     if (url instanceof URL && url.href?.startsWith('blob:')) {
       const key = url.href.slice(5)

--- a/packages/runtime/src/templates/edge/shims.ts
+++ b/packages/runtime/src/templates/edge/shims.ts
@@ -1,0 +1,59 @@
+// deno-lint-ignore-file no-var prefer-const no-unused-vars no-explicit-any
+import { decode as _base64Decode } from 'https://deno.land/std@0.175.0/encoding/base64.ts'
+import { AsyncLocalStorage as ALSCompat } from 'https://deno.land/std@0.175.0/node/async_hooks.ts'
+
+/**
+ * These are the shims, polyfills and other kludges to make Next.js work in standards-compliant runtime.
+ * This file isn't imported, but is instead inlined along with other chunks into the edge bundle.
+ */
+
+declare global {
+  var process: {
+    env: Record<string, string>
+  }
+  var EdgeRuntime: string
+  var AsyncLocalStorage: typeof ALSCompat
+  var _ASSETS: Record<string, string>
+}
+
+// Deno defines "window", but naughty libraries think this means it's a browser
+delete (globalThis as Omit<typeof globalThis, 'window'> & Pick<Partial<typeof globalThis>, 'window'>).window
+globalThis.process = {
+  env: { ...Deno.env.toObject(), NEXT_RUNTIME: 'edge', NEXT_PRIVATE_MINIMAL_MODE: '1' },
+}
+globalThis.EdgeRuntime = 'netlify-edge'
+let _ENTRIES = {}
+
+// Next.js expects this as a global
+globalThis.AsyncLocalStorage = ALSCompat
+
+// Next.js uses this extension to the Headers API implemented by Cloudflare workerd
+if (!('getAll' in Headers.prototype)) {
+  ;(Headers as any).prototype.getAll = function getAll(name: string) {
+    name = name.toLowerCase()
+    if (name !== 'set-cookie') {
+      throw new Error('Headers.getAll is only supported for Set-Cookie')
+    }
+    return [...this.entries()].filter(([key]) => key === name).map(([, value]) => value)
+  }
+}
+//  Next uses blob: urls to refer to local assets, so we need to intercept these
+const _fetch = globalThis.fetch
+const fetch: typeof globalThis.fetch = async (url, init) => {
+  try {
+    if (url instanceof URL && url.href?.startsWith('blob:')) {
+      const key = url.href.slice(5)
+      if (key in _ASSETS) {
+        return new Response(_base64Decode(_ASSETS[key]))
+      }
+    }
+    return await _fetch(url, init)
+  } catch (error) {
+    console.error(error)
+    throw error
+  }
+}
+
+// Next edge runtime uses "self" as a function-scoped global-like object, but some of the older polyfills expect it to equal globalThis
+// See https://nextjs.org/docs/basic-features/supported-browsers-features#polyfills
+const self = { ...globalThis, fetch }


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guildines, https://github.com/netlify/next-runtime/blob/main/CONTRIBUTING.md. -->

### Summary

We provide a number of shims and polyfills to make our edge runtime work with Next.js. Currently they're a big string in a helper file. This PR extracts them into a file, meaning they can be properly typechecked.

### Test plan

This should have no effect on the output.

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal
![image](https://user-images.githubusercontent.com/213306/216339122-73d861e3-c870-40f7-ba18-37a91382602b.png)

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
