### PR TITLE
fix: remove fs access which isn't available in edge functions

### DIFF
--- a/packages/runtime/src/templates/edge/next-dev.js
+++ b/packages/runtime/src/templates/edge/next-dev.js
@@ -38,7 +38,7 @@ const handler = async (req, context) => {
     const nextMiddleware = await import(`../../middleware.js#${idx++}`)
     middleware = nextMiddleware.middleware
   } catch (importError) {
-    // Error message is `Module not found "file://<path>/buxtehude.mjs#123456".` in Deno
+    // Error message is `Module not found "file://<path>/middleware.js#123456".` in Deno
     if (importError.code === 'ERR_MODULE_NOT_FOUND' && importError.message.includes(`/middleware.js#${idx}`)) {
       //  No middleware, so we silently return
       return

--- a/packages/runtime/src/templates/edge/next-dev.js
+++ b/packages/runtime/src/templates/edge/next-dev.js
@@ -18,19 +18,6 @@ if (!('getAll' in Headers.prototype)) {
   }
 }
 
-// Check if a file exists, given a relative path
-const exists = async (relativePath) => {
-  const path = fromFileUrl(new URL(relativePath, import.meta.url))
-  try {
-    await Deno.stat(path)
-    return true
-  } catch (error) {
-    if (error instanceof Deno.errors.NotFound) {
-      return false
-    }
-    throw error
-  }
-}
 let idx = 0
 
 const handler = async (req, context) => {
@@ -45,14 +32,19 @@ const handler = async (req, context) => {
   // We don't want to just try importing and use that to test,
   // because that would also throw if there's an error in the middleware,
   // which we would want to surface not ignore.
-  if (await exists('../../middleware.js')) {
+  try {
     // We need to cache-bust the import because otherwise it will claim it
     // doesn't exist if the user creates it after the server starts
     const nextMiddleware = await import(`../../middleware.js#${idx++}`)
     middleware = nextMiddleware.middleware
-  } else {
-    //  No middleware, so we silently return
-    return
+  } catch (importError) {
+    // Error message is `Module not found "file://<path>/buxtehude.mjs#123456".` in Deno
+    if (importError.code === 'ERR_MODULE_NOT_FOUND' && importError.message.includes(`/middleware.js#${idx}`)) {
+      //  No middleware, so we silently return
+      return
+    }
+
+    throw importError
   }
 
   //  This is the format expected by Next.js along with the timezone which we support.

--- a/packages/runtime/src/templates/edge/next-dev.js
+++ b/packages/runtime/src/templates/edge/next-dev.js
@@ -39,7 +39,7 @@ const handler = async (req, context) => {
     middleware = nextMiddleware.middleware
   } catch (importError) {
     // Error message is `Module not found "file://<path>/middleware.js#123456".` in Deno
-    if (importError.code === 'ERR_MODULE_NOT_FOUND' && importError.message.includes(`/middleware.js#${idx}`)) {
+    if (importError.code === 'ERR_MODULE_NOT_FOUND' && importError.message.includes(`middleware.js#${idx}`)) {
       //  No middleware, so we silently return
       return
     }


### PR DESCRIPTION
### Summary

Removes the `Deno.stat` call from the dev edge function.

It rethrows any errors besides the Module not found error for the `middleware.js` file. 

Because we have a number in the hash of the import it is also super easy to see if this error is from our import or not.

Fixes https://github.com/netlify/pod-ecosystem-frameworks/issues/422

### Test plan


### Picture of cute animal

![61CNGisjWUL _SY450_](https://user-images.githubusercontent.com/231804/224695257-f86ec3e9-e1ca-4298-868a-298104cde971.jpg)


### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
