### PR TITLE
fix: now data routes for dynamic routes filter even when null when creating the RSC data router

### DIFF
--- a/packages/runtime/src/templates/edge-shared/rsc-data.ts
+++ b/packages/runtime/src/templates/edge-shared/rsc-data.ts
@@ -44,7 +44,7 @@ export const getRscDataRouter = ({ routes: staticRoutes, dynamicRoutes }: Preren
   )
 
   const dynamicRouteMatcher = Object.values(dynamicRoutes)
-    .filter(({ dataRoute }) => dataRoute.endsWith('.rsc'))
+    .filter(({ dataRoute }) => dataRoute?.endsWith('.rsc'))
     .map(({ routeRegex }) => new RegExp(routeRegex))
 
   const matchesDynamicRscDataRoute = (pathname: string) => {

--- a/test/rsc-data.spec.ts
+++ b/test/rsc-data.spec.ts
@@ -8,7 +8,7 @@ const basePrerenderManifest: PrerenderManifest = {
 }
 
 describe('getRscDataRouter', () => {
-  it('should create a RSC data router when data routes are not present for routes', () => {
+  it('should filter static routes when creating the RSC data router', () => {
     const manifest: PrerenderManifest = {
       ...basePrerenderManifest,
       routes: {

--- a/test/rsc-data.spec.ts
+++ b/test/rsc-data.spec.ts
@@ -37,4 +37,36 @@ describe('getRscDataRouter', () => {
 
     expect(typeof rscDataRouter).toBe('function')
   })
+
+  it('should filter dynamic routes when creating the RSC data router', () => {
+    const manifest: PrerenderManifest = {
+      ...basePrerenderManifest,
+      dynamicRoutes: {
+        '/[slug]': {
+          routeRegex: '^\\/(?<slug>[^\\/]+?)(?:\\/)?$',
+          fallback: null,
+          dataRoute: null,
+          dataRouteRegex: '^\\/(?<slug>[^\\/]+?)(?:\\/)?$',
+        },
+        '/[slug]/[slug2]': {
+          routeRegex: '^\\/(?<slug>[^\\/]+?)(?:\\/)(?<slug2>[^\\/]+?)(?:\\/)?$',
+          fallback: null,
+          dataRoute: '/[slug]/[slug2].json.rsc',
+          dataRouteRegex: '^\\/(?<slug>[^\\/]+?)(?:\\/)(?<slug2>[^\\/]+?)(?:\\/)?$',
+        },
+      },
+    }
+
+    let rscDataRouter
+
+    // Normally type checking would pick this up, but because this file is copied when generating
+    // edge functions for the build, we need to make sure it's valid for builds.
+    //
+    // See https://github.com/netlify/next-runtime/issues/1940
+    expect(() => {
+      rscDataRouter = getRscDataRouter(manifest)
+    }).not.toThrow()
+
+    expect(typeof rscDataRouter).toBe('function')
+  })
 })


### PR DESCRIPTION
### Summary

There was a TypeScript error that was not picked up as we copy them for the build. I've added some tests to cover this like we did in #2018.

Closes #1940

### Test plan

1. Ensure the deploy previews are green.
2. There are tests that cover this fix.

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [x] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.

<img src="https://media2.giphy.com/media/ciqopE4d0dKX6/giphy.gif" alt="someone petting an alapaca" />
