### PR TITLE
fix: shim require to include Buffer module

### DIFF
--- a/packages/runtime/src/helpers/edge.ts
+++ b/packages/runtime/src/helpers/edge.ts
@@ -263,7 +263,7 @@ export const writeDevEdgeFunction = async ({
  * Writes an edge function that routes RSC data requests to the `.rsc` route
  */
 
-export const writeRscDataEdgeFunction = async ({
+export const generateRscDataEdgeManifest = async ({
   prerenderManifest,
   appPathRoutesManifest,
 }: {
@@ -368,7 +368,7 @@ export const writeEdgeFunctions = async ({
     return
   }
 
-  const rscFunctions = await writeRscDataEdgeFunction({
+  const rscFunctions = await generateRscDataEdgeManifest({
     prerenderManifest: await loadPrerenderManifest(netlifyConfig),
     appPathRoutesManifest: await loadAppPathRoutesManifest(netlifyConfig),
   })

--- a/packages/runtime/src/helpers/edge.ts
+++ b/packages/runtime/src/helpers/edge.ts
@@ -275,14 +275,14 @@ export const writeRscDataEdgeFunction = async ({
   }
   const staticAppdirRoutes: Array<string> = []
   for (const [path, route] of Object.entries(prerenderManifest.routes)) {
-    if (isAppDirRoute(route.srcRoute, appPathRoutesManifest)) {
+    if (isAppDirRoute(route.srcRoute, appPathRoutesManifest) && route.dataRoute) {
       staticAppdirRoutes.push(path, route.dataRoute)
     }
   }
   const dynamicAppDirRoutes: Array<string> = []
 
   for (const [path, route] of Object.entries(prerenderManifest.dynamicRoutes)) {
-    if (isAppDirRoute(path, appPathRoutesManifest)) {
+    if (isAppDirRoute(path, appPathRoutesManifest) && route.dataRouteRegex) {
       dynamicAppDirRoutes.push(route.routeRegex, route.dataRouteRegex)
     }
   }

--- a/packages/runtime/src/templates/edge/shims.js
+++ b/packages/runtime/src/templates/edge/shims.js
@@ -2,6 +2,7 @@
 // deno-lint-ignore-file no-var prefer-const no-unused-vars no-explicit-any
 import { decode as _base64Decode } from 'https://deno.land/std@0.175.0/encoding/base64.ts'
 import { AsyncLocalStorage as ALSCompat } from 'https://deno.land/std@0.175.0/node/async_hooks.ts'
+import { Buffer } from 'https://deno.land/std@0.175.0/io/buffer.ts'
 
 /**
  * These are the shims, polyfills and other kludges to make Next.js work in standards-compliant runtime.
@@ -48,6 +49,11 @@ const fetch /* type {typeof globalThis.fetch} */ = async (url, init) => {
   }
 }
 
+const require = (name) => {
+  if (name === 'node:buffer') return Buffer
+  throw new ReferenceError('require is not defined')
+}
+
 // Next edge runtime uses "self" as a function-scoped global-like object, but some of the older polyfills expect it to equal globalThis
 // See https://nextjs.org/docs/basic-features/supported-browsers-features#polyfills
-const self = { ...globalThis, fetch }
+const self = { ...globalThis, fetch, require }

--- a/test/edge.spec.ts
+++ b/test/edge.spec.ts
@@ -1,0 +1,118 @@
+import { writeRscDataEdgeFunction } from '../packages/runtime/src/helpers/edge'
+import type { PrerenderManifest } from 'next/dist/build'
+
+const basePrerenderManifest: PrerenderManifest = {
+  version: 3,
+  routes: {},
+  dynamicRoutes: {},
+  notFoundRoutes: [],
+  preview: {
+    previewModeId: '',
+    previewModeSigningKey: '',
+    previewModeEncryptionKey: '',
+  },
+}
+
+describe('writeRscDataEdgeFunction', () => {
+  it('should return manifest entries for static appDir routes', async () => {
+    const prerenderManifest: PrerenderManifest = {
+      ...basePrerenderManifest,
+      routes: {
+        '/': {
+          initialRevalidateSeconds: false,
+          srcRoute: '/',
+          dataRoute: '/index.rsc',
+        },
+      },
+    }
+    const appPathRoutesManifest = {
+      '/page': '/',
+    }
+    const edgeManifest = await writeRscDataEdgeFunction({ prerenderManifest, appPathRoutesManifest })
+
+    expect(edgeManifest).toEqual([
+      {
+        function: 'rsc-data',
+        name: 'RSC data routing',
+        path: '/',
+      },
+      {
+        function: 'rsc-data',
+        name: 'RSC data routing',
+        path: '/index.rsc',
+      },
+    ])
+  })
+
+  it('should not return manifest entries for static appDir routes without dataRoutes', async () => {
+    const prerenderManifest: PrerenderManifest = {
+      ...basePrerenderManifest,
+      routes: {
+        '/api/hello': {
+          initialRevalidateSeconds: false,
+          srcRoute: '/api/hello',
+          dataRoute: null,
+        },
+      },
+    }
+    const appPathRoutesManifest = {
+      '/api/hello/route': '/api/hello',
+    }
+    const edgeManifest = await writeRscDataEdgeFunction({ prerenderManifest, appPathRoutesManifest })
+
+    expect(edgeManifest).toEqual([])
+  })
+
+  it('should return manifest entries for dynamic appDir routes', async () => {
+    const prerenderManifest: PrerenderManifest = {
+      ...basePrerenderManifest,
+      dynamicRoutes: {
+        '/blog/[author]': {
+          routeRegex: '^/blog/([^/]+?)(?:/)?$',
+          dataRoute: '/blog/[author].rsc',
+          fallback: null,
+          dataRouteRegex: '^/blog/([^/]+?)\\.rsc$',
+        },
+      },
+    }
+
+    const appPathRoutesManifest = {
+      '/blog/[author]/page': '/blog/[author]',
+    }
+    const edgeManifest = await writeRscDataEdgeFunction({ prerenderManifest, appPathRoutesManifest })
+
+    expect(edgeManifest).toEqual([
+      {
+        function: 'rsc-data',
+        name: 'RSC data routing',
+        pattern: '^/blog/([^/]+?)(?:/)?$',
+      },
+      {
+        function: 'rsc-data',
+        name: 'RSC data routing',
+        pattern: '^/blog/([^/]+?)\\.rsc$',
+      },
+    ])
+  })
+
+  it('should not return manifest entries for dynamic appDir routes without dataRoutes', async () => {
+    const prerenderManifest: PrerenderManifest = {
+      ...basePrerenderManifest,
+      dynamicRoutes: {
+        '/api/[endpoint]': {
+          routeRegex: '^/api/([^/]+?)(?:/)?$',
+          dataRoute: '/api/[endpoint].rsc',
+          fallback: null,
+          dataRouteRegex: null,
+        },
+      },
+    }
+
+    const appPathRoutesManifest = {
+      '/api/[endpoint]/route': '/api/[endpoint]',
+    }
+    const edgeManifest = await writeRscDataEdgeFunction({ prerenderManifest, appPathRoutesManifest })
+
+    expect(edgeManifest).toEqual([])
+  })
+})

--- a/test/edge.spec.ts
+++ b/test/edge.spec.ts
@@ -1,4 +1,4 @@
-import { writeRscDataEdgeFunction } from '../packages/runtime/src/helpers/edge'
+import { generateRscDataEdgeManifest } from '../packages/runtime/src/helpers/edge'
 import type { PrerenderManifest } from 'next/dist/build'
 
 const basePrerenderManifest: PrerenderManifest = {
@@ -13,7 +13,7 @@ const basePrerenderManifest: PrerenderManifest = {
   },
 }
 
-describe('writeRscDataEdgeFunction', () => {
+describe('generateRscDataEdgeManifest', () => {
   it('should return manifest entries for static appDir routes', async () => {
     const prerenderManifest: PrerenderManifest = {
       ...basePrerenderManifest,
@@ -28,7 +28,7 @@ describe('writeRscDataEdgeFunction', () => {
     const appPathRoutesManifest = {
       '/page': '/',
     }
-    const edgeManifest = await writeRscDataEdgeFunction({ prerenderManifest, appPathRoutesManifest })
+    const edgeManifest = await generateRscDataEdgeManifest({ prerenderManifest, appPathRoutesManifest })
 
     expect(edgeManifest).toEqual([
       {
@@ -58,7 +58,7 @@ describe('writeRscDataEdgeFunction', () => {
     const appPathRoutesManifest = {
       '/api/hello/route': '/api/hello',
     }
-    const edgeManifest = await writeRscDataEdgeFunction({ prerenderManifest, appPathRoutesManifest })
+    const edgeManifest = await generateRscDataEdgeManifest({ prerenderManifest, appPathRoutesManifest })
 
     expect(edgeManifest).toEqual([])
   })
@@ -79,7 +79,7 @@ describe('writeRscDataEdgeFunction', () => {
     const appPathRoutesManifest = {
       '/blog/[author]/page': '/blog/[author]',
     }
-    const edgeManifest = await writeRscDataEdgeFunction({ prerenderManifest, appPathRoutesManifest })
+    const edgeManifest = await generateRscDataEdgeManifest({ prerenderManifest, appPathRoutesManifest })
 
     expect(edgeManifest).toEqual([
       {
@@ -95,7 +95,7 @@ describe('writeRscDataEdgeFunction', () => {
     ])
   })
 
-  it('should not return manifest entries for dynamic appDir routes without dataRoutes', async () => {
+  it('should not return manifest entries for dynamic appDir routes without dataRoute', async () => {
     const prerenderManifest: PrerenderManifest = {
       ...basePrerenderManifest,
       dynamicRoutes: {
@@ -111,7 +111,7 @@ describe('writeRscDataEdgeFunction', () => {
     const appPathRoutesManifest = {
       '/api/[endpoint]/route': '/api/[endpoint]',
     }
-    const edgeManifest = await writeRscDataEdgeFunction({ prerenderManifest, appPathRoutesManifest })
+    const edgeManifest = await generateRscDataEdgeManifest({ prerenderManifest, appPathRoutesManifest })
 
     expect(edgeManifest).toEqual([])
   })

--- a/test/edge.spec.ts
+++ b/test/edge.spec.ts
@@ -95,7 +95,7 @@ describe('generateRscDataEdgeManifest', () => {
     ])
   })
 
-  it('should not return manifest entries for dynamic appDir routes without dataRoute', async () => {
+  it('should not return manifest entries for dynamic appDir routes without dataRouteRegex', async () => {
     const prerenderManifest: PrerenderManifest = {
       ...basePrerenderManifest,
       dynamicRoutes: {


### PR DESCRIPTION
### Summary

A new turbopack feature allows free variables to be aliased to modules, which causes a Next.js reference to `Buffer` to be bundled as `require("node:buffer")`, which is not supported by Deno.

This PR adds a shim for require that specifically loads `Buffer` for this case only.

### Test plan

Incoming...

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

Fixes #2047