### PR TITLE
fix: resolve follow-redirects from runtime package

### DIFF
--- a/packages/runtime/src/helpers/functions.ts
+++ b/packages/runtime/src/helpers/functions.ts
@@ -269,7 +269,7 @@ const traceNextServer = async (publish: string): Promise<string[]> => {
 
 export const traceNPMPackage = async (packageName: string, publish: string) => {
   try {
-    return await glob(join(dirname(require.resolve(packageName, { paths: [publish] })), '**', '*'), {
+    return await glob(join(dirname(require.resolve(packageName, { paths: [__dirname, publish] })), '**', '*'), {
       absolute: true,
     })
   } catch (error) {


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/netlify/next-runtime/blob/main/CONTRIBUTING.md. -->

## Description

If the Next Runtime is auto-installed, then `follow-redirects` (which is a dep of `next-runtime`) won't be resolvable from `.next` (the `publish` dir). This results in an error.

To fix this, I'm adding `__dirname` as a second resolution starting point. `__dirname` always points to a file within the `next-runtime` package, so `follow-redirects` should be resolvable from there.

Previously discussed in https://netlify.slack.com/archives/C02T8ASK2E9/p1684318093610159.

<!-- Provide a brief summary of the change. -->

### Documentation

<!-- Where is this feature or API documented? Did you create an internal and/or external artifact to document this change? -->

## Tests

<!-- Did you add tests? How did you test this change? -->

You can test this change yourself like so:

1. TODO

## Relevant links (GitHub issues, etc.) or a picture of cute animal

<!-- Link to an issue that is fixed by this PR or related to this PR. -->
