### PR TITLE
chore: up test timeout

### DIFF
--- a/test/e2e/jest.config.js
+++ b/test/e2e/jest.config.js
@@ -15,7 +15,7 @@ const config = {
     '\\.[jt]sx?$': 'babel-jest',
   },
   verbose: true,
-  testTimeout: 300000,
+  testTimeout: 600000, // ten minutes
   moduleFileExtensions: ['js', 'jsx', 'ts', 'tsx'],
   moduleNameMapper: {
     'e2e-utils': '<rootDir>/next-test-lib/e2e-utils.ts',


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/netlify/next-runtime/blob/main/CONTRIBUTING.md. -->

### Summary

Ups the e2e timeout to 10 minutes instead of 5.
