### PR TITLE
fix: don't ever execute middleware in lambda

### DIFF
--- a/cypress/e2e/middleware/preview.cy.ts
+++ b/cypress/e2e/middleware/preview.cy.ts
@@ -1,0 +1,34 @@
+describe('Preview Mode', () => {
+  it('enters and exits preview mode', () => {
+    Cypress.Cookies.debug(true)
+    cy.getCookies().then((cookie) => cy.log('cookies', cookie))
+
+    cy.intercept('/previewTest', (req) => {
+      req.continue((res) => {
+        expect(res.headers?.['x-middleware-executed']).to.equal('true')
+      })
+    }).as('previewTestVisit')
+
+    // preview mode is off by default
+    cy.visit('/previewTest')
+    cy.findByText('Is preview? No', { selector: 'h1' })
+
+    // enter preview mode
+    cy.request('/api/enterPreview').then((response) => {
+      expect(response.body).to.have.property('name', 'preview mode')
+    })
+
+    // exptected content is rendered
+    cy.visit('/previewTest')
+    cy.findByText('Is preview? Yes!', { selector: 'h1' })
+
+    // exit preview mode
+    cy.request('/api/exitPreview')
+    cy.visit('/previewTest')
+    cy.findByText('Is preview? No', { selector: 'h1' })
+
+    // we should hit /previewTest 3 times (before entering preview, after entering preview, after exiting preview)
+    // this assertion is mainly to ensure interception works and assertion on response header is made
+    cy.get('@previewTestVisit.all').should('have.length', 3)
+  })
+})

--- a/demos/middleware/middleware.ts
+++ b/demos/middleware/middleware.ts
@@ -15,11 +15,11 @@ export async function middleware(req: NextRequest) {
     headers.set('x-hello', 'world')
     return NextResponse.next({
       request: {
-        headers
-      }
+        headers,
+      },
     })
   }
-  
+
   const request = new MiddlewareRequest(req)
 
   // skipMiddlewareUrlNormalize next config option is used so we have to try to match both html path and data blob path
@@ -41,12 +41,11 @@ export async function middleware(req: NextRequest) {
   // skipMiddlewareUrlNormalize next config option is used so we have to try to match both html path and data blob path
   if (pathname.startsWith('/request-rewrite') || pathname.endsWith('/request-rewrite.json')) {
     // request.rewrite() should return the MiddlewareResponse object instead of the Response object.
-    const res = await request.rewrite('/static-rewrite',
-    {
+    const res = await request.rewrite('/static-rewrite', {
       headers: {
         'x-rewrite-test': 'hello',
-        'x-rewrite-test-2': 'hello-2'
-      }
+        'x-rewrite-test-2': 'hello-2',
+      },
     })
     const message = `This was static (& escaping test &amp;) but has been transformed in ${req.geo?.city}`
 
@@ -90,7 +89,7 @@ export async function middleware(req: NextRequest) {
     return response
   }
 
-  if(pathname.startsWith('/matcher-cookie')) {
+  if (pathname.startsWith('/matcher-cookie')) {
     response = NextResponse.next()
     response.cookies.set('missingCookie', 'true')
     return response
@@ -106,6 +105,13 @@ export async function middleware(req: NextRequest) {
   if (pathname.startsWith('/missing')) {
     response = NextResponse.next()
     response.headers.set('x-cookie-missing', 'true')
+    return response
+  }
+
+  if (pathname.startsWith('/previewTest')) {
+    response = NextResponse.next()
+
+    response.headers.set('x-middleware-executed', 'true')
     return response
   }
 
@@ -167,8 +173,8 @@ export const config = {
     '/:all*/locale-preserving-rewrite',
     '/cookies/:path*',
     { source: '/static' },
-    {source: '/request-rewrite' },
-    { source: '/matcher-cookie'},
+    { source: '/request-rewrite' },
+    { source: '/matcher-cookie' },
     { source: '/shows/((?!99|88).*)' },
     {
       source: '/conditional',
@@ -186,8 +192,9 @@ export const config = {
         {
           type: 'cookie',
           key: 'missingCookie',
-        }
+        },
       ],
     },
+    '/previewTest',
   ],
 }

--- a/demos/middleware/pages/api/enterPreview.js
+++ b/demos/middleware/pages/api/enterPreview.js
@@ -1,0 +1,6 @@
+export default async function preview(req, res) {
+  // Enable Preview Mode by setting the cookies
+  res.setPreviewData({})
+
+  res.status(200).json({ name: 'preview mode' })
+}

--- a/demos/middleware/pages/api/exitPreview.js
+++ b/demos/middleware/pages/api/exitPreview.js
@@ -1,0 +1,8 @@
+export default async function exit(_, res) {
+  // Exit the current user from "Preview Mode". This function accepts no args.
+  res.clearPreviewData()
+
+  // Redirect the user back to the index page.
+  res.writeHead(307, { Location: '/' })
+  res.end()
+}

--- a/demos/middleware/pages/index.js
+++ b/demos/middleware/pages/index.js
@@ -48,6 +48,9 @@ export default function Home() {
         <p>
           <Link href="/headers">Adds `x-hello` request header to a rewrite</Link>
         </p>
+        <p>
+          <Link href="/previewTest">Preview mode</Link>
+        </p>
       </main>
     </div>
   )

--- a/demos/middleware/pages/previewTest.js
+++ b/demos/middleware/pages/previewTest.js
@@ -1,0 +1,25 @@
+import Link from 'next/link'
+
+const StaticTest = ({ isPreview }) => {
+  return (
+    <div>
+      <h1>Is preview? {isPreview ? 'Yes!' : 'No'}</h1>
+      <p>
+        <a href={isPreview ? '/api/exitPreview' : '/api/enterPreview'}>
+          {isPreview ? 'Exit Preview' : 'Enter Preview'}
+        </a>
+      </p>
+      <Link href="/">Go back home</Link>
+    </div>
+  )
+}
+
+export const getStaticProps = async ({ preview }) => {
+  return {
+    props: {
+      isPreview: Boolean(preview),
+    },
+  }
+}
+
+export default StaticTest

--- a/packages/runtime/src/templates/server.ts
+++ b/packages/runtime/src/templates/server.ts
@@ -18,6 +18,7 @@ interface NetlifyConfig {
   revalidateToken?: string
 }
 
+// eslint-disable-next-line max-lines-per-function
 const getNetlifyNextServer = (NextServer: NextServerType) => {
   class NetlifyNextServer extends NextServer {
     private netlifyConfig: NetlifyConfig
@@ -115,6 +116,13 @@ const getNetlifyNextServer = (NextServer: NextServerType) => {
       } catch (error) {
         console.log(`Error revalidating ${route}:`, error.message)
         throw error
+      }
+    }
+
+    // eslint-disable-next-line class-methods-use-this, require-await
+    async runMiddleware(): Promise<{ finished: boolean }> {
+      return {
+        finished: false,
       }
     }
 


### PR DESCRIPTION
## Description

This change make `next-server`'s `runMiddleware` no-op in lambdas. There are some scenarios where `next-server` would attempt that (example one seems to be rendering page in preview mode). The middleware is executed at the edge so executing it at lambda would cause:
 - it to run twice causing unknown effects
 - rather unknown behavior and support for various middleware APIs (geo? text rewrite)
 - crash when using `@netlify/next` enhanced middleware as that would execute in Nodejs env which cause early bail because it's not Deno env.
 - when SPLIT_* (api / render ) mode is enabled in next runtime we would not bundle required files to run middleware (common missing module is `.next/server/edge-runtime-webpack.js` and middleware module itself) - we could bundle those but because of all of above it seems better to not even try to run middleware at lambda.

Making `runMiddleware` always no-op in lambda seems safe for now as Next middleware is supposed to run only at edge, but https://github.com/vercel/next.js/discussions/46722 is a feature request asking to make middleware environment configurable, but at least as of now there was no reply from Next.js maintainers 

`next-server` in general does have capability to run in Nodejs env as that's what is used locally (`next start`) through Next.js sandbox environment ( https://github.com/vercel/next.js/tree/canary/packages/next/src/server/web/sandbox )

It does seem like there is some difference in behavior between recent next versions (I could reproduce missing module problem with `next@13.2.4`, but it didn't seem to happen with `next@13.4.13`), but even if things don't crash, it still seems valid to not run middleware in lambda ever if it runs at edge already.

### Documentation

<!-- Where is this feature or API documented? Did you create an internal and/or external artifact to document this change? -->

## Tests

<!-- Did you add tests? How did you test this change? -->

Added cypress tests for middleware demo site

## Relevant links (GitHub issues, etc.) or a picture of cute animal

<!-- Link to an issue that is fixed by this PR or related to this PR. -->
https://github.com/netlify/pod-ecosystem-frameworks/issues/588