### PR TITLE
chore: fix path for e2e tests

### DIFF
--- a/.github/workflows/cypress-canary.yml
+++ b/.github/workflows/cypress-canary.yml
@@ -8,7 +8,7 @@ on:
     paths:
       - 'demos/canary/**/*.{js,jsx,ts,tsx}'
       - 'cypress/e2e/canary/**/*.{ts,js}'
-      - 'src/**/*.{ts,js}'
+      - 'packages/*/src/**/*.{ts,js}'
 jobs:
   cypress:
     name: Cypress

--- a/.github/workflows/cypress-demo-nx.yml
+++ b/.github/workflows/cypress-demo-nx.yml
@@ -8,7 +8,7 @@ on:
     paths:
       - 'demos/nx-next-monorepo-demo/**/*.{js,jsx,ts,tsx}'
       - 'cypress/e2e/nx/**/*.{ts,js}'
-      - 'src/**/*.{ts,js}'
+      - 'packages/*/src/**/*.{ts,js}'
 jobs:
   cypress:
     name: Cypress

--- a/.github/workflows/cypress-demo-static.yml
+++ b/.github/workflows/cypress-demo-static.yml
@@ -8,7 +8,7 @@ on:
     paths:
       - 'demos/static-root/**/*.{js,jsx,ts,tsx}'
       - 'cypress/e2e/static/**/*.{ts,js}'
-      - 'src/**/*.{ts,js}'
+      - 'packages/*/src/**/*.{ts,js}'
 jobs:
   cypress:
     name: Cypress

--- a/.github/workflows/cypress-demo.yml
+++ b/.github/workflows/cypress-demo.yml
@@ -8,7 +8,7 @@ on:
     paths:
       - 'demos/default/**/*.{js,jsx,ts,tsx}'
       - 'cypress/e2e/default/**/*.{ts,js}'
-      - 'src/**/*.{ts,js}'
+      - 'packages/*/src/**/*.{ts,js}'
 jobs:
   cypress:
     name: Cypress

--- a/.github/workflows/cypress-middleware.yml
+++ b/.github/workflows/cypress-middleware.yml
@@ -8,7 +8,7 @@ on:
     paths:
       - 'demos/middleware/**/*.{js,jsx,ts,tsx}'
       - 'cypress/e2e/middleware/**/*.{ts,js}'
-      - 'src/**/*.{ts,js}'
+      - 'packages/*/src/**/*.{ts,js}'
 jobs:
   cypress:
     name: Cypress


### PR DESCRIPTION
Currently the e2e tests are not run on master, because the paths in the workflow are incorrect.