### PR TITLE
fix: add fallback ID for scheduled test run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
     - cron: '0 0 * * *'
 
 concurrency:
-  group: ${{ github.head_ref }}
+  group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
### Summary

The scheduled tests run fails consistently due to incorrect syntax in the workflow.
This is due to the `group: {{github.head_ref}}` reference being blank if the workflow isn't executed from a pull request.

[Test workflow](https://github.com/netlify/next-runtime/blob/92e209f177312d4c4e6b64f8feb6c80670e46d8d/.github/workflows/test.yml#L11)

```
concurrency:
  group: ${{ github.head_ref }}
  cancel-in-progress: true
```

This PR adds a default fallback which is guaranteed to be unique and defined for the run.
See: https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value

Fixes netlify/pod-ecosystem-frameworks#434

### Test plan

1. Ensure that the PR tests still runs
2. Verify that the nightly tests now runs without failure

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

![image](https://user-images.githubusercontent.com/1965510/227512061-4e592f62-032c-4ecf-b465-d9fbdeb14a62.png)

---
