### PR TITLE
fix: make error message matching more generic

### DIFF
--- a/packages/runtime/src/templates/edge/next-dev.js
+++ b/packages/runtime/src/templates/edge/next-dev.js
@@ -38,7 +38,6 @@ const handler = async (req, context) => {
     const nextMiddleware = await import(`../../middleware.js#${idx++}`)
     middleware = nextMiddleware.middleware
   } catch (importError) {
-    // Error message is `Module not found "file://<path>/middleware.js#123456".` in Deno
     if (importError.code === 'ERR_MODULE_NOT_FOUND' && importError.message.includes(`middleware.js`)) {
       //  No middleware, so we silently return
       return

--- a/packages/runtime/src/templates/edge/next-dev.js
+++ b/packages/runtime/src/templates/edge/next-dev.js
@@ -39,7 +39,7 @@ const handler = async (req, context) => {
     middleware = nextMiddleware.middleware
   } catch (importError) {
     // Error message is `Module not found "file://<path>/middleware.js#123456".` in Deno
-    if (importError.code === 'ERR_MODULE_NOT_FOUND' && importError.message.includes(`middleware.js#${idx}`)) {
+    if (importError.code === 'ERR_MODULE_NOT_FOUND' && importError.message.includes(`middleware.js`)) {
       //  No middleware, so we silently return
       return
     }


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/netlify/next-runtime/blob/main/CONTRIBUTING.md. -->

### Summary

Some async business is messing with the idx value, where it's idx=z (strangely 1 more than we'd expect) when entering the catch condition, but idx=z-1 (correct value) when comparing in the if statement in the catch. 

We know that the correct values are being used when comparing, and the value of the middleware.js#x doesn't matter when the catch occurs, we just want to return silently. 

### Test plan

1. Visit the Deploy Preview ([insert link to specific page]()) ...

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal
Fixes https://github.com/netlify/next-runtime/issues/1983
### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
