### PR TITLE
fix: bundle dynamic API routes correctly with split-api-routes

### DIFF
--- a/cypress/e2e/default/api.cy.ts
+++ b/cypress/e2e/default/api.cy.ts
@@ -6,6 +6,14 @@ describe('API routes', () => {
   })
 })
 
+describe('Dynamic API routes', () => {
+  it('are bundled correctly', () => {
+    cy.request('/api/shows/1').then((response) => {
+      expect(response.status).to.equal(200)
+    })
+  })
+})
+
 describe('Extended API routes', () => {
   it('returns HTTP 202 Accepted for background route', () => {
     cy.request('/api/hello-background').then((response) => {

--- a/packages/runtime/src/helpers/config.ts
+++ b/packages/runtime/src/helpers/config.ts
@@ -96,6 +96,12 @@ export const hasManuallyAddedModule = ({
   )
 /* eslint-enable camelcase */
 
+/**
+ * Transforms `/api/shows/[id].js` into `/api/shows/*id*.js`,
+ * so that the file `[id].js` is matched correctly.
+ */
+const escapeGlob = (path: string) => path.replace(/\[/g, '*').replace(/]/g, '*')
+
 export const configureHandlerFunctions = async ({
   netlifyConfig,
   publish,
@@ -173,7 +179,7 @@ export const configureHandlerFunctions = async ({
       netlifyConfig.functions[functionName] ||= { included_files: [] }
       netlifyConfig.functions[functionName].node_bundler = 'none'
       netlifyConfig.functions[functionName].included_files ||= []
-      netlifyConfig.functions[functionName].included_files.push(...includedFiles)
+      netlifyConfig.functions[functionName].included_files.push(...includedFiles.map(escapeGlob))
     }
   } else {
     configureFunction('_api_*')


### PR DESCRIPTION
## Description

We discovered that dynamic API routes, e.g. `/api/shows/[id].js`, aren't bundled correctly. This is likely due to the square brackets being interpreted as special glob patterns, resulting in the underlying files not being included correctly.

This PR adds an e2e test that demonstrates the bug, and then fixes it by processing the glob patterns before passing them to the build process.

### Documentation

<!-- Where is this feature or API documented? Did you create an internal and/or external artifact to document this change? -->

## Tests

<!-- Did you add tests? How did you test this change? -->

You can test this change yourself like so:

1. TODO

## Relevant links (GitHub issues, etc.) or a picture of cute animal

https://github.com/netlify/pod-dev-foundations/issues/516

<!-- Link to an issue that is fixed by this PR or related to this PR. -->
