### PR TITLE
fix: tracing root use `appDir` as fallback

### DIFF
--- a/packages/runtime/src/helpers/functions.ts
+++ b/packages/runtime/src/helpers/functions.ts
@@ -231,11 +231,12 @@ export const setupImageFunction = async ({
 const traceRequiredServerFiles = async (publish: string): Promise<string[]> => {
   const requiredServerFiles = await getRequiredServerFiles(publish)
 
-  const relativeAppDir = requiredServerFiles.relativeAppDir ?? ''
-  const outputFileTracingRoot = requiredServerFiles.config.experimental.outputFileTracingRoot ?? ''
-  const files = requiredServerFiles.files ?? []
+  let appDirRoot = requiredServerFiles.appDir ?? join(publish, '..')
+  if (requiredServerFiles.relativeAppDir && requiredServerFiles.config.experimental.outputFileTracingRoot) {
+    appDirRoot = join(requiredServerFiles.relativeAppDir, requiredServerFiles.config.experimental.outputFileTracingRoot)
+  }
 
-  const appDirRoot = join(outputFileTracingRoot, relativeAppDir)
+  const files = requiredServerFiles.files ?? []
   const absoluteFiles = files.map((file) => join(appDirRoot, file))
 
   absoluteFiles.push(join(publish, 'required-server-files.json'))

--- a/packages/runtime/src/helpers/functions.ts
+++ b/packages/runtime/src/helpers/functions.ts
@@ -229,13 +229,12 @@ export const setupImageFunction = async ({
 }
 
 const traceRequiredServerFiles = async (publish: string): Promise<string[]> => {
-  const {
-    files,
-    relativeAppDir,
-    config: {
-      experimental: { outputFileTracingRoot },
-    },
-  } = await getRequiredServerFiles(publish)
+  const requiredServerFiles = await getRequiredServerFiles(publish)
+
+  const relativeAppDir = requiredServerFiles.relativeAppDir ?? ''
+  const outputFileTracingRoot = requiredServerFiles.config.experimental.outputFileTracingRoot ?? ''
+  const files = requiredServerFiles.files ?? []
+
   const appDirRoot = join(outputFileTracingRoot, relativeAppDir)
   const absoluteFiles = files.map((file) => join(appDirRoot, file))
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -737,6 +737,26 @@ describe('onBuild()', () => {
 
     expect(netlifyConfig.functions['_api_*'].node_bundler).toEqual('nft')
   })
+
+  it('works when `relativeAppDir` is undefined', async () => {
+    await moveNextDist()
+
+    const initialConfig = await getRequiredServerFiles(netlifyConfig.build.publish)
+    delete initialConfig.relativeAppDir
+    await updateRequiredServerFiles(netlifyConfig.build.publish, initialConfig)
+
+    await expect(nextRuntime.onBuild(defaultArgs)).not.toReject()
+  })
+
+  it('works when `outputFileTracingRoot` is undefined', async () => {
+    await moveNextDist()
+
+    const initialConfig = await getRequiredServerFiles(netlifyConfig.build.publish)
+    delete initialConfig.config.experimental.outputFileTracingRoot
+    await updateRequiredServerFiles(netlifyConfig.build.publish, initialConfig)
+
+    await expect(nextRuntime.onBuild(defaultArgs)).not.toReject()
+  })
 })
 
 describe('onPostBuild', () => {


### PR DESCRIPTION
## Description

We were relying on values `relativeAppDir` and `outputFileTracingRoot` that were optional, and don't exist for every version of Next.js.

`relativeAppDir` was introduced in https://github.com/vercel/next.js/pull/46393.
`appDir` was introduced in https://github.com/vercel/next.js/pull/22915.
`outputFileTracingRoot` was introduced in https://github.com/vercel/next.js/pull/22915.

This PR makes it so that we fall back to use `appDir` if `outputFileTracingRoot` and `relativeAppDir` aren't available.

### Documentation

<!-- Where is this feature or API documented? Did you create an internal and/or external artifact to document this change? -->

## Tests

<!-- Did you add tests? How did you test this change? -->

You can test this change yourself like so:

1. TODO

## Relevant links (GitHub issues, etc.) or a picture of cute animal

<!-- Link to an issue that is fixed by this PR or related to this PR. -->
