### PR TITLE
fix: support named & default export for middleware in ntl dev

### DIFF
--- a/packages/runtime/src/templates/edge-shared/utils.ts
+++ b/packages/runtime/src/templates/edge-shared/utils.ts
@@ -306,4 +306,4 @@ export const redirectTrailingSlash = (url: URL, trailingSlash: boolean): Respons
   }
 }
 
-export const isFunction = f => Boolean(f) && typeof f === 'function'
+export const isFunction = (f) => Boolean(f) && typeof f === 'function'

--- a/packages/runtime/src/templates/edge-shared/utils.ts
+++ b/packages/runtime/src/templates/edge-shared/utils.ts
@@ -306,4 +306,4 @@ export const redirectTrailingSlash = (url: URL, trailingSlash: boolean): Respons
   }
 }
 
-export const isFunction = (f) => Boolean(f) && typeof f === 'function'
+export const isFunction = (f: unknown) => Boolean(f) && typeof f === 'function'

--- a/packages/runtime/src/templates/edge-shared/utils.ts
+++ b/packages/runtime/src/templates/edge-shared/utils.ts
@@ -305,3 +305,5 @@ export const redirectTrailingSlash = (url: URL, trailingSlash: boolean): Respons
     return Response.redirect(url, 308)
   }
 }
+
+export const isFunction = f => Boolean(f) && typeof f === 'function'

--- a/packages/runtime/src/templates/edge/next-dev.js
+++ b/packages/runtime/src/templates/edge/next-dev.js
@@ -38,7 +38,11 @@ const handler = async (req, context) => {
     const nextMiddleware = await import(`../../middleware.js#${++idx}`)
 
     // The middleware file can export a named `middleware` export or a `default` export
-    middleware = isFunction(nextMiddleware.middleware) ? nextMiddleware.middleware : isFunction(nextMiddleware.default) ? nextMiddleware.default : undefined
+    middleware = isFunction(nextMiddleware.middleware)
+      ? nextMiddleware.middleware
+      : isFunction(nextMiddleware.default)
+      ? nextMiddleware.default
+      : undefined
 
     if (!middleware) {
       throw new Error('The middleware must export a `middleware` or a `default` function')

--- a/packages/runtime/src/templates/edge/next-dev.js
+++ b/packages/runtime/src/templates/edge/next-dev.js
@@ -1,7 +1,7 @@
 import { NextRequest } from 'https://esm.sh/v91/next@12.2.5/deno/dist/server/web/spec-extension/request.js'
 import { NextResponse } from 'https://esm.sh/v91/next@12.2.5/deno/dist/server/web/spec-extension/response.js'
 import { fromFileUrl } from 'https://deno.land/std@0.151.0/path/mod.ts'
-import { buildResponse } from '../edge-shared/utils.ts'
+import { buildResponse, isFunction } from '../edge-shared/utils.ts'
 
 globalThis.NFRequestContextMap ||= new Map()
 globalThis.__dirname = fromFileUrl(new URL('./', import.meta.url)).slice(0, -1)
@@ -36,7 +36,9 @@ const handler = async (req, context) => {
     // We need to cache-bust the import because otherwise it will claim it
     // doesn't exist if the user creates it after the server starts
     const nextMiddleware = await import(`../../middleware.js#${++idx}`)
-    middleware = nextMiddleware.middleware
+
+    // The middleware file can export a named `middleware` export or a `default` export
+    middleware = isFunction(nextMiddleware.middleware) ? nextMiddleware.middleware : nextMiddleware.default
   } catch (importError) {
     if (importError.code === 'ERR_MODULE_NOT_FOUND' && importError.message.includes(`middleware.js`)) {
       //  No middleware, so we silently return

--- a/packages/runtime/src/templates/edge/next-dev.js
+++ b/packages/runtime/src/templates/edge/next-dev.js
@@ -38,7 +38,11 @@ const handler = async (req, context) => {
     const nextMiddleware = await import(`../../middleware.js#${++idx}`)
 
     // The middleware file can export a named `middleware` export or a `default` export
-    middleware = isFunction(nextMiddleware.middleware) ? nextMiddleware.middleware : nextMiddleware.default
+    middleware = isFunction(nextMiddleware.middleware) ? nextMiddleware.middleware : isFunction(nextMiddleware.default) ? nextMiddleware.default : undefined
+
+    if (!middleware) {
+      throw new Error('The middleware must export a `middleware` or a `default` function')
+    }
   } catch (importError) {
     if (importError.code === 'ERR_MODULE_NOT_FOUND' && importError.message.includes(`middleware.js`)) {
       //  No middleware, so we silently return


### PR DESCRIPTION
## Description

As explained in https://github.com/amannn/next-intl/issues/290#issuecomment-1549110801 it seems that both a named `middleware` export and a `default` export is supported.

This allows both for `netlify dev` when we import the middleware.

### Documentation

N/A

## Tests

No tests were added but I tried the change manually on the repository shared in https://github.com/netlify/next-runtime/issues/2106

You can test this change yourself like so:

1. Existing E2E middleware should continue to work
2. https://github.com/netlify/next-runtime/issues/2106

## Relevant links (GitHub issues, etc.) or a picture of cute animal

Fixes https://github.com/netlify/next-runtime/issues/2106
