### PR TITLE
chore: migrate to Github Action's output files

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -25,8 +25,8 @@ jobs:
           tag_version=${branch:9}
           tag=${tag_version%/*}
           version=${tag_version##*/}
-          echo "::set-output name=tag::${tag}"
-          echo "::set-output name=version::${version}"
+          echo "tag=${tag}" >> $GITHUB_OUTPUT
+          echo "version=${version}" >> $GITHUB_OUTPUT
       - name: Log versions
         run: |-
           echo tag=${{ steps.extract.outputs.tag }}


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ for context.
