### PR TITLE
feat: support edge runtime key

### DIFF
--- a/demos/default/pages/api/og.tsx
+++ b/demos/default/pages/api/og.tsx
@@ -2,7 +2,7 @@ import { ImageResponse } from '@vercel/og'
 import { NextRequest } from 'next/server'
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 export default async function handler(req: NextRequest) {

--- a/demos/middleware/pages/api/edge.ts
+++ b/demos/middleware/pages/api/edge.ts
@@ -1,5 +1,5 @@
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 export default (req) => new Response('Hello world!')

--- a/packages/runtime/src/helpers/analysis.ts
+++ b/packages/runtime/src/helpers/analysis.ts
@@ -11,7 +11,7 @@ export const enum ApiRouteType {
 
 export interface ApiStandardConfig {
   type?: never
-  runtime?: 'nodejs' | 'experimental-edge'
+  runtime?: 'nodejs' | 'experimental-edge' | 'edge'
   schedule?: never
 }
 
@@ -39,7 +39,7 @@ export const validateConfigValue = (config: ApiConfig, apiFilePath: string): con
       )
       return false
     }
-    if ((config as ApiConfig).runtime === 'experimental-edge') {
+    if ((config as ApiConfig).runtime === 'experimental-edge' || (config as ApiConfig).runtime === 'edge') {
       console.error(
         `Invalid config value in ${relative(
           process.cwd(),
@@ -60,7 +60,7 @@ export const validateConfigValue = (config: ApiConfig, apiFilePath: string): con
       )
       return false
     }
-    if (config.type && (config as ApiConfig).runtime === 'experimental-edge') {
+    if (config.type && ((config as ApiConfig).runtime === 'experimental-edge' || (config as ApiConfig).runtime === 'edge')) {
       console.error(
         `Invalid config value in ${relative(
           process.cwd(),

--- a/packages/runtime/src/helpers/analysis.ts
+++ b/packages/runtime/src/helpers/analysis.ts
@@ -39,7 +39,7 @@ export const validateConfigValue = (config: ApiConfig, apiFilePath: string): con
       )
       return false
     }
-    if ((config as ApiConfig).runtime === 'experimental-edge' || (config as ApiConfig).runtime === 'edge') {
+    if (['experimental-edge', 'edge'].includes((config as ApiConfig).runtime)) {
       console.error(
         `Invalid config value in ${relative(
           process.cwd(),
@@ -60,7 +60,7 @@ export const validateConfigValue = (config: ApiConfig, apiFilePath: string): con
       )
       return false
     }
-    if (config.type && ((config as ApiConfig).runtime === 'experimental-edge' || (config as ApiConfig).runtime === 'edge')) {
+    if (config.type && ['experimental-edge', 'edge'].includes((config as ApiConfig).runtime)) {
       console.error(
         `Invalid config value in ${relative(
           process.cwd(),

--- a/packages/runtime/src/helpers/analysis.ts
+++ b/packages/runtime/src/helpers/analysis.ts
@@ -29,6 +29,8 @@ export interface ApiBackgroundConfig {
 
 export type ApiConfig = ApiStandardConfig | ApiScheduledConfig | ApiBackgroundConfig
 
+export const isEdgeConfig = (config: string) => ['experimental-edge', 'edge'].includes(config)
+
 export const validateConfigValue = (config: ApiConfig, apiFilePath: string): config is ApiConfig => {
   if (config.type === ApiRouteType.SCHEDULED) {
     if (!config.schedule) {
@@ -39,7 +41,7 @@ export const validateConfigValue = (config: ApiConfig, apiFilePath: string): con
       )
       return false
     }
-    if (['experimental-edge', 'edge'].includes((config as ApiConfig).runtime)) {
+    if (isEdgeConfig((config as ApiConfig).runtime)) {
       console.error(
         `Invalid config value in ${relative(
           process.cwd(),
@@ -60,7 +62,7 @@ export const validateConfigValue = (config: ApiConfig, apiFilePath: string): con
       )
       return false
     }
-    if (config.type && ['experimental-edge', 'edge'].includes((config as ApiConfig).runtime)) {
+    if (config.type && isEdgeConfig((config as ApiConfig).runtime)) {
       console.error(
         `Invalid config value in ${relative(
           process.cwd(),

--- a/packages/runtime/src/helpers/functions.ts
+++ b/packages/runtime/src/helpers/functions.ts
@@ -43,7 +43,7 @@ export const generateFunctions = async (
 
   for (const { route, config, compiled } of apiRoutes) {
     // Don't write a lambda if the runtime is edge
-    if (config.runtime === 'experimental-edge') {
+    if (config.runtime === 'experimental-edge' || config.runtime === 'edge') {
       continue
     }
     const apiHandlerSource = await getApiHandler({

--- a/packages/runtime/src/helpers/functions.ts
+++ b/packages/runtime/src/helpers/functions.ts
@@ -20,7 +20,7 @@ import { getApiHandler } from '../templates/getApiHandler'
 import { getHandler } from '../templates/getHandler'
 import { getResolverForPages, getResolverForSourceFiles } from '../templates/getPageResolver'
 
-import { ApiConfig, ApiRouteType, extractConfigFromFile } from './analysis'
+import { ApiConfig, ApiRouteType, extractConfigFromFile, isEdgeConfig } from './analysis'
 import { getSourceFileForPage } from './files'
 import { writeFunctionConfiguration } from './functionsMetaData'
 import { getFunctionNameForPage } from './utils'
@@ -43,7 +43,7 @@ export const generateFunctions = async (
 
   for (const { route, config, compiled } of apiRoutes) {
     // Don't write a lambda if the runtime is edge
-    if (['experimental-edge', 'edge'].includes(config.runtime)) {
+    if (isEdgeConfig(config.runtime)) {
       continue
     }
     const apiHandlerSource = await getApiHandler({

--- a/packages/runtime/src/helpers/functions.ts
+++ b/packages/runtime/src/helpers/functions.ts
@@ -43,7 +43,7 @@ export const generateFunctions = async (
 
   for (const { route, config, compiled } of apiRoutes) {
     // Don't write a lambda if the runtime is edge
-    if (config.runtime === 'experimental-edge' || config.runtime === 'edge') {
+    if (['experimental-edge', 'edge'].includes(config.runtime)) {
       continue
     }
     const apiHandlerSource = await getApiHandler({

--- a/test/e2e/app-dir/app-edge-global/next.config.js
+++ b/test/e2e/app-dir/app-edge-global/next.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   experimental: {
     appDir: true,
-    runtime: 'experimental-edge',
+    runtime: 'edge',
   },
 }

--- a/test/e2e/app-dir/app-edge/app/app-edge/page.tsx
+++ b/test/e2e/app-dir/app-edge/app/app-edge/page.tsx
@@ -5,4 +5,4 @@ export default function Page() {
   return <p>Node!</p>
 }
 
-export const runtime = 'experimental-edge'
+export const runtime = 'edge'

--- a/test/e2e/app-dir/app-edge/pages/pages-edge.tsx
+++ b/test/e2e/app-dir/app-edge/pages/pages-edge.tsx
@@ -2,4 +2,4 @@ export default function Page() {
   return <p>pages-edge-ssr</p>
 }
 
-export const config = { runtime: 'experimental-edge' }
+export const config = { runtime: 'edge' }

--- a/test/e2e/app-dir/app-middleware/pages/api/dump-headers-edge.js
+++ b/test/e2e/app-dir/app-middleware/pages/api/dump-headers-edge.js
@@ -1,5 +1,5 @@
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 export default (req) => {

--- a/test/e2e/app-dir/app/app/(rootonly)/dashboard/hello/page.js
+++ b/test/e2e/app-dir/app/app/(rootonly)/dashboard/hello/page.js
@@ -6,4 +6,4 @@ export default function HelloPage(props) {
   )
 }
 
-export const runtime = 'experimental-edge'
+export const runtime = 'edge'

--- a/test/e2e/app-dir/app/app/dashboard/page.js
+++ b/test/e2e/app-dir/app/app/dashboard/page.js
@@ -13,4 +13,4 @@ export default function DashboardPage(props) {
   )
 }
 
-export const runtime = 'experimental-edge'
+export const runtime = 'edge'

--- a/test/e2e/app-dir/app/app/edge-apis/cookies/page.js
+++ b/test/e2e/app-dir/app/app/edge-apis/cookies/page.js
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers'
 
-export const runtime = 'experimental-edge'
+export const runtime = 'edge'
 
 export default function Page() {
   cookies()

--- a/test/e2e/app-dir/app/app/slow-page-no-loading/page.js
+++ b/test/e2e/app-dir/app/app/slow-page-no-loading/page.js
@@ -13,4 +13,4 @@ export default function SlowPage(props) {
   return <h1 id="slow-page-message">{data.message}</h1>
 }
 
-export const runtime = 'experimental-edge'
+export const runtime = 'edge'

--- a/test/e2e/app-dir/app/app/slow-page-with-loading/page.js
+++ b/test/e2e/app-dir/app/app/slow-page-with-loading/page.js
@@ -13,4 +13,4 @@ export default function SlowPage(props) {
   return <h1 id="slow-page-message">{data.message}</h1>
 }
 
-export const runtime = 'experimental-edge'
+export const runtime = 'edge'

--- a/test/e2e/app-dir/app/pages/api/hello.js
+++ b/test/e2e/app-dir/app/pages/api/hello.js
@@ -3,5 +3,5 @@ export default function api(req) {
 }
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }

--- a/test/e2e/app-dir/next-font/app/page.js
+++ b/test/e2e/app-dir/next-font/app/page.js
@@ -13,4 +13,4 @@ export default function HomePage() {
   )
 }
 
-export const runtime = 'experimental-edge'
+export const runtime = 'edge'

--- a/test/e2e/app-dir/next-image/app/page.js
+++ b/test/e2e/app-dir/next-image/app/page.js
@@ -12,4 +12,4 @@ export default function Page() {
   )
 }
 
-export const runtime = 'experimental-edge'
+export const runtime = 'edge'

--- a/test/e2e/app-dir/rsc-basic/app/edge/dynamic/[id]/page.js
+++ b/test/e2e/app-dir/rsc-basic/app/edge/dynamic/[id]/page.js
@@ -2,4 +2,4 @@ export default function page() {
   return 'dynamic route [id] page'
 }
 
-export const runtime = 'experimental-edge'
+export const runtime = 'edge'

--- a/test/e2e/app-dir/rsc-basic/app/edge/dynamic/page.js
+++ b/test/e2e/app-dir/rsc-basic/app/edge/dynamic/page.js
@@ -2,4 +2,4 @@ export default function page() {
   return 'dynamic route index page'
 }
 
-export const runtime = 'experimental-edge'
+export const runtime = 'edge'

--- a/test/e2e/disabled-tests/edge-render-getserversideprops/app/pages/[id].js
+++ b/test/e2e/disabled-tests/edge-render-getserversideprops/app/pages/[id].js
@@ -1,5 +1,5 @@
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 export default function Page(props) {

--- a/test/e2e/disabled-tests/edge-render-getserversideprops/app/pages/index.js
+++ b/test/e2e/disabled-tests/edge-render-getserversideprops/app/pages/index.js
@@ -1,5 +1,5 @@
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 export default function Page(props) {

--- a/test/e2e/disabled-tests/middleware-request-header-overrides/app/pages/api/dump-headers-edge.js
+++ b/test/e2e/disabled-tests/middleware-request-header-overrides/app/pages/api/dump-headers-edge.js
@@ -1,5 +1,5 @@
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 export default (req) => {

--- a/test/e2e/modified-tests/edge-can-use-wasm-files/index.test.ts
+++ b/test/e2e/modified-tests/edge-can-use-wasm-files/index.test.ts
@@ -49,7 +49,7 @@ describe('edge api endpoints can use wasm files', () => {
             const value = await increment(input);
             return new Response(null, { headers: { data: JSON.stringify({ input, value }) } });
           }
-          export const config = { runtime: 'experimental-edge' };
+          export const config = { runtime: 'edge' };
         `,
         'src/add.wasm': new FileRef(path.join(__dirname, './add.wasm')),
         'src/add.js': `

--- a/test/e2e/modified-tests/edge-compiler-can-import-blob-assets/app/pages/api/edge.js
+++ b/test/e2e/modified-tests/edge-compiler-can-import-blob-assets/app/pages/api/edge.js
@@ -1,4 +1,4 @@
-export const config = { runtime: 'experimental-edge' }
+export const config = { runtime: 'edge' }
 
 /**
  * @param {import('next/server').NextRequest} req

--- a/test/e2e/modified-tests/middleware-general/app/pages/api/edge-search-params.js
+++ b/test/e2e/modified-tests/middleware-general/app/pages/api/edge-search-params.js
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
 
-export const config = { runtime: 'experimental-edge', regions: 'default' }
+export const config = { runtime: 'edge', regions: 'default' }
 
 /**
  * @param {import('next/server').NextRequest}

--- a/test/e2e/modified-tests/skip-trailing-slash-redirect/app/pages/api/test-cookie-edge.js
+++ b/test/e2e/modified-tests/skip-trailing-slash-redirect/app/pages/api/test-cookie-edge.js
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 export default function handler(req) {

--- a/test/e2e/modified-tests/streaming-ssr/streaming-ssr/pages/api/user/[id].js
+++ b/test/e2e/modified-tests/streaming-ssr/streaming-ssr/pages/api/user/[id].js
@@ -3,5 +3,5 @@ export default async function handler() {
 }
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }

--- a/test/e2e/modified-tests/streaming-ssr/streaming-ssr/pages/hello.js
+++ b/test/e2e/modified-tests/streaming-ssr/streaming-ssr/pages/hello.js
@@ -9,4 +9,4 @@ export default function Page() {
   )
 }
 
-export const config = { runtime: 'experimental-edge' }
+export const config = { runtime: 'edge' }

--- a/test/e2e/modified-tests/streaming-ssr/streaming-ssr/pages/index.js
+++ b/test/e2e/modified-tests/streaming-ssr/streaming-ssr/pages/index.js
@@ -11,4 +11,4 @@ export default function Page() {
   )
 }
 
-export const config = { runtime: 'experimental-edge' }
+export const config = { runtime: 'edge' }

--- a/test/e2e/modified-tests/streaming-ssr/streaming-ssr/pages/multi-byte.js
+++ b/test/e2e/modified-tests/streaming-ssr/streaming-ssr/pages/multi-byte.js
@@ -6,4 +6,4 @@ export default function Page() {
   )
 }
 
-export const config = { runtime: 'experimental-edge' }
+export const config = { runtime: 'edge' }

--- a/test/e2e/modified-tests/streaming-ssr/streaming-ssr/pages/router.js
+++ b/test/e2e/modified-tests/streaming-ssr/streaming-ssr/pages/router.js
@@ -7,5 +7,5 @@ export default () => {
 }
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }

--- a/test/e2e/tests/edge-api-endpoints-can-receive-body/app/pages/api/edge.js
+++ b/test/e2e/tests/edge-api-endpoints-can-receive-body/app/pages/api/edge.js
@@ -7,5 +7,5 @@ export default async (req) => {
 }
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }

--- a/test/e2e/tests/edge-api-endpoints-can-receive-body/app/pages/api/index.js
+++ b/test/e2e/tests/edge-api-endpoints-can-receive-body/app/pages/api/index.js
@@ -7,5 +7,5 @@ export default async (req) => {
 }
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }

--- a/test/e2e/tests/og-api/app/pages/api/og.js
+++ b/test/e2e/tests/og-api/app/pages/api/og.js
@@ -2,7 +2,7 @@
 import { ImageResponse } from '@vercel/og'
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 export default function () {
@@ -21,6 +21,6 @@ export default function () {
       >
         Hello!
       </div>
-    )
+    ),
   )
 }

--- a/test/fixtures/analysis/background-edge.ts
+++ b/test/fixtures/analysis/background-edge.ts
@@ -6,5 +6,5 @@ export default (req, res) => {
 
 export const config = {
   type: 'experimental-background',
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }

--- a/test/fixtures/analysis/scheduled-edge.ts
+++ b/test/fixtures/analysis/scheduled-edge.ts
@@ -7,5 +7,5 @@ export default (req, res) => {
 export const config = {
   type: 'experimental-scheduled',
   schedule: '@daily',
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/netlify/next-runtime/blob/main/CONTRIBUTING.md. -->

### Summary

Adds support for 
```
export const config = {
  runtime: 'edge',
}
```
before, only `runtime: 'experimental-edge'` was supported.

### Test plan

1. Visit the middleware Deploy Preview 
2. Go to the /api/edge route -> It should display "Hello world"

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal
<img width="526" alt="Screenshot 2023-04-11 at 3 42 09 PM" src="https://user-images.githubusercontent.com/4700602/231271429-bd1a981c-733c-4682-b731-620895a3929c.png">

Fixes https://github.com/netlify/next-runtime/issues/1936

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
