### PR TITLE
fix: clientContext isn't available in background functions

### DIFF
--- a/packages/runtime/src/templates/getApiHandler.ts
+++ b/packages/runtime/src/templates/getApiHandler.ts
@@ -70,9 +70,7 @@ const makeApiHandler = ({ conf, app, pageRoot, NextServer }: MakeApiHandlerParam
       return bridge
     }
 
-    const {
-      clientContext: { custom: customContext },
-    } = context
+    const customContext = context.clientContext?.custom
 
     // Scheduled functions don't have a URL, but we need to give one so Next knows the route to serve
     const url = event.rawUrl ? new URL(event.rawUrl) : new URL(path, process.env.URL || 'http://n')


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/netlify/next-runtime/blob/main/CONTRIBUTING.md. -->

## Description

This PR fixes a regression introduced in https://github.com/netlify/next-runtime/pull/2058. `clientContext` isn't available in backround functions, so destructuring on it throws an error.

<!-- Provide a brief summary of the change. -->

### Documentation

<!-- Where is this feature or API documented? Did you create an internal and/or external artifact to document this change? -->

## Tests

<!-- Did you add tests? How did you test this change? -->

You can test this change yourself like so:

1. TODO

## Relevant links (GitHub issues, etc.) or a picture of cute animal

<!-- Link to an issue that is fixed by this PR or related to this PR. -->
