### PR TITLE
fix: default to target: server, not serverless

### DIFF
--- a/packages/runtime/src/helpers/files.ts
+++ b/packages/runtime/src/helpers/files.ts
@@ -85,7 +85,7 @@ export const moveStaticPages = async ({
   basePath?: string
 }): Promise<void> => {
   console.log('Moving static page files to serve from CDN...')
-  const outputDir = join(netlifyConfig.build.publish, target === 'server' ? 'server' : 'serverless')
+  const outputDir = join(netlifyConfig.build.publish, target === 'serverless' ? 'serverless' : 'server')
   const buildId = readFileSync(join(netlifyConfig.build.publish, 'BUILD_ID'), 'utf8').trim()
   const dataDir = join('_next', 'data', buildId)
   await ensureDir(join(netlifyConfig.build.publish, dataDir))
@@ -134,6 +134,7 @@ export const moveStaticPages = async ({
     const dest = join(netlifyConfig.build.publish, targetPath)
 
     try {
+      console.log(`Moving ${source} to ${dest}`)
       await move(source, dest)
     } catch (error) {
       console.warn('Error moving file', source, error)


### PR DESCRIPTION
### Summary

In v13.3.0, Next.js shipped a [change](https://github.com/vercel/next.js/pull/46801) that removed the `target` parameter from the Next config object. It was deprecated in Next 12 (and its usage [discontinued](https://github.com/vercel/next.js/pull/41495) in 12.3.2), but this recent change means the value is `undefined` instead of defaulting to `server`, which causes our Runtime to not find any static files to move to the CDN.

This PR simply flips the logic so that 'server' is the default instead of 'serverless'. This works because the default directory for static files is `.next/server`.

### Test plan

Tests should pass as before.

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

Fixes #2043 

<img src="https://pbs.twimg.com/media/EwDll05XcAox-4r?format=jpg&name=small" />

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
