### PR TITLE
feat: support new monorepo setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@babel/preset-env": "^7.15.8",
     "@babel/preset-typescript": "^7.16.0",
     "@delucis/if-env": "^1.1.2",
-    "@netlify/build": "^29.20.3",
+    "@netlify/build": "^29.20.4",
     "@netlify/eslint-config-node": "^7.0.1",
     "@testing-library/cypress": "^9.0.0",
     "@types/fs-extra": "^9.0.13",

--- a/packages/runtime/src/helpers/edge.ts
+++ b/packages/runtime/src/helpers/edge.ts
@@ -354,9 +354,11 @@ export const getEdgeFunctionPatternForPage = ({
 export const writeEdgeFunctions = async ({
   netlifyConfig,
   routesManifest,
+  constants: { PACKAGE_PATH = '' },
 }: {
   netlifyConfig: NetlifyConfig
   routesManifest: RoutesManifest
+  constants: NetlifyPluginConstants
 }) => {
   const generator = await getPluginVersion()
 
@@ -366,7 +368,7 @@ export const writeEdgeFunctions = async ({
     version: 1,
   }
 
-  const edgeFunctionRoot = resolve('.netlify', 'edge-functions')
+  const edgeFunctionRoot = resolve(PACKAGE_PATH, '.netlify', 'edge-functions')
   await emptyDir(edgeFunctionRoot)
 
   const { publish } = netlifyConfig.build

--- a/packages/runtime/src/helpers/functions.ts
+++ b/packages/runtime/src/helpers/functions.ts
@@ -58,7 +58,12 @@ export interface APILambda extends SSRLambda {
 }
 
 export const generateFunctions = async (
-  { FUNCTIONS_SRC = DEFAULT_FUNCTIONS_SRC, INTERNAL_FUNCTIONS_SRC, PUBLISH_DIR }: NetlifyPluginConstants,
+  {
+    INTERNAL_FUNCTIONS_SRC,
+    PUBLISH_DIR,
+    PACKAGE_PATH = '',
+    FUNCTIONS_SRC = join(PACKAGE_PATH, DEFAULT_FUNCTIONS_SRC),
+  }: NetlifyPluginConstants,
   appDir: string,
   apiLambdas: APILambda[],
   ssrLambdas: SSRLambda[],
@@ -171,12 +176,13 @@ export const generateFunctions = async (
  */
 export const generatePagesResolver = async ({
   INTERNAL_FUNCTIONS_SRC,
-  FUNCTIONS_SRC = DEFAULT_FUNCTIONS_SRC,
   PUBLISH_DIR,
+  PACKAGE_PATH = '',
+  FUNCTIONS_SRC = join(PACKAGE_PATH, DEFAULT_FUNCTIONS_SRC),
 }: NetlifyPluginConstants): Promise<void> => {
   const functionsPath = INTERNAL_FUNCTIONS_SRC || FUNCTIONS_SRC
 
-  const jsSource = await getResolverForPages(PUBLISH_DIR)
+  const jsSource = await getResolverForPages(PUBLISH_DIR, PACKAGE_PATH)
 
   await writeFile(join(functionsPath, ODB_FUNCTION_NAME, 'pages.js'), jsSource)
   await writeFile(join(functionsPath, HANDLER_FUNCTION_NAME, 'pages.js'), jsSource)
@@ -184,7 +190,12 @@ export const generatePagesResolver = async ({
 
 // Move our next/image function into the correct functions directory
 export const setupImageFunction = async ({
-  constants: { INTERNAL_FUNCTIONS_SRC, FUNCTIONS_SRC = DEFAULT_FUNCTIONS_SRC, IS_LOCAL },
+  constants: {
+    IS_LOCAL,
+    INTERNAL_FUNCTIONS_SRC,
+    PACKAGE_PATH = '',
+    FUNCTIONS_SRC = join(PACKAGE_PATH, DEFAULT_FUNCTIONS_SRC),
+  },
   imageconfig = {},
   netlifyConfig,
   basePath,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -213,7 +213,7 @@ const plugin: NetlifyPlugin = {
       apiLambdas,
     })
 
-    await writeEdgeFunctions({ netlifyConfig, routesManifest })
+    await writeEdgeFunctions({ constants, netlifyConfig, routesManifest })
   },
 
   async onPostBuild({

--- a/packages/runtime/src/templates/getPageResolver.ts
+++ b/packages/runtime/src/templates/getPageResolver.ts
@@ -43,8 +43,8 @@ export const getResolverForDependencies = ({
   `
 }
 
-export const getResolverForPages = async (publish: string) => {
-  const functionDir = resolve('.netlify', 'functions', HANDLER_FUNCTION_NAME)
+export const getResolverForPages = async (publish: string, packagePath: string) => {
+  const functionDir = resolve(packagePath, '.netlify', 'functions', HANDLER_FUNCTION_NAME)
   const dependencies = await getAllPageDependencies(publish)
   return getResolverForDependencies({ dependencies, functionDir })
 }


### PR DESCRIPTION
## Description

Changes the function path resolution logic to account for the new `packagePath` property, such that functions are placed in the `.netlify/functions-internal` directory inside the package path and not at the repository root.

## Relevant links (GitHub issues, etc.) or a picture of cute animal

- https://github.com/netlify/build/pull/5223
- https://github.com/netlify/build/pull/5225
