### PR TITLE
refactor: use LAMBDA_WARNING_SIZE as packing threshold

### DIFF
--- a/packages/runtime/src/helpers/functions.ts
+++ b/packages/runtime/src/helpers/functions.ts
@@ -16,6 +16,7 @@ import {
   HANDLER_FUNCTION_TITLE,
   ODB_FUNCTION_TITLE,
   IMAGE_FUNCTION_TITLE,
+  LAMBDA_WARNING_SIZE,
 } from '../constants'
 import { getApiHandler } from '../templates/getApiHandler'
 import { getHandler } from '../templates/getHandler'
@@ -314,8 +315,6 @@ const getBundleWeight = async (patterns: string[]) => {
   return sum(sizes.flat(1))
 }
 
-const MB = 1024 * 1024
-
 export const getAPILambdas = async (
   publish: string,
   baseDir: string,
@@ -323,7 +322,7 @@ export const getAPILambdas = async (
 ): Promise<APILambda[]> => {
   const commonDependencies = await getAPIPRouteCommonDependencies(publish)
 
-  const threshold = 50 * MB - (await getBundleWeight(commonDependencies))
+  const threshold = LAMBDA_WARNING_SIZE - (await getBundleWeight(commonDependencies))
 
   const apiRoutes = await getApiRouteConfigs(publish, baseDir, pageExtensions)
 

--- a/test/helpers/functionsMetaData.spec.ts
+++ b/test/helpers/functionsMetaData.spec.ts
@@ -4,6 +4,7 @@ import { join } from 'pathe'
 
 import { NEXT_PLUGIN_NAME } from '../../packages/runtime/src/constants'
 import { writeFunctionConfiguration } from '../../packages/runtime/src/helpers/functionsMetaData'
+import { getFunctionNameForPage } from '../../packages/runtime/src/helpers/utils'
 
 describe('writeFunctionConfiguration', () => {
   afterEach(() => {
@@ -102,5 +103,9 @@ describe('writeFunctionConfiguration', () => {
     const actual = await readJSON(filePathToSaveTo)
 
     expect(actual).toEqual(expected)
+  })
+
+  it('test', () => {
+    expect(getFunctionNameForPage('/api/shows/[id]')).toEqual('index')
   })
 })


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/netlify/next-runtime/blob/main/CONTRIBUTING.md. -->

## Description

While going through the codebase, I discovered a magic number I left floating around. This PR replaces that with a reference to a constant we already had.

<!-- Provide a brief summary of the change. -->

### Documentation

<!-- Where is this feature or API documented? Did you create an internal and/or external artifact to document this change? -->

## Tests

<!-- Did you add tests? How did you test this change? -->

You can test this change yourself like so:

1. TODO

## Relevant links (GitHub issues, etc.) or a picture of cute animal

<!-- Link to an issue that is fixed by this PR or related to this PR. -->
