### PR TITLE
chore: Optimize Cypress parallelization

### DIFF
--- a/.github/workflows/cypress-canary.yml
+++ b/.github/workflows/cypress-canary.yml
@@ -55,7 +55,6 @@ jobs:
         uses: cypress-io/github-action@v5
         with:
           browser: chrome
-          headless: true
           record: true
           config-file: cypress/config/canary.config.ts
           group: 'Next Runtime - Demo Canary'

--- a/.github/workflows/cypress-canary.yml
+++ b/.github/workflows/cypress-canary.yml
@@ -13,10 +13,6 @@ jobs:
   cypress:
     name: Cypress
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        containers: [1, 2, 3, 4]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -61,7 +57,6 @@ jobs:
           browser: chrome
           headless: true
           record: true
-          parallel: true
           config-file: cypress/config/canary.config.ts
           group: 'Next Runtime - Demo Canary'
           spec: cypress/e2e/canary/*

--- a/.github/workflows/cypress-demo-nx.yml
+++ b/.github/workflows/cypress-demo-nx.yml
@@ -13,10 +13,6 @@ jobs:
   cypress:
     name: Cypress
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        containers: [1, 2, 3, 4]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -61,7 +57,6 @@ jobs:
           browser: chrome
           headless: true
           record: true
-          parallel: true
           config-file: cypress/config/nx-demo.config.ts
           group: 'Next Runtime - Demo NX'
           spec: cypress/e2e/nx/*

--- a/.github/workflows/cypress-demo-nx.yml
+++ b/.github/workflows/cypress-demo-nx.yml
@@ -55,7 +55,6 @@ jobs:
         uses: cypress-io/github-action@v5
         with:
           browser: chrome
-          headless: true
           record: true
           config-file: cypress/config/nx-demo.config.ts
           group: 'Next Runtime - Demo NX'

--- a/.github/workflows/cypress-demo-static.yml
+++ b/.github/workflows/cypress-demo-static.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        containers: [1, 2, 3, 4]
+        containers: [1, 2]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/cypress-demo-static.yml
+++ b/.github/workflows/cypress-demo-static.yml
@@ -59,7 +59,6 @@ jobs:
         uses: cypress-io/github-action@v5
         with:
           browser: chrome
-          headless: true
           record: true
           parallel: true
           config-file: cypress/config/static-root.config.ts

--- a/.github/workflows/cypress-demo.yml
+++ b/.github/workflows/cypress-demo.yml
@@ -59,7 +59,6 @@ jobs:
         uses: cypress-io/github-action@v5
         with:
           browser: chrome
-          headless: true
           record: true
           parallel: true
           config-file: cypress/config/ci.config.ts

--- a/.github/workflows/cypress-middleware.yml
+++ b/.github/workflows/cypress-middleware.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        containers: [1, 2, 3, 4]
+        containers: [1, 2]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/cypress-middleware.yml
+++ b/.github/workflows/cypress-middleware.yml
@@ -59,7 +59,6 @@ jobs:
         uses: cypress-io/github-action@v5
         with:
           browser: chrome
-          headless: true
           record: true
           parallel: true
           config-file: cypress/config/middleware.config.ts


### PR DESCRIPTION
### Summary

We unnecessarily parallelize our Cypress tests when actually a lower `matrix` is needed or no parallelization at all. This PR fixes that.

I also noticed that GitHub actions complained about unknown `headless` arg - it doesn't exist on the action since it runs headless by default. So I just removed it.
