### PR TITLE
fix: data route rewrite for i18n root route

### DIFF
--- a/packages/runtime/src/helpers/utils.ts
+++ b/packages/runtime/src/helpers/utils.ts
@@ -74,7 +74,7 @@ export const generateNetlifyRoutes = ({
 }) => [...(withData ? toNetlifyRoute(dataRoute) : []), ...toNetlifyRoute(route)]
 
 export const routeToDataRoute = (route: string, buildId: string, locale?: string) =>
-  `/_next/data/${buildId}${locale ? `/${locale}` : ''}${route === '/' ? '/index' : route}.json`
+  `/_next/data/${buildId}${locale ? `/${locale}` : ''}${route === '/' ? (locale ? '' : '/index') : route}.json`
 
 // Default locale is served from root, not localized
 export const localizeRoute = (route: string, locale: string, defaultLocale: string) =>


### PR DESCRIPTION
### Summary

The runtime creates rewrites that route ISR pages (and their data routes) to the ODB handler. However, the runtime was not correctly handling data route rewrites on ISR index pages for i18n sites.

On non-i18n sites, the index data route has the 'index' suffix, e.g. `/_next/data/build-id/index.json`
On i18n sites, the index data route uses the locale instead, e.g. `/_next/data/build-id/en.json`, but the runtime was still using the 'index' suffix. This PR fixes that.

### Test plan

1. Visit the Deploy Preview and navigate away from the home page
2. Open the network inspector and mouseover any link back to the homepage
3. Observe a request is made to `/_next/data/build-id/en.json` instead of `/_next/data/build-id/index.json`
4. Observe the response has an `x-nf-render-mode: odb ttl=60` header and not an `x-nf-render-mode: ssr` header

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

Closes netlify/pod-ecosystem-frameworks#429

![danger cat](https://pbs.twimg.com/media/FrqzmvtaAAAX5OL?format=png&name=small)