### PR TITLE
fix: pass packagePath down to rsc edge manifest

### DIFF
--- a/packages/runtime/src/helpers/edge.ts
+++ b/packages/runtime/src/helpers/edge.ts
@@ -277,7 +277,9 @@ export const writeDevEdgeFunction = async ({
 export const generateRscDataEdgeManifest = async ({
   prerenderManifest,
   appPathRoutesManifest,
+  packagePath,
 }: {
+  packagePath: string
   prerenderManifest?: PrerenderManifest
   appPathRoutesManifest?: Record<string, string>
 }): Promise<FunctionManifest['functions']> => {
@@ -303,7 +305,7 @@ export const generateRscDataEdgeManifest = async ({
     return []
   }
 
-  const edgeFunctionDir = resolve('.netlify', 'edge-functions', 'rsc-data')
+  const edgeFunctionDir = resolve(packagePath, '.netlify', 'edge-functions', 'rsc-data')
   await ensureDir(edgeFunctionDir)
   await copyEdgeSourceFile({ edgeFunctionDir, file: 'rsc-data.ts' })
 
@@ -387,6 +389,7 @@ export const writeEdgeFunctions = async ({
   }
 
   const rscFunctions = await generateRscDataEdgeManifest({
+    packagePath: PACKAGE_PATH,
     prerenderManifest: await loadPrerenderManifest(netlifyConfig),
     appPathRoutesManifest: await loadAppPathRoutesManifest(netlifyConfig),
   })

--- a/packages/runtime/src/helpers/edge.ts
+++ b/packages/runtime/src/helpers/edge.ts
@@ -277,9 +277,9 @@ export const writeDevEdgeFunction = async ({
 export const generateRscDataEdgeManifest = async ({
   prerenderManifest,
   appPathRoutesManifest,
-  packagePath,
+  packagePath = '',
 }: {
-  packagePath: string
+  packagePath?: string
   prerenderManifest?: PrerenderManifest
   appPathRoutesManifest?: Record<string, string>
 }): Promise<FunctionManifest['functions']> => {


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/netlify/next-runtime/blob/main/CONTRIBUTING.md. -->

## Description

Fixes an issue with monorepos and the new `appDir` where the `packagePath` was not passed down to the RSC edge manifest


I've deployed this change here on my test site with monorepo settings turned on, and the `content-type` is correctly set to `text/x-component`

```
curl -i -H "RSC: 1" https://lukas-next-runtime-demos-default.netlify.app/blog/erica/
```
![CleanShot 2023-08-17 at 09 46 55](https://github.com/netlify/next-runtime/assets/11156362/d879d239-7e9e-4599-96ba-1fe0c2ca5f19)


<!-- Provide a brief summary of the change. -->

### Documentation

<!-- Where is this feature or API documented? Did you create an internal and/or external artifact to document this change? -->

## Tests

<!-- Did you add tests? How did you test this change? -->

You can test this change yourself like so:

1. TODO

## Relevant links (GitHub issues, etc.) or a picture of cute animal

<!-- Link to an issue that is fixed by this PR or related to this PR. -->
