### PR TITLE
fix: checks when Next.js' implementation of ResponseCookies._headers is undefined now

### DIFF
--- a/packages/runtime/src/templates/edge-shared/utils.ts
+++ b/packages/runtime/src/templates/edge-shared/utils.ts
@@ -58,6 +58,8 @@ export const addMiddlewareHeaders = async (
 }
 
 interface ResponseCookies {
+  // This is non-standard that Next.js adds.
+  // See github.com/vercel/next.js/blob/de08f8b3d31ef45131dad97a7d0e95fa01001167/packages/next/src/compiled/@edge-runtime/cookies/index.js#L158
   readonly _headers: Headers
 }
 
@@ -191,7 +193,8 @@ export const buildResponse = async ({
     }
 
     // NextResponse doesn't set cookies onto the originResponse, so we need to copy them over
-    if (response.cookies._headers.has('set-cookie')) {
+    // In some cases, it's possible there are no headers set. See https://github.com/netlify/pod-ecosystem-frameworks/issues/475
+    if (response.cookies._headers?.has('set-cookie')) {
       response.originResponse.headers.set('set-cookie', response.cookies._headers.get('set-cookie')!)
     }
 


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/netlify/next-runtime/blob/main/CONTRIBUTING.md. -->

## Description

In some instances `response.cookies._headers` was `undefined` even though the types say they're not supposed to be causing the check introduced in #2027 to crash. Now we check if `response.cookies._headers` is defined before doing any operations on it.

### Documentation

## Tests

<!-- Did you add tests? How did you test this change? -->

You can test this change yourself like so:

1. There are already E2E tests in place from #2027 

## Relevant links (GitHub issues, etc.) or a picture of cute animal

Non-standard implementation of ResponseCookies, https://github.com/vercel/next.js/blob/de08f8b3d31ef45131dad97a7d0e95fa01001167/packages/next/src/compiled/@edge-runtime/cookies/index.js#L158

Closes https://github.com/netlify/pod-ecosystem-frameworks/issues/475
