### PR TITLE
chore: remove console log

### DIFF
--- a/packages/runtime/src/helpers/files.ts
+++ b/packages/runtime/src/helpers/files.ts
@@ -133,7 +133,6 @@ export const moveStaticPages = async ({
     const dest = join(netlifyConfig.build.publish, targetPath)
 
     try {
-      console.log(`Moving ${source} to ${dest}`)
       await move(source, dest)
     } catch (error) {
       console.warn('Error moving file', source, error)


### PR DESCRIPTION
### Summary

Removed an errant `console.log` from [this PR](https://github.com/netlify/next-runtime/pull/2060) that was causing issues with build logs.