### PR TITLE
chore: Add `next` dep to renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,21 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>netlify/renovate-config"]
+  "extends": ["local>netlify/renovate-config"],
+  "packageRules": [
+    {
+      "groupName": "Next.js",
+      "matchPackagePatterns": ["next"],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ]
+    },
+    {
+      "groupName": "Next.js (Major)",
+      "matchPackagePatterns": ["next"],
+      "matchUpdateTypes": [
+        "major"
+      ]
+    }
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -5,17 +5,12 @@
     {
       "groupName": "Next.js",
       "matchPackagePatterns": ["next"],
-      "matchUpdateTypes": [
-        "patch",
-        "minor"
-      ]
+      "matchUpdateTypes": ["patch", "minor"]
     },
     {
       "groupName": "Next.js (Major)",
       "matchPackagePatterns": ["next"],
-      "matchUpdateTypes": [
-        "major"
-      ]
+      "matchUpdateTypes": ["major"]
     }
   ]
 }


### PR DESCRIPTION
### Summary

In order for us to not get outdated with the `next` version, tell renovate to update it.

Fixes https://github.com/netlify/pod-ecosystem-frameworks/issues/468
