### PR TITLE
fix: use the same id for importing and checking error

### DIFF
--- a/packages/runtime/src/templates/edge/next-dev.js
+++ b/packages/runtime/src/templates/edge/next-dev.js
@@ -35,7 +35,7 @@ const handler = async (req, context) => {
   try {
     // We need to cache-bust the import because otherwise it will claim it
     // doesn't exist if the user creates it after the server starts
-    const nextMiddleware = await import(`../../middleware.js#${idx++}`)
+    const nextMiddleware = await import(`../../middleware.js#${++idx}`)
     middleware = nextMiddleware.middleware
   } catch (importError) {
     // Error message is `Module not found "file://<path>/middleware.js#123456".` in Deno


### PR DESCRIPTION
The id in the import and in the catch was different. Now they are the same.