### PR TITLE
fix: use native path matching for prebundled react conditional

### DIFF
--- a/packages/runtime/src/templates/server.ts
+++ b/packages/runtime/src/templates/server.ts
@@ -12,7 +12,6 @@ import {
   localizeRoute,
   localizeDataRoute,
   unlocalizeRoute,
-  joinPaths,
 } from './handlerUtils'
 
 interface NetlifyConfig {
@@ -78,12 +77,11 @@ const getNetlifyNextServer = (NextServer: NextServerType) => {
     // doing what they do in https://github.com/vercel/vercel/blob/1663db7ca34d3dd99b57994f801fb30b72fbd2f3/packages/next/src/server-build.ts#L576-L580
     private netlifyPrebundleReact(path: string) {
       const routesManifest = this.getRoutesManifest?.()
-      const appPathsManifest = this.getAppPathsManifest?.()
+      const appPathsRoutes = this.getAppPathRoutes?.()
 
       const routes = routesManifest && [...routesManifest.staticRoutes, ...routesManifest.dynamicRoutes]
-      const matchedRoute = routes?.find((route) => new RegExp(route.regex).test(path.split('?')[0]))
-      const isAppRoute =
-        appPathsManifest && matchedRoute ? appPathsManifest[joinPaths(matchedRoute.page, 'page')] : false
+      const matchedRoute = routes?.find((route) => new RegExp(route.regex).test(new URL(path, 'http://n').pathname))
+      const isAppRoute = appPathsRoutes && matchedRoute ? appPathsRoutes[matchedRoute.page] : false
 
       if (isAppRoute) {
         // app routes should use prebundled React

--- a/test/templates/server.spec.ts
+++ b/test/templates/server.spec.ts
@@ -66,14 +66,6 @@ jest.mock(
 )
 
 jest.mock(
-  'server/app-paths-manifest.json',
-  () => ({
-    '/blog/(test)/[author]/[slug]/page': 'app/blog/[author]/[slug]/page.js',
-  }),
-  { virtual: true },
-)
-
-jest.mock(
   'routes-manifest.json',
   () => ({
     dynamicRoutes: [
@@ -113,6 +105,10 @@ jest.mock(
   { virtual: true },
 )
 
+const appPathsManifest = {
+  '/blog/(test)/[author]/[slug]/page': 'app/blog/[author]/[slug]/page.js',
+}
+
 let NetlifyNextServer: NetlifyNextServerType
 beforeAll(() => {
   const NextServer: NextServerType = require(getServerFile(__dirname, false)).default
@@ -125,8 +121,7 @@ beforeAll(() => {
     this.nextConfig = nextOptions.conf
     this.netlifyConfig = netlifyConfig
     this.renderOpts = { previewProps: {} }
-    this.hasAppDir = Boolean(this.nextConfig?.experimental?.appDir)
-    this.appPathsManifest = this.getAppPathsManifest()
+    this.appPathsManifest = appPathsManifest
   }
   Object.setPrototypeOf(NetlifyNextServer, MockNetlifyNextServerConstructor)
 })


### PR DESCRIPTION
## Description

During the upgrade to Next 13.4 we implemented a fix so that the correct prebundled version of React is chosen when the route is App vs Pages router. However, we were attempting to determine the type of route using a custom path matching algorithm and it was failing when the route used route groups.

This PR uses the Next native `getAppPathRoutes` function to normalize the route, removing route groups and other artifacts in the path.

## Tests

Unit tests have been added (and former tests restored as these were yet to be re-enabled after #2080 was merged).

## Relevant links (GitHub issues, etc.) or a picture of cute animal

Fixes netlify/pod-ecosystem-frameworks#489 (again)
