### PR TITLE
chore: add github workflow to add zenhub label

### DIFF
--- a/.github/workflows/add-zenhub-label.yml
+++ b/.github/workflows/add-zenhub-label.yml
@@ -1,0 +1,24 @@
+# Ensure we add the correct ZenHub label for all new issues
+# Avoids problem where checklist issues are not added to the correct ZenHub pipeline
+
+name: Add ZenHub label to issues
+on:
+  issues:
+    types:
+      - reopened
+      - opened
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["Ecosystem: Frameworks"]
+            })

--- a/package-lock.json
+++ b/package-lock.json
@@ -24530,7 +24530,7 @@
     },
     "packages/runtime": {
       "name": "@netlify/plugin-nextjs",
-      "version": "4.37.1",
+      "version": "4.37.2",
       "license": "MIT",
       "dependencies": {
         "@netlify/esbuild": "0.14.39",
@@ -24552,7 +24552,7 @@
         "p-limit": "^3.1.0",
         "pathe": "^0.2.0",
         "pretty-bytes": "^5.6.0",
-        "regexp-tree": "^0.1.27",
+        "regexp-tree": "^0.1.24",
         "semver": "^7.3.5",
         "slash": "^3.0.0",
         "tiny-glob": "^0.2.9"
@@ -28041,7 +28041,7 @@
         "p-limit": "^3.1.0",
         "pathe": "^0.2.0",
         "pretty-bytes": "^5.6.0",
-        "regexp-tree": "0.1.27",
+        "regexp-tree": "^0.1.24",
         "semver": "^7.3.5",
         "slash": "^3.0.0",
         "tiny-glob": "^0.2.9",


### PR DESCRIPTION
## Description

Adds `Ecosystem: Frameworks` label for all created issues to ensure it appears on the correct ZenHub workspace. Issues which are created using GitHub checklists didn't apply the issue template and the label was missing.

### Documentation

N/A

## Tests

N/A

## Relevant links (GitHub issues, etc.) or a picture of cute animal

![image](https://github.com/netlify/next-runtime/assets/1965510/59498894-ecd5-4990-b645-35241b09b120)


Related issue: https://github.com/netlify/pod-ecosystem-frameworks/issues/507
