### PR TITLE
fix: strip domain from ipx edge functions path (#2098)

### DIFF
--- a/packages/runtime/src/helpers/edge.ts
+++ b/packages/runtime/src/helpers/edge.ts
@@ -93,6 +93,11 @@ export const loadPrerenderManifest = (netlifyConfig: NetlifyConfig): Promise<Pre
  */
 const sanitizeName = (name: string) => `next_${name.replace(/\W/g, '_')}`
 
+/**
+ * Convert the images path to strip the origin (until domain-level Edge functions are supported)
+ */
+const sanitizeEdgePath = (imagesPath: string) => new URL(imagesPath, process.env.URL || 'http://n').pathname
+
 // Slightly different spacing in different versions!
 const IMPORT_UNSUPPORTED = [
   `Object.defineProperty(globalThis,"__import_unsupported"`,
@@ -485,10 +490,11 @@ export const writeEdgeFunctions = async ({
       join('.netlify', 'functions-internal', IMAGE_FUNCTION_NAME, 'imageconfig.json'),
       join(edgeFunctionDir, 'imageconfig.json'),
     )
+
     manifest.functions.push({
       function: 'ipx',
       name: 'next/image handler',
-      path: nextConfig.images.path || '/_next/image',
+      path: nextConfig.images.path ? sanitizeEdgePath(nextConfig.images.path) : '/_next/image',
       generator,
     })
 


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/netlify/next-runtime/blob/main/CONTRIBUTING.md. -->

### Summary

When folks put in a full URL into the `images.path` configuration while using Edge functions for image format content negotiation, the Edge function never runs, as full URLs are not supported for Edge function paths.

Strictly speaking in your `next.config.js`:

```js
module.exports = {
  images: {
    path: `https://example.com/_next/image`,
  },
}
```

The PR changes the Edge function to capture `/_next/image` instead of (previously erroring) `https://example.com/_next/image`. It does not affect the generated markup.

See #2098 for more info.

Potential issues:
* if a project is using a `loader` other than `default` (the code assumes that opting into edge function images means they’re using the `default` loader)
* when the Edge functions team circles back and adds support for domain-level Edge declarations, we’ll need to also circle back and remove this change.

### Test plan

Would appreciate some additional guidance here! I did attempt to put together a sample repo but encountered some errors when attempting to `npm install github:netlify/next-runtime#zl/next-images-path-edge`.

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

Fixes #2098

![image](https://github.com/netlify/next-runtime/assets/39355/9c667849-b911-4824-88db-a25260cbd395)


### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
