### PR TITLE
feat: add generator meta data for framework generated Netlify Functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "jest-extended": "^3.2.0",
         "jest-fetch-mock": "^3.0.3",
         "jest-junit": "^14.0.1",
+        "mock-fs": "^5.2.0",
         "netlify-plugin-cypress": "^2.2.1",
         "npm-run-all": "^4.1.5",
         "playwright-chromium": "^1.26.1",
@@ -17994,6 +17995,15 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
+    },
+    "node_modules/mock-fs": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-5.2.0.tgz",
+      "integrity": "sha512-2dF2R6YMSZbpip1V1WHKGLNjr/k48uQClqMVb5H3MOvwc9qhYis3/IWbj02qIg/Y8MDXKFF4c5v0rxx2o6xTZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/module-definition": {
       "version": "4.0.0",
@@ -37524,6 +37534,12 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
+    },
+    "mock-fs": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-5.2.0.tgz",
+      "integrity": "sha512-2dF2R6YMSZbpip1V1WHKGLNjr/k48uQClqMVb5H3MOvwc9qhYis3/IWbj02qIg/Y8MDXKFF4c5v0rxx2o6xTZw==",
+      "dev": true
     },
     "module-definition": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "jest-extended": "^3.2.0",
     "jest-fetch-mock": "^3.0.3",
     "jest-junit": "^14.0.1",
+    "mock-fs": "^5.2.0",
     "netlify-plugin-cypress": "^2.2.1",
     "npm-run-all": "^4.1.5",
     "playwright-chromium": "^1.26.1",

--- a/packages/runtime/src/constants.ts
+++ b/packages/runtime/src/constants.ts
@@ -5,7 +5,7 @@ export const NEXT_PLUGIN_NAME = '@netlify/next-runtime'
 export const NEXT_PLUGIN = '@netlify/plugin-nextjs'
 export const HANDLER_FUNCTION_TITLE = 'Next.js SSR handler'
 export const ODB_FUNCTION_TITLE = 'Next.js ISR handler'
-export const IMAGE_FUNCTION_TITLE = 'next/image handler'
+export const IMAGE_FUNCTION_TITLE = "next/image handler"
 // These are paths in .next that shouldn't be publicly accessible
 export const HIDDEN_PATHS = [
   '/cache/*',

--- a/packages/runtime/src/constants.ts
+++ b/packages/runtime/src/constants.ts
@@ -1,7 +1,11 @@
 export const HANDLER_FUNCTION_NAME = '___netlify-handler'
 export const ODB_FUNCTION_NAME = '___netlify-odb-handler'
 export const IMAGE_FUNCTION_NAME = '_ipx'
-
+export const NEXT_PLUGIN_NAME = '@netlify/next-runtime'
+export const NEXT_PLUGIN = '@netlify/plugin-nextjs'
+export const HANDLER_FUNCTION_TITLE = 'Next.js SSR handler'
+export const ODB_FUNCTION_TITLE = 'Next.js ISR handler'
+export const IMAGE_FUNCTION_TITLE = "'next/image handler'"
 // These are paths in .next that shouldn't be publicly accessible
 export const HIDDEN_PATHS = [
   '/cache/*',

--- a/packages/runtime/src/constants.ts
+++ b/packages/runtime/src/constants.ts
@@ -5,7 +5,7 @@ export const NEXT_PLUGIN_NAME = '@netlify/next-runtime'
 export const NEXT_PLUGIN = '@netlify/plugin-nextjs'
 export const HANDLER_FUNCTION_TITLE = 'Next.js SSR handler'
 export const ODB_FUNCTION_TITLE = 'Next.js ISR handler'
-export const IMAGE_FUNCTION_TITLE = "'next/image handler'"
+export const IMAGE_FUNCTION_TITLE = "next/image handler"
 // These are paths in .next that shouldn't be publicly accessible
 export const HIDDEN_PATHS = [
   '/cache/*',

--- a/packages/runtime/src/constants.ts
+++ b/packages/runtime/src/constants.ts
@@ -5,7 +5,7 @@ export const NEXT_PLUGIN_NAME = '@netlify/next-runtime'
 export const NEXT_PLUGIN = '@netlify/plugin-nextjs'
 export const HANDLER_FUNCTION_TITLE = 'Next.js SSR handler'
 export const ODB_FUNCTION_TITLE = 'Next.js ISR handler'
-export const IMAGE_FUNCTION_TITLE = "'next/image handler'"
+export const IMAGE_FUNCTION_TITLE = 'next/image handler'
 // These are paths in .next that shouldn't be publicly accessible
 export const HIDDEN_PATHS = [
   '/cache/*',

--- a/packages/runtime/src/constants.ts
+++ b/packages/runtime/src/constants.ts
@@ -5,7 +5,7 @@ export const NEXT_PLUGIN_NAME = '@netlify/next-runtime'
 export const NEXT_PLUGIN = '@netlify/plugin-nextjs'
 export const HANDLER_FUNCTION_TITLE = 'Next.js SSR handler'
 export const ODB_FUNCTION_TITLE = 'Next.js ISR handler'
-export const IMAGE_FUNCTION_TITLE = "next/image handler"
+export const IMAGE_FUNCTION_TITLE = 'next/image handler'
 // These are paths in .next that shouldn't be publicly accessible
 export const HIDDEN_PATHS = [
   '/cache/*',

--- a/packages/runtime/src/constants.ts
+++ b/packages/runtime/src/constants.ts
@@ -5,7 +5,7 @@ export const NEXT_PLUGIN_NAME = '@netlify/next-runtime'
 export const NEXT_PLUGIN = '@netlify/plugin-nextjs'
 export const HANDLER_FUNCTION_TITLE = 'Next.js SSR handler'
 export const ODB_FUNCTION_TITLE = 'Next.js ISR handler'
-export const IMAGE_FUNCTION_TITLE = "next/image handler"
+export const IMAGE_FUNCTION_TITLE = "'next/image handler'"
 // These are paths in .next that shouldn't be publicly accessible
 export const HIDDEN_PATHS = [
   '/cache/*',

--- a/packages/runtime/src/helpers/config.ts
+++ b/packages/runtime/src/helpers/config.ts
@@ -71,7 +71,7 @@ export const updateRequiredServerFiles = async (publish: string, modifiedConfig:
   await writeJSON(configFile, modifiedConfig)
 }
 
-const resolveModuleRoot = (moduleName) => {
+export const resolveModuleRoot = (moduleName) => {
   try {
     return dirname(relative(process.cwd(), require.resolve(`${moduleName}/package.json`, { paths: [process.cwd()] })))
   } catch {

--- a/packages/runtime/src/helpers/functions.ts
+++ b/packages/runtime/src/helpers/functions.ts
@@ -149,7 +149,7 @@ export const setupImageFunction = async ({
 
     await copyFile(join(__dirname, '..', '..', 'lib', 'templates', 'ipx.js'), join(functionDirectory, functionName))
     writeFunctionConfiguration({
-      functionName: functionName.replace('.js', ''),
+      functionName: IMAGE_FUNCTION_NAME,
       functionTitle: IMAGE_FUNCTION_TITLE,
       functionsDir: functionsPath,
     })

--- a/packages/runtime/src/helpers/functions.ts
+++ b/packages/runtime/src/helpers/functions.ts
@@ -80,7 +80,7 @@ export const generateFunctions = async (
       join(__dirname, '..', '..', 'lib', 'templates', 'handlerUtils.js'),
       join(functionsDir, functionName, 'handlerUtils.js'),
     )
-    writeFunctionConfiguration(functionName, functionTitle, functionsDir)
+    writeFunctionConfiguration({ functionName, functionTitle, functionsDir })
   }
 
   await writeHandler(HANDLER_FUNCTION_NAME, HANDLER_FUNCTION_TITLE, false)
@@ -148,7 +148,11 @@ export const setupImageFunction = async ({
     })
 
     await copyFile(join(__dirname, '..', '..', 'lib', 'templates', 'ipx.js'), join(functionDirectory, functionName))
-    writeFunctionConfiguration(functionName.replace('.js', ''), IMAGE_FUNCTION_TITLE, functionsPath)
+    writeFunctionConfiguration({
+      functionName: functionName.replace('.js', ''),
+      functionTitle: IMAGE_FUNCTION_TITLE,
+      functionsDir: functionsPath,
+    })
 
     // If we have edge functions then the request will have already been rewritten
     // so this won't match. This is matched if edge is disabled or unavailable.

--- a/packages/runtime/src/helpers/functions.ts
+++ b/packages/runtime/src/helpers/functions.ts
@@ -22,7 +22,7 @@ import { getResolverForPages, getResolverForSourceFiles } from '../templates/get
 
 import { ApiConfig, ApiRouteType, extractConfigFromFile } from './analysis'
 import { getSourceFileForPage } from './files'
-import { writeFunctionConfiguration } from './functionsMetadata'
+import { writeFunctionConfiguration } from './functionsMetaData'
 import { getFunctionNameForPage } from './utils'
 
 export interface ApiRouteConfig {

--- a/packages/runtime/src/helpers/functions.ts
+++ b/packages/runtime/src/helpers/functions.ts
@@ -22,7 +22,7 @@ import { getResolverForPages, getResolverForSourceFiles } from '../templates/get
 
 import { ApiConfig, ApiRouteType, extractConfigFromFile } from './analysis'
 import { getSourceFileForPage } from './files'
-import { writeFunctionConfiguration } from './functionsMetaData'
+import { writeFunctionConfiguration } from './functionsMetadata'
 import { getFunctionNameForPage } from './utils'
 
 export interface ApiRouteConfig {

--- a/packages/runtime/src/helpers/functionsMetaData.ts
+++ b/packages/runtime/src/helpers/functionsMetaData.ts
@@ -35,7 +35,8 @@ export interface FunctionInfo {
 export const writeFunctionConfiguration = async (functionInfo: FunctionInfo) => {
   const { functionName, functionTitle, functionsDir } = functionInfo
   const pluginPackagePath = '.netlify/plugins/package.json'
-  const nodeModulesPath = join(resolveModuleRoot(NEXT_PLUGIN), 'package.json')
+  const moduleRoot = resolveModuleRoot(NEXT_PLUGIN)
+  const nodeModulesPath = moduleRoot ? join(moduleRoot, 'package.json') : null
 
   const nextPluginVersion =
     (await getNextRuntimeVersion(nodeModulesPath, true)) ||

--- a/packages/runtime/src/helpers/functionsMetaData.ts
+++ b/packages/runtime/src/helpers/functionsMetaData.ts
@@ -38,12 +38,15 @@ export const writeFunctionConfiguration = async (functionInfo: FunctionInfo) => 
   const nodeModulesPath = join(resolveModuleRoot(NEXT_PLUGIN), 'package.json')
 
   const nextPluginVersion =
-    (await getNextRuntimeVersion(nodeModulesPath, true)) || (await getNextRuntimeVersion(pluginPackagePath, false))
+    (await getNextRuntimeVersion(nodeModulesPath, true)) ||
+    (await getNextRuntimeVersion(pluginPackagePath, false)) ||
+    // The runtime version should always be available, but if it's not, return 'unknown'
+    'unknown'
 
   const metadata = {
     config: {
       name: functionTitle,
-      generator: `${NEXT_PLUGIN_NAME}@${nextPluginVersion || 'unknown'}`,
+      generator: `${NEXT_PLUGIN_NAME}@${nextPluginVersion}`,
     },
     version: 1,
   }

--- a/packages/runtime/src/helpers/functionsMetaData.ts
+++ b/packages/runtime/src/helpers/functionsMetaData.ts
@@ -17,14 +17,25 @@ const checkForPackage = async (packageDir: string, nodeModule: boolean) => {
   return nextPlugin
 }
 
+// The information needed to create a function configuration file
+export interface FunctionInfo {
+  // The name of the function, e.g. `___netlify-handler`
+  functionName: string
+
+  // The name of the function that will be displayed in logs, e.g. `Next.js SSR handler`
+  functionTitle: string
+
+  // The directory where the function is located, e.g. `.netlify/functions`
+  functionsDir: string
+}
+
 /**
- * Creates a function configuration file for the given function
+ * Creates a function configuration file for the given function.
  *
- * @param functionName The name of the function, e.g. `___netlify-handler`
- * @param functionTitle The name of the function that will be displayed in logs, e.g. `Next.js SSR handler`
- * @param functionsDir The directory where the function is located, e.g. `.netlify/functions`
+ * @param functionInfo The information needed to create a function configuration file
  */
-export const writeFunctionConfiguration = async (functionName: string, functionTitle: string, functionsDir: string) => {
+export const writeFunctionConfiguration = async (functionInfo: FunctionInfo) => {
+  const { functionName, functionTitle, functionsDir } = functionInfo
   const pluginPackagePath = '.netlify/plugins/package.json'
   const nodeModulesPath = join(resolveModuleRoot(NEXT_PLUGIN), 'package.json')
 

--- a/packages/runtime/src/helpers/functionsMetaData.ts
+++ b/packages/runtime/src/helpers/functionsMetaData.ts
@@ -35,7 +35,7 @@ export const writeFunctionConfiguration = async (functionName: string, functionT
   const metadata = {
     config: {
       name: functionTitle,
-      generator: nextPluginVersion ? `${NEXT_PLUGIN_NAME}@${nextPluginVersion}` : 'Next Runtime Version Not Found',
+      generator: `${NEXT_PLUGIN_NAME}@${nextPluginVersion || 'version-not-found'}`,
     },
     version: 1,
   }

--- a/packages/runtime/src/helpers/functionsMetaData.ts
+++ b/packages/runtime/src/helpers/functionsMetaData.ts
@@ -26,8 +26,7 @@ const checkForPackage = async (packageDir: string, nodeModule: boolean) => {
  */
 export const writeFunctionConfiguration = async (functionName: string, functionTitle: string, functionsDir: string) => {
   const pluginPackagePath = '.netlify/plugins/package.json'
-  const ProjDir = resolveModuleRoot(NEXT_PLUGIN)
-  const nodeModulesPath = `${ProjDir}/package.json`
+  const nodeModulesPath = join(resolveModuleRoot(NEXT_PLUGIN), 'package.json')
 
   const nextPluginVersion =
     (await checkForPackage(nodeModulesPath, true)) || (await checkForPackage(pluginPackagePath, false))

--- a/packages/runtime/src/helpers/functionsMetaData.ts
+++ b/packages/runtime/src/helpers/functionsMetaData.ts
@@ -5,16 +5,14 @@ import { NEXT_PLUGIN, NEXT_PLUGIN_NAME } from '../constants'
 
 import { resolveModuleRoot } from './config'
 
-const checkForPackage = async (packageDir: string, nodeModule: boolean) => {
-  const packagePlugin = existsSync(packageDir) ? await readJSON(packageDir) : null
-  let nextPlugin
-  if (!nodeModule && packagePlugin) {
-    nextPlugin = packagePlugin.dependencies[NEXT_PLUGIN] ? packagePlugin.dependencies[NEXT_PLUGIN] : null
-  } else if (nodeModule && packagePlugin) {
-    nextPlugin = packagePlugin.version ? packagePlugin.version : null
+const getNextRuntimeVersion = async (packageJsonPath: string, useNodeModulesPath: boolean) => {
+  if (!existsSync(packageJsonPath)) {
+    return
   }
 
-  return nextPlugin
+  const packagePlugin = await readJSON(packageJsonPath)
+
+  return useNodeModulesPath ? packagePlugin.version : packagePlugin.dependencies[NEXT_PLUGIN]
 }
 
 // The information needed to create a function configuration file
@@ -40,7 +38,7 @@ export const writeFunctionConfiguration = async (functionInfo: FunctionInfo) => 
   const nodeModulesPath = join(resolveModuleRoot(NEXT_PLUGIN), 'package.json')
 
   const nextPluginVersion =
-    (await checkForPackage(nodeModulesPath, true)) || (await checkForPackage(pluginPackagePath, false))
+    (await getNextRuntimeVersion(nodeModulesPath, true)) || (await getNextRuntimeVersion(pluginPackagePath, false))
 
   const metadata = {
     config: {

--- a/packages/runtime/src/helpers/functionsMetaData.ts
+++ b/packages/runtime/src/helpers/functionsMetaData.ts
@@ -35,7 +35,7 @@ export const writeFunctionConfiguration = async (functionName: string, functionT
   const metadata = {
     config: {
       name: functionTitle,
-      generator: `${NEXT_PLUGIN_NAME}@${nextPluginVersion || 'version-not-found'}`,
+      generator: nextPluginVersion ? `${NEXT_PLUGIN_NAME}@${nextPluginVersion}` : 'Next Runtime Version Not Found',
     },
     version: 1,
   }

--- a/packages/runtime/src/helpers/functionsMetaData.ts
+++ b/packages/runtime/src/helpers/functionsMetaData.ts
@@ -43,7 +43,7 @@ export const writeFunctionConfiguration = async (functionInfo: FunctionInfo) => 
   const metadata = {
     config: {
       name: functionTitle,
-      generator: `${NEXT_PLUGIN_NAME}@${nextPluginVersion || 'version-not-found'}`,
+      generator: `${NEXT_PLUGIN_NAME}@${nextPluginVersion || 'unknown'}`,
     },
     version: 1,
   }

--- a/packages/runtime/src/helpers/functionsMetaData.ts
+++ b/packages/runtime/src/helpers/functionsMetaData.ts
@@ -1,0 +1,44 @@
+import { existsSync, readJSON, writeFile } from 'fs-extra'
+import { join } from 'pathe'
+
+import { NEXT_PLUGIN, NEXT_PLUGIN_NAME } from '../constants'
+
+import { resolveModuleRoot } from './config'
+
+const checkForPackage = async (packageDir: string, nodeModule: boolean) => {
+  const packagePlugin = existsSync(packageDir) ? await readJSON(packageDir) : null
+  let nextPlugin
+  if (!nodeModule && packagePlugin) {
+    nextPlugin = packagePlugin.dependencies[NEXT_PLUGIN] ? packagePlugin.dependencies[NEXT_PLUGIN] : null
+  } else if (nodeModule && packagePlugin) {
+    nextPlugin = packagePlugin.version ? packagePlugin.version : null
+  }
+
+  return nextPlugin
+}
+
+/**
+ * Creates a function configuration file for the given function
+ *
+ * @param functionName The name of the function, e.g. `___netlify-handler`
+ * @param functionTitle The name of the function that will be displayed in logs, e.g. `Next.js SSR handler`
+ * @param functionsDir The directory where the function is located, e.g. `.netlify/functions`
+ */
+export const writeFunctionConfiguration = async (functionName: string, functionTitle: string, functionsDir: string) => {
+  const pluginPackagePath = '.netlify/plugins/package.json'
+  const ProjDir = resolveModuleRoot(NEXT_PLUGIN)
+  const nodeModulesPath = `${ProjDir}/package.json`
+
+  const nextPluginVersion =
+    (await checkForPackage(nodeModulesPath, true)) || (await checkForPackage(pluginPackagePath, false))
+
+  const metadata = {
+    config: {
+      name: functionTitle,
+      generator: nextPluginVersion ? `${NEXT_PLUGIN_NAME}@${nextPluginVersion}` : 'Next Runtime Version Not Found',
+    },
+    version: 1,
+  }
+
+  await writeFile(join(functionsDir, functionName, `${functionName}.json`), JSON.stringify(metadata))
+}

--- a/test/functionsMetaData.spec.ts
+++ b/test/functionsMetaData.spec.ts
@@ -40,7 +40,7 @@ describe('writeFunctionConfiguration', () => {
     }
 
     const filePathToSaveTo = join(functionsDir, functionName, `${functionName}.json`)
-    await writeFunctionConfiguration(functionName, functionTitle, functionsDir)
+    await writeFunctionConfiguration({ functionName, functionTitle, functionsDir })
     const actual = await readJSON(filePathToSaveTo)
 
     expect(actual).toEqual(expected)
@@ -73,7 +73,7 @@ describe('writeFunctionConfiguration', () => {
     }
 
     const filePathToSaveTo = join(functionsDir, functionName, `${functionName}.json`)
-    await writeFunctionConfiguration(functionName, functionTitle, functionsDir)
+    await writeFunctionConfiguration({ functionName, functionTitle, functionsDir })
     const actual = await readJSON(filePathToSaveTo)
 
     expect(actual).toEqual(expected)
@@ -97,7 +97,7 @@ describe('writeFunctionConfiguration', () => {
     }
 
     const filePathToSaveTo = join(functionsDir, functionName, `${functionName}.json`)
-    await writeFunctionConfiguration(functionName, functionTitle, functionsDir)
+    await writeFunctionConfiguration({ functionName, functionTitle, functionsDir })
     const actual = await readJSON(filePathToSaveTo)
 
     expect(actual).toEqual(expected)

--- a/test/functionsMetaData.spec.ts
+++ b/test/functionsMetaData.spec.ts
@@ -91,7 +91,7 @@ describe('writeFunctionConfiguration', () => {
     const expected = {
       config: {
         name: functionTitle,
-        generator: 'Next Runtime Version Not Found',
+        generator: '@netlify/next-runtime@version-not-found',
       },
       version: 1,
     }

--- a/test/functionsMetaData.spec.ts
+++ b/test/functionsMetaData.spec.ts
@@ -1,0 +1,105 @@
+import { readJSON } from 'fs-extra'
+import mock from 'mock-fs'
+import { join } from 'pathe'
+import { NEXT_PLUGIN_NAME } from '../packages/runtime/src/constants'
+import { writeFunctionConfiguration } from '../packages/runtime/src/helpers/functionsMetaData'
+
+describe('writeFunctionConfiguration', () => {
+  afterEach(() => {
+    mock.restore()
+  })
+
+  it('should write the configuration for a function using node modules version of @netlify/plugin-nextjs', async () => {
+    const nextRuntimeVersion = '23.4.5'
+
+    mock({
+      '.netlify/plugins/package.json': JSON.stringify({
+        name: 'test',
+        version: '1.0.0',
+        dependencies: {
+          '@netlify/plugin-nextjs': '29.3.4',
+        },
+      }),
+      'node_modules/@netlify/plugin-nextjs/package.json': JSON.stringify({
+        name: '@netlify/plugin-nextjs',
+        version: nextRuntimeVersion,
+      }),
+      '.netlify/functions/some-folder/someFunctionName': {},
+    })
+
+    const functionName = 'someFunctionName'
+    const functionTitle = 'some function title'
+    const functionsDir = '.netlify/functions/some-folder'
+
+    const expected = {
+      config: {
+        name: functionTitle,
+        generator: `${NEXT_PLUGIN_NAME}@${nextRuntimeVersion}`,
+      },
+      version: 1,
+    }
+
+    const filePathToSaveTo = join(functionsDir, functionName, `${functionName}.json`)
+    await writeFunctionConfiguration(functionName, functionTitle, functionsDir)
+    const actual = await readJSON(filePathToSaveTo)
+
+    expect(actual).toEqual(expected)
+  })
+
+  it('should write the configuration for a function using version of @netlify/plugin-nextjs in package.json', async () => {
+    const nextRuntimeVersion = '23.4.5'
+
+    mock({
+      '.netlify/plugins/package.json': JSON.stringify({
+        name: 'test',
+        version: '1.0.0',
+        dependencies: {
+          '@netlify/plugin-nextjs': nextRuntimeVersion,
+        },
+      }),
+      '.netlify/functions/some-folder/someFunctionName': {},
+    })
+
+    const functionName = 'someFunctionName'
+    const functionTitle = 'some function title'
+    const functionsDir = '.netlify/functions/some-folder'
+
+    const expected = {
+      config: {
+        name: functionTitle,
+        generator: `${NEXT_PLUGIN_NAME}@${nextRuntimeVersion}`,
+      },
+      version: 1,
+    }
+
+    const filePathToSaveTo = join(functionsDir, functionName, `${functionName}.json`)
+    await writeFunctionConfiguration(functionName, functionTitle, functionsDir)
+    const actual = await readJSON(filePathToSaveTo)
+
+    expect(actual).toEqual(expected)
+  })
+
+  it('should write the configuration for a function with runtime version not found', async () => {
+    mock({
+      '.netlify/functions/some-folder/someFunctionName': {},
+    })
+
+    const functionName = 'someFunctionName'
+    const functionTitle = 'some function title'
+    const functionsDir = '.netlify/functions/some-folder'
+
+    const expected = {
+      config: {
+        name: functionTitle,
+        generator: 'Next Runtime Version Not Found',
+      },
+      version: 1,
+    }
+
+    const filePathToSaveTo = join(functionsDir, functionName, `${functionName}.json`)
+    await writeFunctionConfiguration(functionName, functionTitle, functionsDir)
+    const actual = await readJSON(filePathToSaveTo)
+
+    expect(actual).toEqual(expected)
+  })
+})

--- a/test/functionsMetaData.spec.ts
+++ b/test/functionsMetaData.spec.ts
@@ -91,7 +91,7 @@ describe('writeFunctionConfiguration', () => {
     const expected = {
       config: {
         name: functionTitle,
-        generator: '@netlify/next-runtime@version-not-found',
+        generator: '@netlify/next-runtime@unknown',
       },
       version: 1,
     }

--- a/test/functionsMetaData.spec.ts
+++ b/test/functionsMetaData.spec.ts
@@ -2,7 +2,7 @@ import { readJSON } from 'fs-extra'
 import mock from 'mock-fs'
 import { join } from 'pathe'
 import { NEXT_PLUGIN_NAME } from '../packages/runtime/src/constants'
-import { writeFunctionConfiguration } from '../packages/runtime/src/helpers/functionsMetadata'
+import { writeFunctionConfiguration } from '../packages/runtime/src/helpers/functionsMetaData'
 
 describe('writeFunctionConfiguration', () => {
   afterEach(() => {
@@ -91,7 +91,7 @@ describe('writeFunctionConfiguration', () => {
     const expected = {
       config: {
         name: functionTitle,
-        generator: '@netlify/next-runtime@version-not-found',
+        generator: 'Next Runtime Version Not Found',
       },
       version: 1,
     }

--- a/test/functionsMetaData.spec.ts
+++ b/test/functionsMetaData.spec.ts
@@ -2,7 +2,7 @@ import { readJSON } from 'fs-extra'
 import mock from 'mock-fs'
 import { join } from 'pathe'
 import { NEXT_PLUGIN_NAME } from '../packages/runtime/src/constants'
-import { writeFunctionConfiguration } from '../packages/runtime/src/helpers/functionsMetaData'
+import { writeFunctionConfiguration } from '../packages/runtime/src/helpers/functionsMetadata'
 
 describe('writeFunctionConfiguration', () => {
   afterEach(() => {
@@ -91,7 +91,7 @@ describe('writeFunctionConfiguration', () => {
     const expected = {
       config: {
         name: functionTitle,
-        generator: 'Next Runtime Version Not Found',
+        generator: '@netlify/next-runtime@version-not-found',
       },
       version: 1,
     }


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/netlify/next-runtime/blob/main/CONTRIBUTING.md. -->

### Summary
This update creates a metadata file that will allow us to update the naming of our generated functions within the UI and will help us keep track of the nextjs-runtime versions being used.

We ran into some errors within the previous PR that were seemingly unrelated to our changes and transferred everything over. 
Prev: https://github.com/netlify/next-runtime/pull/1973

closes https://github.com/netlify/pod-ecosystem-frameworks/issues/407
closes https://github.com/netlify/pod-ecosystem-frameworks/issues/376

<!-- Provide a brief summary of the change. -->

### Test plan
#### Netlify UI test
1. Within the Netlify UI go to the demo site and go to the Functions tab 
2. In the Functions search bar enter 1999 for the repo
3. Should see Next.js SSR handler, Next.js ISR handler, and next/image handler

#### Version test
1. Should be able to see the version being returned within [Humio](https://cloud.us.humio.com/netlify-us-production/search?end=1679085696147&live=false&query=%24proxy()%0A%7C%20proxy_type%20%3D%20lambda%0A%7C%20generator%20!%3D%22%22%0A%7C%20groupBy(%5Bgenerator%2C%20host%5D)%0A%7C%20generator%20%3D%20%2F%40netlify%5C%2Fnext-runtime%2F&start=1678999296147&tz=America%2FChicago)

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
