### PR TITLE
test: added tests to check that the vary header contains 'RSC'

### DIFF
--- a/cypress/integration/default/appdir.spec.ts
+++ b/cypress/integration/default/appdir.spec.ts
@@ -29,12 +29,24 @@ describe('appDir', () => {
     })
   })
 
-  it('returns HTML for non-RSC data requests to ISR pages', () => {
+  it('returns a vary header for RSC data requests to ISR pages', () => {
+    cy.request({
+      url: '/blog/erica/',
+      followRedirect: false,
+      headers: {
+        RSC: '1',
+      },
+    }).then((response) => {
+      expect(response.headers).to.have.property('vary').contains('RSC')
+    })
+  })
+
+  it('returns a vary header for non-RSC data requests to ISR pages', () => {
     cy.request({
       url: '/blog/erica/',
       followRedirect: false,
     }).then((response) => {
-      expect(response.headers).to.have.property('content-type', 'text/html; charset=utf-8')
+      expect(response.headers).to.have.property('vary').contains('RSC')
     })
   })
 

--- a/cypress/integration/default/appdir.spec.ts
+++ b/cypress/integration/default/appdir.spec.ts
@@ -29,7 +29,7 @@ describe('appDir', () => {
     })
   })
 
-  it('returns HTML for non-RSC requests to ISR pages', () => {
+  it('returns HTML for non-RSC data requests to ISR pages', () => {
     cy.request({
       url: '/blog/erica/',
       followRedirect: false,

--- a/cypress/integration/default/appdir.spec.ts
+++ b/cypress/integration/default/appdir.spec.ts
@@ -29,6 +29,15 @@ describe('appDir', () => {
     })
   })
 
+  it('returns HTML for non-RSC requests to ISR pages', () => {
+    cy.request({
+      url: '/blog/erica/',
+      followRedirect: false,
+    }).then((response) => {
+      expect(response.headers).to.have.property('content-type', 'text/html; charset=utf-8')
+    })
+  })
+
   it('returns RSC data for RSC requests to static pages', () => {
     cy.request({
       url: '/blog/erica/first-post/',

--- a/packages/runtime/src/templates/edge-shared/rsc-data.ts
+++ b/packages/runtime/src/templates/edge-shared/rsc-data.ts
@@ -60,6 +60,12 @@ export const getRscDataRouter = ({ routes: staticRoutes, dynamicRoutes }: Preren
     const debug = request.headers.has('x-next-debug-logging')
     const log = debug ? (...args: unknown[]) => console.log(...args) : noop
     const url = new URL(request.url)
+
+    // Set the 'vary' header to 'RSC' to ensure that we cache correctly for the different
+    // possible mime types: application/octet-stream and text/html
+    // See https://github.com/netlify/pod-ecosystem-frameworks/issues/352#issuecomment-1450364417
+    request.headers.set('vary', 'RSC')
+
     // If this is a static RSC request, rewrite to the data route
     if (request.headers.get('rsc') === '1') {
       log('Is rsc request')

--- a/packages/runtime/src/templates/edge-shared/rsc-data.ts
+++ b/packages/runtime/src/templates/edge-shared/rsc-data.ts
@@ -60,11 +60,6 @@ export const getRscDataRouter = ({ routes: staticRoutes, dynamicRoutes }: Preren
     const debug = request.headers.has('x-next-debug-logging')
     const log = debug ? (...args: unknown[]) => console.log(...args) : noop
     const url = new URL(request.url)
-
-    // Set the 'vary' header to 'RSC' to ensure that we cache correctly for the different
-    // possible content-types: application/octet-stream and text/html
-    request.headers.set('vary', 'RSC')
-
     // If this is a static RSC request, rewrite to the data route
     if (request.headers.get('rsc') === '1') {
       log('Is rsc request')

--- a/packages/runtime/src/templates/edge-shared/rsc-data.ts
+++ b/packages/runtime/src/templates/edge-shared/rsc-data.ts
@@ -62,8 +62,7 @@ export const getRscDataRouter = ({ routes: staticRoutes, dynamicRoutes }: Preren
     const url = new URL(request.url)
 
     // Set the 'vary' header to 'RSC' to ensure that we cache correctly for the different
-    // possible mime types: application/octet-stream and text/html
-    // See https://github.com/netlify/pod-ecosystem-frameworks/issues/352#issuecomment-1450364417
+    // possible content-types: application/octet-stream and text/html
     request.headers.set('vary', 'RSC')
 
     // If this is a static RSC request, rewrite to the data route


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/netlify/next-runtime/blob/main/CONTRIBUTING.md. -->

### Summary

~Fixes an issue where requests coming in to the edge function that were handling React Server Components were always returning the first cached response causing issues with serving the content type `text/html` or `application/octet-stream`~

It looks like the `vary` header is already in the response, so I've added tests to ensure it remains.

Closes https://github.com/netlify/pod-ecosystem-frameworks/issues/352

<!-- Provide a brief summary of the change. -->

### Test plan

There is an end-to-end test in this PR that tests that this works, but you can also curl the deploy preview to see it working.

1. Run `curl -v https://deploy-preview-1993--netlify-plugin-nextjs-demo.netlify.app/blog/erica/`. The content type returned is `content-type: text/html; charset=utf-8`
2. Run `curl -v -H "RSC: 1" https://deploy-preview-1993--netlify-plugin-nextjs-demo.netlify.app/blog/erica/`, The content type returned is `content-type: application/octet-stream`

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [x] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
