### PR TITLE
fix: optionally chain server functions when selecting react version

### DIFF
--- a/packages/runtime/src/templates/server.ts
+++ b/packages/runtime/src/templates/server.ts
@@ -70,11 +70,11 @@ const getNetlifyNextServer = (NextServer: NextServerType) => {
 
     // doing what they do in https://github.com/vercel/vercel/blob/1663db7ca34d3dd99b57994f801fb30b72fbd2f3/packages/next/src/server-build.ts#L576-L580
     private netlifyPrebundleReact(path: string) {
-      const routesManifest = this.getRoutesManifest()
-      const appPathsManifest = this.getAppPathsManifest()
+      const routesManifest = this.getRoutesManifest?.()
+      const appPathsManifest = this.getAppPathsManifest?.()
 
-      const routes = [...routesManifest.staticRoutes, ...routesManifest.dynamicRoutes]
-      const matchedRoute = routes.find((route) => new RegExp(route.regex).test(path))
+      const routes = routesManifest && [...routesManifest.staticRoutes, ...routesManifest.dynamicRoutes]
+      const matchedRoute = routes?.find((route) => new RegExp(route.regex).test(path))
       const isAppRoute =
         appPathsManifest && matchedRoute ? appPathsManifest[joinPaths(matchedRoute.page, 'page')] : false
 


### PR DESCRIPTION
## Description

The previous Next 13.4 [update PR](https://github.com/netlify/next-runtime/pull/2080/) introduced a route check to optionally use the prebundled react module, as required by Next.

This PR makes it backwards-compatible with Next 11.

## Tests

Automated tests for previous Next versions are currently in discussion.