### PR TITLE
chore: update github workflows

### DIFF
--- a/.github/workflows/cypress-canary.yml
+++ b/.github/workflows/cypress-canary.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Generate Github token
         uses: navikt/github-app-token-generator@v1
@@ -25,7 +25,7 @@ jobs:
           app-id: ${{ secrets.TOKENS_APP_ID }}
 
       - name: Checkout @netlify/wait-for-deploy-action
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: netlify/wait-for-deploy-action
           token: ${{ steps.get-token.outputs.token }}
@@ -43,7 +43,7 @@ jobs:
         run: echo ${{ steps.deploy.outputs.origin-url }}
 
       - name: Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
 

--- a/.github/workflows/cypress-demo-nx.yml
+++ b/.github/workflows/cypress-demo-nx.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Generate Github token
         uses: navikt/github-app-token-generator@v1
@@ -25,7 +25,7 @@ jobs:
           app-id: ${{ secrets.TOKENS_APP_ID }}
 
       - name: Checkout @netlify/wait-for-deploy-action
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: netlify/wait-for-deploy-action
           token: ${{ steps.get-token.outputs.token }}
@@ -43,7 +43,7 @@ jobs:
         run: echo ${{ steps.deploy.outputs.origin-url }}
 
       - name: Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
 

--- a/.github/workflows/cypress-demo-static.yml
+++ b/.github/workflows/cypress-demo-static.yml
@@ -19,7 +19,7 @@ jobs:
         containers: [1, 2]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Generate Github token
         uses: navikt/github-app-token-generator@v1
@@ -29,7 +29,7 @@ jobs:
           app-id: ${{ secrets.TOKENS_APP_ID }}
 
       - name: Checkout @netlify/wait-for-deploy-action
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: netlify/wait-for-deploy-action
           token: ${{ steps.get-token.outputs.token }}
@@ -47,7 +47,7 @@ jobs:
         run: echo ${{ steps.deploy.outputs.origin-url }}
 
       - name: Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
 

--- a/.github/workflows/cypress-demo.yml
+++ b/.github/workflows/cypress-demo.yml
@@ -19,7 +19,7 @@ jobs:
         containers: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Generate Github token
         uses: navikt/github-app-token-generator@v1
@@ -29,7 +29,7 @@ jobs:
           app-id: ${{ secrets.TOKENS_APP_ID }}
 
       - name: Checkout @netlify/wait-for-deploy-action
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: netlify/wait-for-deploy-action
           token: ${{ steps.get-token.outputs.token }}
@@ -47,7 +47,7 @@ jobs:
         run: echo ${{ steps.deploy.outputs.origin-url }}
 
       - name: Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
 

--- a/.github/workflows/cypress-middleware.yml
+++ b/.github/workflows/cypress-middleware.yml
@@ -19,7 +19,7 @@ jobs:
         containers: [1, 2]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Generate Github token
         uses: navikt/github-app-token-generator@v1
@@ -29,7 +29,7 @@ jobs:
           app-id: ${{ secrets.TOKENS_APP_ID }}
 
       - name: Checkout @netlify/wait-for-deploy-action
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: netlify/wait-for-deploy-action
           token: ${{ steps.get-token.outputs.token }}
@@ -47,7 +47,7 @@ jobs:
         run: echo ${{ steps.deploy.outputs.origin-url }}
 
       - name: Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
 

--- a/.github/workflows/e2e-appdir.yml
+++ b/.github/workflows/e2e-appdir.yml
@@ -35,7 +35,7 @@ jobs:
         test-file: ${{ fromJson(needs.setup.outputs['test-files']) }}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: '16'
           cache: 'npm'

--- a/.github/workflows/e2e-next.yml
+++ b/.github/workflows/e2e-next.yml
@@ -37,7 +37,7 @@ jobs:
         test-file: ${{ fromJson(needs.setup.outputs['test-files']) }}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: '16'
           cache: 'npm'

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -8,8 +8,8 @@ jobs:
   prerelease:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 'lts/*'
           cache: 'npm'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,9 +17,9 @@ jobs:
         with:
           token: ${{ steps.get-token.outputs.token }}
           command: manifest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         if: ${{ steps.release.outputs.releases_created }}
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 'lts/*'
           cache: 'npm'

--- a/.github/workflows/test-deno.yml
+++ b/.github/workflows/test-deno.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Git Checkout Deno Module
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Use Deno Version ${{ matrix.deno-version }}
         uses: denolib/setup-deno@v2
         with:

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Installing with LTS Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 18
           check-latest: true

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -6,7 +6,7 @@ on:
     branches: [main]
 
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
     - cron: '0 0 * * *'
 
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,9 +22,9 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Installing with LTS Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16
           check-latest: true
@@ -45,9 +45,9 @@ jobs:
 
     if: github.ref_name == 'main'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Installing with LTS Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16
           check-latest: true


### PR DESCRIPTION
### Summary

This makes use of the correct concurrency setting as explained here: https://docs.github.com/en/actions/using-jobs/using-concurrency#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow

This also updates the checkout and setup-node actions which were out of date.
