### PR TITLE
chore: remove netlify graph helper

### DIFF
--- a/packages/runtime/src/templates/getHandler.ts
+++ b/packages/runtime/src/templates/getHandler.ts
@@ -116,14 +116,6 @@ const makeHandler = (conf: NextConfig, app, pageRoot, staticManifest: Array<[str
     const query = new URLSearchParams(event.queryStringParameters).toString()
     event.path = query ? `${event.path}?${query}` : event.path
 
-    const graphToken = event.netlifyGraphToken
-    if (graphToken && requestMode !== 'ssr') {
-      // Prefix with underscore to help us determine the origin of the token
-      // allows us to write better error messages
-      // eslint-disable-next-line no-underscore-dangle
-      process.env._NETLIFY_GRAPH_TOKEN = graphToken
-    }
-
     const { headers, ...result } = await getBridge(event, context).launcher(event, context)
 
     // Convert all headers to multiValueHeaders


### PR DESCRIPTION
### Summary

Removes helper that make the Netlify Graph token available to the next runtime as it has reached its end of life.

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

https://github.com/netlify/pod-api-ecosystem/issues/174

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
