### PR TITLE
fix: use `IMAGE_FUNCTION_NAME` constant

### DIFF
--- a/packages/runtime/src/helpers/config.ts
+++ b/packages/runtime/src/helpers/config.ts
@@ -6,7 +6,7 @@ import type { NextConfigComplete } from 'next/dist/server/config-shared'
 import { join, dirname, relative } from 'pathe'
 import slash from 'slash'
 
-import { HANDLER_FUNCTION_NAME, ODB_FUNCTION_NAME } from '../constants'
+import { HANDLER_FUNCTION_NAME, IMAGE_FUNCTION_NAME, ODB_FUNCTION_NAME } from '../constants'
 
 import type { RoutesManifest } from './types'
 import { escapeStringRegexp } from './utils'
@@ -107,10 +107,9 @@ export const configureHandlerFunctions = async ({
   const files = config.files || []
   const cssFilesToInclude = files.filter((f) => f.startsWith(`${publish}/static/css/`))
 
-  /* eslint-disable no-underscore-dangle */
   if (!destr(process.env.DISABLE_IPX)) {
-    netlifyConfig.functions._ipx ||= {}
-    netlifyConfig.functions._ipx.node_bundler = 'nft'
+    netlifyConfig.functions[IMAGE_FUNCTION_NAME] ||= {}
+    netlifyConfig.functions[IMAGE_FUNCTION_NAME].node_bundler = 'nft'
   }
 
   // If the user has manually added the module to included_files, then don't exclude it
@@ -118,7 +117,6 @@ export const configureHandlerFunctions = async ({
     (moduleName) => !hasManuallyAddedModule({ netlifyConfig, moduleName }),
   )
 
-  /* eslint-enable no-underscore-dangle */
   ;[HANDLER_FUNCTION_NAME, ODB_FUNCTION_NAME, '_api_*'].forEach((functionName) => {
     netlifyConfig.functions[functionName] ||= { included_files: [], external_node_modules: [] }
     netlifyConfig.functions[functionName].node_bundler = 'nft'

--- a/packages/runtime/src/helpers/edge.ts
+++ b/packages/runtime/src/helpers/edge.ts
@@ -10,6 +10,8 @@ import type { MiddlewareManifest } from 'next/dist/build/webpack/plugins/middlew
 import type { RouteHas } from 'next/dist/lib/load-custom-routes'
 import { outdent } from 'outdent'
 
+import { IMAGE_FUNCTION_NAME } from '../constants'
+
 import { getRequiredServerFiles, NextConfig } from './config'
 import { makeLocaleOptional, stripLookahead, transformCaptureGroups } from './matchers'
 import { RoutesManifest } from './types'
@@ -465,7 +467,7 @@ export const writeEdgeFunctions = async ({
     await ensureDir(edgeFunctionDir)
     await copyEdgeSourceFile({ edgeFunctionDir, file: 'ipx.ts', target: 'index.ts' })
     await copyFile(
-      join('.netlify', 'functions-internal', '_ipx', 'imageconfig.json'),
+      join('.netlify', 'functions-internal', IMAGE_FUNCTION_NAME, 'imageconfig.json'),
       join(edgeFunctionDir, 'imageconfig.json'),
     )
     manifest.functions.push({


### PR DESCRIPTION
### Summary

While looking into https://github.com/netlify/pod-ecosystem-frameworks/issues/376 I searched for the usage of `IMAGE_FUNCTION_NAME` as the other constants showed all their usages. We had a couple of instances where we used `_ipx` instead of the constant and thus couldn't find it immediately.

So this is a small QoL PR to use the constant in all relevant places.
