### PR TITLE
test: move e2e tests to a daily schedule

### DIFF
--- a/.github/workflows/e2e-next.yml
+++ b/.github/workflows/e2e-next.yml
@@ -1,10 +1,12 @@
 name: Next.js e2e test suite
 
 on:
-  pull_request:
-    types: [opened, synchronize]
-  push:
-    branches: [main]
+  # pull_request:
+  #   types: [opened, synchronize]
+  # push:
+  #   branches: [main]
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   setup:


### PR DESCRIPTION
Makes our e2e tests run on a daily schedule. 
I'd like to add slack notifications, but am waiting on info.