### PR TITLE
fix: don't deploy metadata files to CDN

### DIFF
--- a/packages/runtime/src/constants.ts
+++ b/packages/runtime/src/constants.ts
@@ -1,3 +1,5 @@
+import destr from 'destr'
+
 export const HANDLER_FUNCTION_NAME = '___netlify-handler'
 export const ODB_FUNCTION_NAME = '___netlify-odb-handler'
 export const IMAGE_FUNCTION_NAME = '_ipx'
@@ -6,7 +8,6 @@ export const NEXT_PLUGIN = '@netlify/plugin-nextjs'
 export const HANDLER_FUNCTION_TITLE = 'Next.js SSR handler'
 export const ODB_FUNCTION_TITLE = 'Next.js ISR handler'
 export const IMAGE_FUNCTION_TITLE = 'next/image handler'
-
 // These are paths in .next that shouldn't be publicly accessible
 export const HIDDEN_PATHS = [
   '/cache',
@@ -18,7 +19,7 @@ export const HIDDEN_PATHS = [
   '/build-manifest.json',
   '/prerender-manifest.json',
   '/react-loadable-manifest.json',
-  process.env.NODE_ENV === `test` ? `` : '/BUILD_ID',
+  destr(process.env.NEXT_KEEP_BUILD_ID) ? `` : '/BUILD_ID',
   '/app-build-manifest.json',
   '/app-path-routes-manifest.json',
   '/export-marker.json',

--- a/packages/runtime/src/constants.ts
+++ b/packages/runtime/src/constants.ts
@@ -7,7 +7,6 @@ export const HANDLER_FUNCTION_TITLE = 'Next.js SSR handler'
 export const ODB_FUNCTION_TITLE = 'Next.js ISR handler'
 export const IMAGE_FUNCTION_TITLE = 'next/image handler'
 // These are paths in .next that shouldn't be publicly accessible
-
 export const HIDDEN_PATHS = [
   '/cache',
   '/server',
@@ -27,7 +26,7 @@ export const HIDDEN_PATHS = [
   '/package.json',
   '/prerender-manifest.js',
   '/required-server-files.json',
-  'static-manifest.json',
+  '/static-manifest.json',
 ]
 
 export const ODB_FUNCTION_PATH = `/.netlify/builders/${ODB_FUNCTION_NAME}`

--- a/packages/runtime/src/constants.ts
+++ b/packages/runtime/src/constants.ts
@@ -17,7 +17,7 @@ export const HIDDEN_PATHS = [
   '/build-manifest.json',
   '/prerender-manifest.json',
   '/react-loadable-manifest.json',
-  process.env.NODE_ENV === `test` ? false : '/BUILD_ID',
+  process.env.NODE_ENV === `test` ? `` : '/BUILD_ID',
   '/app-build-manifest.json',
   '/app-path-routes-manifest.json',
   '/export-marker.json',

--- a/packages/runtime/src/constants.ts
+++ b/packages/runtime/src/constants.ts
@@ -8,9 +8,9 @@ export const ODB_FUNCTION_TITLE = 'Next.js ISR handler'
 export const IMAGE_FUNCTION_TITLE = 'next/image handler'
 // These are paths in .next that shouldn't be publicly accessible
 export const HIDDEN_PATHS = [
-  '/cache/*',
-  '/server/*',
-  '/serverless/*',
+  '/cache',
+  '/server',
+  '/serverless',
   '/trace',
   '/traces',
   '/routes-manifest.json',

--- a/packages/runtime/src/constants.ts
+++ b/packages/runtime/src/constants.ts
@@ -7,6 +7,7 @@ export const HANDLER_FUNCTION_TITLE = 'Next.js SSR handler'
 export const ODB_FUNCTION_TITLE = 'Next.js ISR handler'
 export const IMAGE_FUNCTION_TITLE = 'next/image handler'
 // These are paths in .next that shouldn't be publicly accessible
+
 export const HIDDEN_PATHS = [
   '/cache',
   '/server',
@@ -18,6 +19,15 @@ export const HIDDEN_PATHS = [
   '/prerender-manifest.json',
   '/react-loadable-manifest.json',
   '/BUILD_ID',
+  '/app-build-manifest.json',
+  '/app-path-routes-manifest.json',
+  '/export-marker.json',
+  '/images-manifest.json',
+  '/next-server.js.nft.json',
+  '/package.json',
+  '/prerender-manifest.js',
+  '/required-server-files.json',
+  'static-manifest.json',
 ]
 
 export const ODB_FUNCTION_PATH = `/.netlify/builders/${ODB_FUNCTION_NAME}`

--- a/packages/runtime/src/constants.ts
+++ b/packages/runtime/src/constants.ts
@@ -9,27 +9,29 @@ export const HANDLER_FUNCTION_TITLE = 'Next.js SSR handler'
 export const ODB_FUNCTION_TITLE = 'Next.js ISR handler'
 export const IMAGE_FUNCTION_TITLE = 'next/image handler'
 // These are paths in .next that shouldn't be publicly accessible
-export const HIDDEN_PATHS = [
-  '/cache',
-  '/server',
-  '/serverless',
-  '/trace',
-  '/traces',
-  '/routes-manifest.json',
-  '/build-manifest.json',
-  '/prerender-manifest.json',
-  '/react-loadable-manifest.json',
-  destr(process.env.NEXT_KEEP_BUILD_ID) ? `` : '/BUILD_ID',
-  '/app-build-manifest.json',
-  '/app-path-routes-manifest.json',
-  '/export-marker.json',
-  '/images-manifest.json',
-  '/next-server.js.nft.json',
-  '/package.json',
-  '/prerender-manifest.js',
-  '/required-server-files.json',
-  '/static-manifest.json',
-].filter(Boolean)
+export const HIDDEN_PATHS = destr(process.env.NEXT_KEEP_METADATA_FILES)
+  ? []
+  : [
+      '/cache',
+      '/server',
+      '/serverless',
+      '/trace',
+      '/traces',
+      '/routes-manifest.json',
+      '/build-manifest.json',
+      '/prerender-manifest.json',
+      '/react-loadable-manifest.json',
+      '/BUILD_ID',
+      '/app-build-manifest.json',
+      '/app-path-routes-manifest.json',
+      '/export-marker.json',
+      '/images-manifest.json',
+      '/next-server.js.nft.json',
+      '/package.json',
+      '/prerender-manifest.js',
+      '/required-server-files.json',
+      '/static-manifest.json',
+    ]
 
 export const ODB_FUNCTION_PATH = `/.netlify/builders/${ODB_FUNCTION_NAME}`
 export const HANDLER_FUNCTION_PATH = `/.netlify/functions/${HANDLER_FUNCTION_NAME}`

--- a/packages/runtime/src/constants.ts
+++ b/packages/runtime/src/constants.ts
@@ -17,7 +17,7 @@ export const HIDDEN_PATHS = [
   '/build-manifest.json',
   '/prerender-manifest.json',
   '/react-loadable-manifest.json',
-  '/BUILD_ID',
+  process.env.NODE_ENV === `test` ? false : '/BUILD_ID',
   '/app-build-manifest.json',
   '/app-path-routes-manifest.json',
   '/export-marker.json',
@@ -27,7 +27,7 @@ export const HIDDEN_PATHS = [
   '/prerender-manifest.js',
   '/required-server-files.json',
   '/static-manifest.json',
-]
+].filter(Boolean)
 
 export const ODB_FUNCTION_PATH = `/.netlify/builders/${ODB_FUNCTION_NAME}`
 export const HANDLER_FUNCTION_PATH = `/.netlify/functions/${HANDLER_FUNCTION_NAME}`

--- a/packages/runtime/src/constants.ts
+++ b/packages/runtime/src/constants.ts
@@ -6,6 +6,7 @@ export const NEXT_PLUGIN = '@netlify/plugin-nextjs'
 export const HANDLER_FUNCTION_TITLE = 'Next.js SSR handler'
 export const ODB_FUNCTION_TITLE = 'Next.js ISR handler'
 export const IMAGE_FUNCTION_TITLE = 'next/image handler'
+
 // These are paths in .next that shouldn't be publicly accessible
 export const HIDDEN_PATHS = [
   '/cache',

--- a/packages/runtime/src/helpers/files.ts
+++ b/packages/runtime/src/helpers/files.ts
@@ -2,7 +2,18 @@ import { cpus } from 'os'
 
 import type { NetlifyConfig } from '@netlify/build'
 import { yellowBright } from 'chalk'
-import { existsSync, readJson, move, copy, writeJson, readFile, writeFile, ensureDir, readFileSync } from 'fs-extra'
+import {
+  existsSync,
+  readJson,
+  move,
+  copy,
+  writeJson,
+  readFile,
+  writeFile,
+  ensureDir,
+  readFileSync,
+  remove,
+} from 'fs-extra'
 import globby from 'globby'
 import { PrerenderManifest } from 'next/dist/build'
 import { outdent } from 'outdent'
@@ -10,7 +21,7 @@ import pLimit from 'p-limit'
 import { join, resolve, dirname } from 'pathe'
 import slash from 'slash'
 
-import { MINIMUM_REVALIDATE_SECONDS, DIVIDER } from '../constants'
+import { MINIMUM_REVALIDATE_SECONDS, DIVIDER, HIDDEN_PATHS } from '../constants'
 
 import { NextConfig } from './config'
 import { loadPrerenderManifest } from './edge'
@@ -465,5 +476,12 @@ export const movePublicFiles = async ({
   const publicDir = outdir ? join(appDir, outdir, 'public') : join(appDir, 'public')
   if (existsSync(publicDir)) {
     await copy(publicDir, `${publish}${basePath}/`)
+  }
+}
+
+export const removeMetadataFiles = async (publish: string) => {
+  for (const HIDDEN_PATH of HIDDEN_PATHS) {
+    const pathToDelete = join(publish, HIDDEN_PATH)
+    await remove(pathToDelete)
   }
 }

--- a/packages/runtime/src/helpers/files.ts
+++ b/packages/runtime/src/helpers/files.ts
@@ -150,7 +150,7 @@ export const moveStaticPages = async ({
     }
   }
   // Move all static files, except error documents and nft manifests
-  const pages = await globby(['{app,pages}/**/*.{html,json,rsc}', '!**/(500|404|*.js.nft).{html,json}'], {
+  const pages = await globby(['{app,pages}/**/*.{html,json,rsc}', '!**/*.js.nft.{html,json}'], {
     cwd: outputDir,
     dot: true,
   })

--- a/packages/runtime/src/helpers/files.ts
+++ b/packages/runtime/src/helpers/files.ts
@@ -149,7 +149,7 @@ export const moveStaticPages = async ({
       console.warn('Error moving file', source, error)
     }
   }
-  // Move all static files, except error documents and nft manifests
+  // Move all static files, except nft manifests
   const pages = await globby(['{app,pages}/**/*.{html,json,rsc}', '!**/*.js.nft.{html,json}'], {
     cwd: outputDir,
     dot: true,

--- a/packages/runtime/src/helpers/files.ts
+++ b/packages/runtime/src/helpers/files.ts
@@ -480,8 +480,13 @@ export const movePublicFiles = async ({
 }
 
 export const removeMetadataFiles = async (publish: string) => {
-  for (const HIDDEN_PATH of HIDDEN_PATHS) {
+  // Limit concurrent file moves to number of cpus or 2 if there is only 1
+  const limit = pLimit(Math.max(2, cpus().length))
+
+  const removePromises = HIDDEN_PATHS.map((HIDDEN_PATH) => {
     const pathToDelete = join(publish, HIDDEN_PATH)
-    await remove(pathToDelete)
-  }
+    return limit(() => remove(pathToDelete))
+  })
+
+  await Promise.all(removePromises)
 }

--- a/packages/runtime/src/helpers/files.ts
+++ b/packages/runtime/src/helpers/files.ts
@@ -480,7 +480,7 @@ export const movePublicFiles = async ({
 }
 
 export const removeMetadataFiles = async (publish: string) => {
-  // Limit concurrent file moves to number of cpus or 2 if there is only 1
+  // Limit concurrent deletions to number of cpus or 2 if there is only 1
   const limit = pLimit(Math.max(2, cpus().length))
 
   const removePromises = HIDDEN_PATHS.map((HIDDEN_PATH) => {

--- a/packages/runtime/src/helpers/redirects.ts
+++ b/packages/runtime/src/helpers/redirects.ts
@@ -7,7 +7,7 @@ import type { PrerenderManifest, SsgRoute } from 'next/dist/build'
 import { outdent } from 'outdent'
 import { join } from 'pathe'
 
-import { HANDLER_FUNCTION_PATH, HIDDEN_PATHS, ODB_FUNCTION_PATH } from '../constants'
+import { HANDLER_FUNCTION_PATH, ODB_FUNCTION_PATH } from '../constants'
 
 import { isAppDirRoute, loadAppPathRoutesManifest } from './edge'
 import { getMiddleware } from './files'
@@ -26,14 +26,6 @@ import {
 
 const matchesMiddleware = (middleware: Array<string>, route: string): boolean =>
   middleware.some((middlewarePath) => route.startsWith(middlewarePath))
-
-const generateHiddenPathRedirects = ({ basePath }: Pick<NextConfig, 'basePath'>): NetlifyConfig['redirects'] =>
-  HIDDEN_PATHS.map((path) => ({
-    from: `${basePath}${path}`,
-    to: '/404.html',
-    status: 404,
-    force: true,
-  }))
 
 const generateLocaleRedirects = ({
   i18n,
@@ -280,8 +272,6 @@ export const generateRedirects = async ({
   const { dynamicRoutes, staticRoutes }: RoutesManifest = await readJSON(
     join(netlifyConfig.build.publish, 'routes-manifest.json'),
   )
-
-  netlifyConfig.redirects.push(...generateHiddenPathRedirects({ basePath }))
 
   if (i18n && i18n.localeDetection !== false) {
     netlifyConfig.redirects.push(...generateLocaleRedirects({ i18n, basePath, trailingSlash }))

--- a/packages/runtime/src/helpers/utils.ts
+++ b/packages/runtime/src/helpers/utils.ts
@@ -170,7 +170,7 @@ export const redirectsForNext404Route = ({
 }): NetlifyConfig['redirects'] =>
   netlifyRoutesForNextRoute({ route, buildId, i18n }).map(({ redirect, locale }) => ({
     from: `${basePath}${redirect}`,
-    to: locale ? `${basePath}/server/pages/${locale}/404.html` : `${basePath}/server/pages/404.html`,
+    to: locale ? `${basePath}/${locale}/404.html` : `${basePath}/404.html`,
     status: 404,
     force,
   }))

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -254,6 +254,10 @@ const plugin: NetlifyPlugin = {
     warnForProblematicUserRewrites({ basePath, redirects })
     warnForRootRedirects({ appDir })
     await warnOnApiRoutes({ FUNCTIONS_DIST })
+
+    // we are removing metadata files from Publish directory
+    // we have to do this after functions were bundled as bundling still
+    // require those files, but we don't want to publish them
     await removeMetadataFiles(publish)
 
     if (experimental?.appDir) {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -3,10 +3,10 @@ import { join, relative } from 'path'
 import type { NetlifyPlugin, NetlifyPluginOptions } from '@netlify/build'
 import { bold, redBright } from 'chalk'
 import destr from 'destr'
-import { existsSync, readFileSync } from 'fs-extra'
+import { existsSync, readFileSync, remove } from 'fs-extra'
 import { outdent } from 'outdent'
 
-import { HANDLER_FUNCTION_NAME, ODB_FUNCTION_NAME } from './constants'
+import { HANDLER_FUNCTION_NAME, ODB_FUNCTION_NAME, HIDDEN_PATHS } from './constants'
 import { restoreCache, saveCache } from './helpers/cache'
 import {
   getNextConfig,
@@ -254,6 +254,13 @@ const plugin: NetlifyPlugin = {
     warnForProblematicUserRewrites({ basePath, redirects })
     warnForRootRedirects({ appDir })
     await warnOnApiRoutes({ FUNCTIONS_DIST })
+
+    for (const HIDDEN_PATH of HIDDEN_PATHS) {
+      const pathToDelete = join(publish, HIDDEN_PATH)
+      console.log({ pathToDelete })
+      await remove(pathToDelete)
+    }
+
     if (experimental?.appDir) {
       console.log(
         '🧪 Thank you for testing "appDir" support on Netlify. For known issues and to give feedback, visit https://ntl.fyi/next-13-feedback',

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -3,10 +3,10 @@ import { join, relative } from 'path'
 import type { NetlifyPlugin, NetlifyPluginOptions } from '@netlify/build'
 import { bold, redBright } from 'chalk'
 import destr from 'destr'
-import { existsSync, readFileSync, remove } from 'fs-extra'
+import { existsSync, readFileSync } from 'fs-extra'
 import { outdent } from 'outdent'
 
-import { HANDLER_FUNCTION_NAME, ODB_FUNCTION_NAME, HIDDEN_PATHS } from './constants'
+import { HANDLER_FUNCTION_NAME, ODB_FUNCTION_NAME } from './constants'
 import { restoreCache, saveCache } from './helpers/cache'
 import {
   getNextConfig,
@@ -17,7 +17,7 @@ import {
 } from './helpers/config'
 import { onPreDev } from './helpers/dev'
 import { writeEdgeFunctions, loadMiddlewareManifest, cleanupEdgeFunctions } from './helpers/edge'
-import { moveStaticPages, movePublicFiles, patchNextFiles } from './helpers/files'
+import { moveStaticPages, movePublicFiles, patchNextFiles, removeMetadataFiles } from './helpers/files'
 import { splitApiRoutes } from './helpers/flags'
 import {
   generateFunctions,
@@ -254,12 +254,7 @@ const plugin: NetlifyPlugin = {
     warnForProblematicUserRewrites({ basePath, redirects })
     warnForRootRedirects({ appDir })
     await warnOnApiRoutes({ FUNCTIONS_DIST })
-
-    for (const HIDDEN_PATH of HIDDEN_PATHS) {
-      const pathToDelete = join(publish, HIDDEN_PATH)
-      console.log({ pathToDelete })
-      await remove(pathToDelete)
-    }
+    await removeMetadataFiles(publish)
 
     if (experimental?.appDir) {
       console.log(

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -1088,6 +1088,14 @@ Array [
     "blog/sarah/second-post.rsc",
   ],
   Array [
+    "pages/en/404.html",
+    "en/404.html",
+  ],
+  Array [
+    "pages/en/500.html",
+    "en/500.html",
+  ],
+  Array [
     "pages/en/broken-image.html",
     "en/broken-image.html",
   ],
@@ -1208,6 +1216,14 @@ Array [
     "en/static.html",
   ],
   Array [
+    "pages/es/404.html",
+    "es/404.html",
+  ],
+  Array [
+    "pages/es/500.html",
+    "es/500.html",
+  ],
+  Array [
     "pages/es/broken-image.html",
     "es/broken-image.html",
   ],
@@ -1262,6 +1278,14 @@ Array [
   Array [
     "pages/es/static.html",
     "es/static.html",
+  ],
+  Array [
+    "pages/fr/404.html",
+    "fr/404.html",
+  ],
+  Array [
+    "pages/fr/500.html",
+    "fr/500.html",
   ],
   Array [
     "pages/fr/broken-image.html",
@@ -1456,7 +1480,7 @@ Array [
     "force": false,
     "from": "/_next/data/build-id/en/getStaticProps/:id.json",
     "status": 404,
-    "to": "/server/pages/en/404.html",
+    "to": "/en/404.html",
   },
   Object {
     "force": false,
@@ -1504,7 +1528,7 @@ Array [
     "force": false,
     "from": "/_next/data/build-id/en/getStaticProps/withRevalidate/:id.json",
     "status": 404,
-    "to": "/server/pages/en/404.html",
+    "to": "/en/404.html",
   },
   Object {
     "force": true,
@@ -1702,7 +1726,7 @@ Array [
     "force": false,
     "from": "/_next/data/build-id/es/getStaticProps/:id.json",
     "status": 404,
-    "to": "/server/pages/es/404.html",
+    "to": "/es/404.html",
   },
   Object {
     "force": false,
@@ -1750,7 +1774,7 @@ Array [
     "force": false,
     "from": "/_next/data/build-id/es/getStaticProps/withRevalidate/:id.json",
     "status": 404,
-    "to": "/server/pages/es/404.html",
+    "to": "/es/404.html",
   },
   Object {
     "force": false,
@@ -1912,7 +1936,7 @@ Array [
     "force": false,
     "from": "/_next/data/build-id/fr/getStaticProps/:id.json",
     "status": 404,
-    "to": "/server/pages/fr/404.html",
+    "to": "/fr/404.html",
   },
   Object {
     "force": false,
@@ -1960,7 +1984,7 @@ Array [
     "force": false,
     "from": "/_next/data/build-id/fr/getStaticProps/withRevalidate/:id.json",
     "status": 404,
-    "to": "/server/pages/fr/404.html",
+    "to": "/fr/404.html",
   },
   Object {
     "force": false,
@@ -2312,7 +2336,7 @@ Array [
     "force": false,
     "from": "/es/getStaticProps/:id",
     "status": 404,
-    "to": "/server/pages/es/404.html",
+    "to": "/es/404.html",
   },
   Object {
     "force": false,
@@ -2360,7 +2384,7 @@ Array [
     "force": false,
     "from": "/es/getStaticProps/withRevalidate/:id",
     "status": 404,
-    "to": "/server/pages/es/404.html",
+    "to": "/es/404.html",
   },
   Object {
     "force": false,
@@ -2552,7 +2576,7 @@ Array [
     "force": false,
     "from": "/fr/getStaticProps/:id",
     "status": 404,
-    "to": "/server/pages/fr/404.html",
+    "to": "/fr/404.html",
   },
   Object {
     "force": false,
@@ -2600,7 +2624,7 @@ Array [
     "force": false,
     "from": "/fr/getStaticProps/withRevalidate/:id",
     "status": 404,
-    "to": "/server/pages/fr/404.html",
+    "to": "/fr/404.html",
   },
   Object {
     "force": false,
@@ -2708,7 +2732,7 @@ Array [
     "force": false,
     "from": "/getStaticProps/:id",
     "status": 404,
-    "to": "/server/pages/en/404.html",
+    "to": "/en/404.html",
   },
   Object {
     "force": false,
@@ -2756,7 +2780,7 @@ Array [
     "force": false,
     "from": "/getStaticProps/withRevalidate/:id",
     "status": 404,
-    "to": "/server/pages/en/404.html",
+    "to": "/en/404.html",
   },
   Object {
     "force": true,

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -2107,6 +2107,21 @@ Array [
     "to": "/.netlify/functions/___netlify-handler",
   },
   Object {
+    "from": "/api/enterPreview",
+    "status": 200,
+    "to": "/.netlify/functions/api-0",
+  },
+  Object {
+    "from": "/api/exitPreview",
+    "status": 200,
+    "to": "/.netlify/functions/api-0",
+  },
+  Object {
+    "from": "/api/hello",
+    "status": 200,
+    "to": "/.netlify/functions/api-0",
+  },
+  Object {
     "from": "/api/hello-background",
     "status": 200,
     "to": "/.netlify/functions/_api_hello-background-background",
@@ -2115,6 +2130,21 @@ Array [
     "from": "/api/hello-scheduled",
     "status": 404,
     "to": "/404.html",
+  },
+  Object {
+    "from": "/api/revalidate",
+    "status": 200,
+    "to": "/.netlify/functions/api-0",
+  },
+  Object {
+    "from": "/api/shows/:id",
+    "status": 200,
+    "to": "/.netlify/functions/api-0",
+  },
+  Object {
+    "from": "/api/shows/:params/*",
+    "status": 200,
+    "to": "/.netlify/functions/api-0",
   },
   Object {
     "force": false,

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -2083,21 +2083,6 @@ Array [
     "to": "/.netlify/functions/___netlify-handler",
   },
   Object {
-    "from": "/api/enterPreview",
-    "status": 200,
-    "to": "/.netlify/functions/api-0",
-  },
-  Object {
-    "from": "/api/exitPreview",
-    "status": 200,
-    "to": "/.netlify/functions/api-0",
-  },
-  Object {
-    "from": "/api/hello",
-    "status": 200,
-    "to": "/.netlify/functions/api-0",
-  },
-  Object {
     "from": "/api/hello-background",
     "status": 200,
     "to": "/.netlify/functions/_api_hello-background-background",
@@ -2106,21 +2091,6 @@ Array [
     "from": "/api/hello-scheduled",
     "status": 404,
     "to": "/404.html",
-  },
-  Object {
-    "from": "/api/revalidate",
-    "status": 200,
-    "to": "/.netlify/functions/api-0",
-  },
-  Object {
-    "from": "/api/shows/:id",
-    "status": 200,
-    "to": "/.netlify/functions/api-0",
-  },
-  Object {
-    "from": "/api/shows/:params/*",
-    "status": 200,
-    "to": "/.netlify/functions/api-0",
   },
   Object {
     "force": false,
@@ -2205,24 +2175,6 @@ Array [
     "from": "/broken-image",
     "status": 200,
     "to": "/.netlify/functions/___netlify-handler",
-  },
-  Object {
-    "force": true,
-    "from": "/BUILD_ID",
-    "status": 404,
-    "to": "/404.html",
-  },
-  Object {
-    "force": true,
-    "from": "/build-manifest.json",
-    "status": 404,
-    "to": "/404.html",
-  },
-  Object {
-    "force": true,
-    "from": "/cache/*",
-    "status": 404,
-    "to": "/404.html",
   },
   Object {
     "force": false,
@@ -2884,22 +2836,10 @@ Array [
     "to": "/.netlify/functions/___netlify-handler",
   },
   Object {
-    "force": true,
-    "from": "/prerender-manifest.json",
-    "status": 404,
-    "to": "/404.html",
-  },
-  Object {
     "force": false,
     "from": "/previewTest",
     "status": 200,
     "to": "/.netlify/functions/___netlify-handler",
-  },
-  Object {
-    "force": true,
-    "from": "/react-loadable-manifest.json",
-    "status": 404,
-    "to": "/404.html",
   },
   Object {
     "force": false,
@@ -2908,28 +2848,10 @@ Array [
     "to": "/.netlify/functions/___netlify-handler",
   },
   Object {
-    "force": true,
-    "from": "/routes-manifest.json",
-    "status": 404,
-    "to": "/404.html",
-  },
-  Object {
     "force": false,
     "from": "/script",
     "status": 200,
     "to": "/.netlify/functions/___netlify-handler",
-  },
-  Object {
-    "force": true,
-    "from": "/server/*",
-    "status": 404,
-    "to": "/404.html",
-  },
-  Object {
-    "force": true,
-    "from": "/serverless/*",
-    "status": 404,
-    "to": "/404.html",
   },
   Object {
     "force": false,
@@ -2965,18 +2887,6 @@ Array [
     "from": "/static/:id",
     "status": 200,
     "to": "/.netlify/functions/___netlify-handler",
-  },
-  Object {
-    "force": true,
-    "from": "/trace",
-    "status": 404,
-    "to": "/404.html",
-  },
-  Object {
-    "force": true,
-    "from": "/traces",
-    "status": 404,
-    "to": "/404.html",
   },
 ]
 `;

--- a/test/e2e/next-test-lib/next-modes/next-deploy.ts
+++ b/test/e2e/next-test-lib/next-modes/next-deploy.ts
@@ -74,7 +74,7 @@ export class NextDeployInstance extends NextInstance {
         NETLIFY_SITE_ID: this._netlifySiteId,
         NODE_ENV: 'production',
         DISABLE_IPX: platform() === 'linux' ? undefined : '1',
-        NEXT_KEEP_BUILD_ID: 'true',
+        NEXT_KEEP_METADATA_FILES: 'true',
       },
     })
 

--- a/test/e2e/next-test-lib/next-modes/next-deploy.ts
+++ b/test/e2e/next-test-lib/next-modes/next-deploy.ts
@@ -74,6 +74,7 @@ export class NextDeployInstance extends NextInstance {
         NETLIFY_SITE_ID: this._netlifySiteId,
         NODE_ENV: 'production',
         DISABLE_IPX: platform() === 'linux' ? undefined : '1',
+        NEXT_KEEP_BUILD_ID: 'true',
       },
     })
 

--- a/test/helpers/utils.spec.ts
+++ b/test/helpers/utils.spec.ts
@@ -149,8 +149,8 @@ describe('redirectsForNext404Route', () => {
     }
 
     expect(redirectsForNext404Route(mockRoute)).toStrictEqual([
-      { force: false, from: '/_next/data/test/test.json', status: 404, to: '/server/pages/404.html' },
-      { force: false, from: '/test', status: 404, to: '/server/pages/404.html' },
+      { force: false, from: '/_next/data/test/test.json', status: 404, to: '/404.html' },
+      { force: false, from: '/test', status: 404, to: '/404.html' },
     ])
   })
 
@@ -166,12 +166,12 @@ describe('redirectsForNext404Route', () => {
     }
 
     expect(redirectsForNext404Route(mockRoute)).toStrictEqual([
-      { force: false, from: '/_next/data/test/en/test.json', status: 404, to: '/server/pages/en/404.html' },
-      { force: false, from: '/test', status: 404, to: '/server/pages/en/404.html' },
-      { force: false, from: '/_next/data/test/es/test.json', status: 404, to: '/server/pages/es/404.html' },
-      { force: false, from: '/es/test', status: 404, to: '/server/pages/es/404.html' },
-      { force: false, from: '/_next/data/test/fr/test.json', status: 404, to: '/server/pages/fr/404.html' },
-      { force: false, from: '/fr/test', status: 404, to: '/server/pages/fr/404.html' },
+      { force: false, from: '/_next/data/test/en/test.json', status: 404, to: '/en/404.html' },
+      { force: false, from: '/test', status: 404, to: '/en/404.html' },
+      { force: false, from: '/_next/data/test/es/test.json', status: 404, to: '/es/404.html' },
+      { force: false, from: '/es/test', status: 404, to: '/es/404.html' },
+      { force: false, from: '/_next/data/test/fr/test.json', status: 404, to: '/fr/404.html' },
+      { force: false, from: '/fr/test', status: 404, to: '/fr/404.html' },
     ])
   })
 
@@ -182,13 +182,13 @@ describe('redirectsForNext404Route', () => {
           force: false,
           from: '/_next/data/test/getStaticProps/:id.json',
           status: 404,
-          to: '/server/pages/404.html',
+          to: '/404.html',
         },
         {
           force: false,
           from: '/getStaticProps/:id',
           status: 404,
-          to: '/server/pages/404.html',
+          to: '/404.html',
         },
       ],
       dynamicRoutesThatMatchMiddleware: [],

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1031,6 +1031,23 @@ describe('onPostBuild', () => {
       },
     ])
   })
+
+  it(`removes metadata files`, async () => {
+    await moveNextDist()
+
+    // routes-manifest.json is one of metadata files that seems to be created with default demo site
+    // there are a lot of other files, but we will test just one
+    const manifestPath = path.resolve('.next/routes-manifest.json')
+
+    expect(await pathExists(manifestPath)).toBe(true)
+
+    await nextRuntime.onPostBuild({
+      ...defaultArgs,
+      utils: { ...utils, cache: { save: jest.fn() }, functions: { list: jest.fn().mockResolvedValue([]) } },
+    })
+
+    expect(await pathExists(manifestPath)).toBe(false)
+  })
 })
 
 describe('function helpers', () => {


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/netlify/next-runtime/blob/main/CONTRIBUTING.md. -->

### Summary

Current strategy of hiding metadata files (creating redirects to 404) has a flaw - redirects are case sensitive, but CDN is not so that means we can still actually reach those files by messing with route casing.

As example `/trace` is supposed to be hidden - and initially it appears to be: https://netlify-plugin-nextjs-demo.netlify.app/trace, however https://netlify-plugin-nextjs-demo.netlify.app/tRace allow to view the `trace` file. Preview Deploy for this PR actually make it impossible to serve that asset regardless of casing as it's just not deployed to CDN: https://deploy-preview-2104--netlify-plugin-nextjs-demo.netlify.app/tRaCe/

This PR changes "hiding metadata files" implementation to actually prevent those files from being deployed by deleting them after all the functions bundling (that rely on those metadata files) is finished.

This change also required adjustment to 404 documents - we were not moving them from `.next/server(less)/pages` before - now they are moved the same as regular html files and 404 redirects were updated to match it. This was needed because we do delete `.next/server(less)` before deployment so those 404 documents were just lost and not available to be served.

### Test plan

1. Visit the Deploy Preview ([insert link to specific page]()) ...

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.

Ref: https://github.com/netlify/pod-ecosystem-frameworks/issues/491
