### PR TITLE
feat: cdn cache control support

### DIFF
--- a/.github/workflows/cypress-demo-all-flags.yml
+++ b/.github/workflows/cypress-demo-all-flags.yml
@@ -1,0 +1,73 @@
+name: Run e2e (default demo with all feature flags enabled)
+on:
+  pull_request:
+    types: [opened, synchronize]
+  push:
+    branches:
+      - main
+    paths:
+      - 'demos/default/**/*.{js,jsx,ts,tsx}'
+      - 'cypress/e2e/default/**/*.{ts,js}'
+      - 'packages/*/src/**/*.{ts,js}'
+jobs:
+  cypress:
+    name: Cypress
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        containers: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Generate Github token
+        uses: navikt/github-app-token-generator@v1
+        id: get-token
+        with:
+          private-key: ${{ secrets.TOKENS_PRIVATE_KEY }}
+          app-id: ${{ secrets.TOKENS_APP_ID }}
+
+      - name: Checkout @netlify/wait-for-deploy-action
+        uses: actions/checkout@v3
+        with:
+          repository: netlify/wait-for-deploy-action
+          token: ${{ steps.get-token.outputs.token }}
+          path: ./.github/actions/wait-for-netlify-deploy
+
+      - name: Wait for Netlify Deploy
+        id: deploy
+        uses: ./.github/actions/wait-for-netlify-deploy
+        with:
+          site-name: netlify-plugin-nextjs-demo-all-flags
+          timeout: 300
+
+      - name: Deploy successful
+        if: ${{ steps.deploy.outputs.origin-url }}
+        run: echo ${{ steps.deploy.outputs.origin-url }}
+
+      - name: Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+
+      - run: npm install
+
+      - name: Cypress run
+        if: ${{ steps.deploy.outputs.origin-url }}
+        id: cypress
+        uses: cypress-io/github-action@v5
+        with:
+          browser: chrome
+          record: true
+          parallel: true
+          config-file: cypress/config/ci.config.ts
+          group: 'Next Runtime - Demo'
+          spec: cypress/e2e/default/*
+        env:
+          DEBUG: '@cypress/github-action'
+          CYPRESS_baseUrl: ${{ steps.deploy.outputs.origin-url }}
+          CYPRESS_NETLIFY_CONTEXT: ${{ steps.deploy.outputs.context }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CYPRESS_RECORD_KEY: ${{ secrets.DEFAULT_CYPRESS_RECORD_KEY }}
+          CYPRESS_PLUGIN_ALL_FEATURE_FLAGS: 'enabled'

--- a/cypress/e2e/default/dynamic-routes.cy.ts
+++ b/cypress/e2e/default/dynamic-routes.cy.ts
@@ -16,11 +16,32 @@ describe('Static Routing', () => {
       expect(res.body).to.contain('Dancing with the Stars')
     })
   })
+  it('renders correct page via ODB on a static route (root)', () => {
+    cy.request({ url: '/', headers: { 'x-nf-debug-logging': '1' } }).then((res) => {
+      console.log(res.headers)
+      expect(res.status).to.eq(200)
+      if (CDNCacheControlEnabled) {
+        expect(res.headers).to.have.property('netlify-cdn-cache-control', 's-maxage=60, stale-while-revalidate')
+        expect(res.headers).to.have.property(
+          'netlify-vary',
+          'header=Accept-Encoding,language=en|es|fr,cookie=__prerender_bypass|__next_preview_data|NEXT_LOCALE',
+        )
+      } else {
+        expect(res.headers).to.have.property('x-nf-render-mode', 'odb ttl=60')
+      }
+      expect(res.body).to.contain('NextJS on Netlify')
+    })
+  })
+
   it('renders correct page via ODB on a static route', () => {
     cy.request({ url: '/getStaticProps/with-revalidate/', headers: { 'x-nf-debug-logging': '1' } }).then((res) => {
       expect(res.status).to.eq(200)
       if (CDNCacheControlEnabled) {
         expect(res.headers).to.have.property('netlify-cdn-cache-control', 's-maxage=1, stale-while-revalidate')
+        expect(res.headers).to.have.property(
+          'netlify-vary',
+          'header=Accept-Encoding,cookie=__prerender_bypass|__next_preview_data',
+        )
       } else {
         expect(res.headers).to.have.property('x-nf-render-mode', 'odb ttl=60')
       }
@@ -72,6 +93,10 @@ describe('Dynamic Routing', () => {
       expect(res.status).to.eq(200)
       if (CDNCacheControlEnabled) {
         expect(res.headers).to.have.property('netlify-cdn-cache-control', 's-maxage=31536000, stale-while-revalidate')
+        expect(res.headers).to.have.property(
+          'netlify-vary',
+          'header=Accept-Encoding,cookie=__prerender_bypass|__next_preview_data',
+        )
       } else {
         // expect 'odb' until https://github.com/netlify/pillar-runtime/issues/438 is fixed
         expect(res.headers).to.have.property('x-nf-render-mode', 'odb')
@@ -95,6 +120,10 @@ describe('Dynamic Routing', () => {
         expect(res.status).to.eq(200)
         if (CDNCacheControlEnabled) {
           expect(res.headers).to.have.property('netlify-cdn-cache-control', 's-maxage=31536000, stale-while-revalidate')
+          expect(res.headers).to.have.property(
+            'netlify-vary',
+            'header=Accept-Encoding,cookie=__prerender_bypass|__next_preview_data',
+          )
         } else {
           expect(res.headers).to.have.property('x-nf-render-mode', 'odb')
         }
@@ -107,6 +136,10 @@ describe('Dynamic Routing', () => {
       expect(res.status).to.eq(200)
       if (CDNCacheControlEnabled) {
         expect(res.headers).to.have.property('netlify-cdn-cache-control', 's-maxage=60, stale-while-revalidate')
+        expect(res.headers).to.have.property(
+          'netlify-vary',
+          'header=Accept-Encoding,cookie=__prerender_bypass|__next_preview_data',
+        )
       } else {
         expect(res.headers).to.have.property('x-nf-render-mode', 'odb ttl=60')
       }
@@ -130,6 +163,10 @@ describe('Dynamic Routing', () => {
         expect(res.status).to.eq(200)
         if (CDNCacheControlEnabled) {
           expect(res.headers).to.have.property('netlify-cdn-cache-control', 's-maxage=60, stale-while-revalidate')
+          expect(res.headers).to.have.property(
+            'netlify-vary',
+            'header=Accept-Encoding,cookie=__prerender_bypass|__next_preview_data',
+          )
         } else {
           expect(res.headers).to.have.property('x-nf-render-mode', 'odb ttl=60')
         }
@@ -143,6 +180,10 @@ describe('Dynamic Routing', () => {
         expect(res.status).to.eq(200)
         if (CDNCacheControlEnabled) {
           expect(res.headers).to.have.property('netlify-cdn-cache-control', 's-maxage=60, stale-while-revalidate')
+          expect(res.headers).to.have.property(
+            'netlify-vary',
+            'header=Accept-Encoding,cookie=__prerender_bypass|__next_preview_data',
+          )
         } else {
           expect(res.headers).to.have.property('x-nf-render-mode', 'odb ttl=60')
         }
@@ -159,6 +200,10 @@ describe('Dynamic Routing', () => {
       expect(res.status).to.eq(200)
       if (CDNCacheControlEnabled) {
         expect(res.headers).to.have.property('netlify-cdn-cache-control', 's-maxage=60, stale-while-revalidate')
+        expect(res.headers).to.have.property(
+          'netlify-vary',
+          'header=Accept-Encoding,cookie=__prerender_bypass|__next_preview_data',
+        )
       } else {
         expect(res.headers).to.have.property('x-nf-render-mode', 'odb ttl=60')
       }
@@ -173,6 +218,10 @@ describe('Dynamic Routing', () => {
       expect(res.status).to.eq(200)
       if (CDNCacheControlEnabled) {
         expect(res.headers).to.have.property('netlify-cdn-cache-control', 's-maxage=60, stale-while-revalidate')
+        expect(res.headers).to.have.property(
+          'netlify-vary',
+          'header=Accept-Encoding,cookie=__prerender_bypass|__next_preview_data',
+        )
       } else {
         expect(res.headers).to.have.property('x-nf-render-mode', 'odb ttl=60')
       }

--- a/cypress/e2e/default/dynamic-routes.cy.ts
+++ b/cypress/e2e/default/dynamic-routes.cy.ts
@@ -1,3 +1,5 @@
+import { CDNCacheControlEnabled } from '../../utils/flags'
+
 /* eslint-disable max-lines-per-function */
 describe('Static Routing', () => {
   it('renders correct page via SSR on a static route', () => {
@@ -17,7 +19,11 @@ describe('Static Routing', () => {
   it('renders correct page via ODB on a static route', () => {
     cy.request({ url: '/getStaticProps/with-revalidate/', headers: { 'x-nf-debug-logging': '1' } }).then((res) => {
       expect(res.status).to.eq(200)
-      expect(res.headers).to.have.property('x-nf-render-mode', 'odb ttl=60')
+      if (CDNCacheControlEnabled) {
+        expect(res.headers).to.have.property('netlify-cdn-cache-control', 's-maxage=1, stale-while-revalidate')
+      } else {
+        expect(res.headers).to.have.property('x-nf-render-mode', 'odb ttl=60')
+      }
       expect(res.body).to.contain('Dancing with the Stars')
     })
   })
@@ -64,8 +70,12 @@ describe('Dynamic Routing', () => {
   it('renders fallback page via ODB on a non-prerendered dynamic route with fallback: true', () => {
     cy.request({ url: '/getStaticProps/withFallback/3/', headers: { 'x-nf-debug-logging': '1' } }).then((res) => {
       expect(res.status).to.eq(200)
-      // expect 'odb' until https://github.com/netlify/pillar-runtime/issues/438 is fixed
-      expect(res.headers).to.have.property('x-nf-render-mode', 'odb')
+      if (CDNCacheControlEnabled) {
+        expect(res.headers).to.have.property('netlify-cdn-cache-control', 's-maxage=31536000, stale-while-revalidate')
+      } else {
+        // expect 'odb' until https://github.com/netlify/pillar-runtime/issues/438 is fixed
+        expect(res.headers).to.have.property('x-nf-render-mode', 'odb')
+      }
       // expect 'Bitten' until the above is fixed and we can test for fallback 'Loading...' message
       expect(res.body).to.contain('Bitten')
     })
@@ -83,7 +93,11 @@ describe('Dynamic Routing', () => {
     cy.request({ url: '/getStaticProps/withFallbackBlocking/3/', headers: { 'x-nf-debug-logging': '1' } }).then(
       (res) => {
         expect(res.status).to.eq(200)
-        expect(res.headers).to.have.property('x-nf-render-mode', 'odb')
+        if (CDNCacheControlEnabled) {
+          expect(res.headers).to.have.property('netlify-cdn-cache-control', 's-maxage=31536000, stale-while-revalidate')
+        } else {
+          expect(res.headers).to.have.property('x-nf-render-mode', 'odb')
+        }
         expect(res.body).to.contain('Bitten')
       },
     )
@@ -91,7 +105,11 @@ describe('Dynamic Routing', () => {
   it('renders correct page via ODB on a prerendered dynamic route with revalidate and fallback: false', () => {
     cy.request({ url: '/getStaticProps/withRevalidate/1/', headers: { 'x-nf-debug-logging': '1' } }).then((res) => {
       expect(res.status).to.eq(200)
-      expect(res.headers).to.have.property('x-nf-render-mode', 'odb ttl=60')
+      if (CDNCacheControlEnabled) {
+        expect(res.headers).to.have.property('netlify-cdn-cache-control', 's-maxage=60, stale-while-revalidate')
+      } else {
+        expect(res.headers).to.have.property('x-nf-render-mode', 'odb ttl=60')
+      }
       expect(res.body).to.contain('Under the Dome')
     })
   })
@@ -110,7 +128,11 @@ describe('Dynamic Routing', () => {
     cy.request({ url: '/getStaticProps/withRevalidate/withFallback/1/', headers: { 'x-nf-debug-logging': '1' } }).then(
       (res) => {
         expect(res.status).to.eq(200)
-        expect(res.headers).to.have.property('x-nf-render-mode', 'odb ttl=60')
+        if (CDNCacheControlEnabled) {
+          expect(res.headers).to.have.property('netlify-cdn-cache-control', 's-maxage=60, stale-while-revalidate')
+        } else {
+          expect(res.headers).to.have.property('x-nf-render-mode', 'odb ttl=60')
+        }
         expect(res.body).to.contain('Under the Dome')
       },
     )
@@ -119,7 +141,11 @@ describe('Dynamic Routing', () => {
     cy.request({ url: '/getStaticProps/withRevalidate/withFallback/3/', headers: { 'x-nf-debug-logging': '1' } }).then(
       (res) => {
         expect(res.status).to.eq(200)
-        expect(res.headers).to.have.property('x-nf-render-mode', 'odb ttl=60')
+        if (CDNCacheControlEnabled) {
+          expect(res.headers).to.have.property('netlify-cdn-cache-control', 's-maxage=60, stale-while-revalidate')
+        } else {
+          expect(res.headers).to.have.property('x-nf-render-mode', 'odb ttl=60')
+        }
         // expect 'Bitten' until https://github.com/netlify/pillar-runtime/issues/438 is fixed
         expect(res.body).to.contain('Bitten')
       },
@@ -131,7 +157,11 @@ describe('Dynamic Routing', () => {
       headers: { 'x-nf-debug-logging': '1' },
     }).then((res) => {
       expect(res.status).to.eq(200)
-      expect(res.headers).to.have.property('x-nf-render-mode', 'odb ttl=60')
+      if (CDNCacheControlEnabled) {
+        expect(res.headers).to.have.property('netlify-cdn-cache-control', 's-maxage=60, stale-while-revalidate')
+      } else {
+        expect(res.headers).to.have.property('x-nf-render-mode', 'odb ttl=60')
+      }
       expect(res.body).to.contain('Under the Dome')
     })
   })
@@ -141,7 +171,11 @@ describe('Dynamic Routing', () => {
       headers: { 'x-nf-debug-logging': '1' },
     }).then((res) => {
       expect(res.status).to.eq(200)
-      expect(res.headers).to.have.property('x-nf-render-mode', 'odb ttl=60')
+      if (CDNCacheControlEnabled) {
+        expect(res.headers).to.have.property('netlify-cdn-cache-control', 's-maxage=60, stale-while-revalidate')
+      } else {
+        expect(res.headers).to.have.property('x-nf-render-mode', 'odb ttl=60')
+      }
       expect(res.body).to.contain('Bitten')
     })
   })

--- a/cypress/e2e/default/revalidate.cy.ts
+++ b/cypress/e2e/default/revalidate.cy.ts
@@ -1,4 +1,6 @@
-describe('On-demand revalidation', () => {
+import { describeConditional, CDNCacheControlEnabled } from '../../utils/flags'
+
+describeConditional(!CDNCacheControlEnabled)('On-demand revalidation', () => {
   it('revalidates static ISR route with default locale', () => {
     cy.request({ url: '/api/revalidate/?select=0' }).then((res) => {
       expect(res.status).to.eq(200)
@@ -33,7 +35,9 @@ describe('On-demand revalidation', () => {
     cy.request({ url: '/api/revalidate/?select=5', failOnStatusCode: false }).then((res) => {
       expect(res.status).to.eq(500)
       expect(res.body).to.have.property('message')
-      expect(res.body.message).to.include('could not refresh content for path /getStaticProps/withRevalidate/3/, path is not handled by an odb')
+      expect(res.body.message).to.include(
+        'could not refresh content for path /getStaticProps/withRevalidate/3/, path is not handled by an odb',
+      )
     })
   })
   it('revalidates dynamic non-prerendered ISR route with fallback blocking', () => {

--- a/cypress/utils/flags.ts
+++ b/cypress/utils/flags.ts
@@ -1,5 +1,10 @@
 export const allFlagsEnabled = Cypress.env('PLUGIN_ALL_FEATURE_FLAGS') === `enabled`
 
+// In current setup this is only enabled when all flags are enabled, but when doing conditional
+// assertions for CDN cache control specific behaviour we want semantically check for just that feature
+// and not everything else - so that's the reason for separate export
+export const CDNCacheControlEnabled = allFlagsEnabled
+
 /**
  * @param shouldExecute {boolean} - if truthy, `describe` will be executed, otherwise skipped
  * @returns {function} - describe or describe.skip

--- a/cypress/utils/flags.ts
+++ b/cypress/utils/flags.ts
@@ -1,0 +1,25 @@
+export const allFlagsEnabled = Cypress.env('PLUGIN_ALL_FEATURE_FLAGS') === `enabled`
+
+/**
+ * @param shouldExecute {boolean} - if truthy, `describe` will be executed, otherwise skipped
+ * @returns {function} - describe or describe.skip
+ * @example
+ * // this will execute the describe block only if CDNCacheControlEnabled variable is falsy
+ * describeConditional(!CDNCacheControlEnabled)('describe block name', () => {
+ * }
+ */
+export const describeConditional = function describeConditional(shouldExecute: boolean) {
+  return shouldExecute ? describe : describe.skip
+}
+
+/**
+ * @param shouldExecute {boolean} - if truthy, `it` will be executed, otherwise skipped
+ * @returns {function} - it or it.skip
+ * @example
+ * // this will execute the test only if CDNCacheControlEnabled variable is falsy
+ * itConditional(!CDNCacheControlEnabled)('test name', () => {
+ * }
+ */
+export const itConditional = function itConditional(shouldExecute: boolean) {
+  return shouldExecute ? it : it.skip
+}

--- a/demos/default/netlify.toml
+++ b/demos/default/netlify.toml
@@ -13,6 +13,9 @@ NODE_VERSION = "16.15.1"
 NEXT_SPLIT_API_ROUTES = "true"
 NEXT_BUNDLE_BASED_ON_NFT_FILES = "true"
 
+# following flags are enabled on "All flags" variant of test site - uncomment those to easily run in that mode
+# NEXT_CDN_CACHE_CONTROL = "true"
+
 [[headers]]
 for = "/_next/image/*"
 

--- a/demos/default/pages/index.js
+++ b/demos/default/pages/index.js
@@ -3,7 +3,7 @@ import dynamic from 'next/dynamic'
 const Header = dynamic(() => import(/* webpackChunkName: 'header' */ '../components/Header'), { ssr: true })
 import { useRouter } from 'next/router'
 
-const Index = ({ shows, nodeEnv }) => {
+const Index = ({ shows, nodeEnv, time }) => {
   const { locale } = useRouter()
 
   return (
@@ -20,6 +20,8 @@ const Index = ({ shows, nodeEnv }) => {
         <p>This is a demo of a NextJS application with Incremental Static Regeneration (ISR).</p>
 
         <h2>Incremental Static Regeneration</h2>
+
+        <pre>{time}</pre>
 
         <p>
           This page is rendered by an On-Demand Builder (ODB) function. It fetches a random list of five TV shows from
@@ -201,6 +203,7 @@ export async function getStaticProps(context) {
     props: {
       shows: data.slice(0, 5),
       nodeEnv: process.env.NODE_ENV || null,
+      time: new Date().toString(),
     },
     revalidate: 60,
   }

--- a/packages/runtime/src/helpers/config.ts
+++ b/packages/runtime/src/helpers/config.ts
@@ -109,6 +109,7 @@ export const configureHandlerFunctions = async ({
   apiLambdas,
   ssrLambdas,
   splitApiRoutes,
+  useCDNCacheControl,
 }: {
   netlifyConfig: NetlifyConfig
   publish: string
@@ -116,6 +117,7 @@ export const configureHandlerFunctions = async ({
   apiLambdas: APILambda[]
   ssrLambdas: SSRLambda[]
   splitApiRoutes: boolean
+  useCDNCacheControl: boolean
 }) => {
   const config = await getRequiredServerFiles(publish)
   const files = config.files || []
@@ -182,7 +184,9 @@ export const configureHandlerFunctions = async ({
 
   if (ssrLambdas.length === 0) {
     configureFunction(HANDLER_FUNCTION_NAME)
-    configureFunction(ODB_FUNCTION_NAME)
+    if (!useCDNCacheControl) {
+      configureFunction(ODB_FUNCTION_NAME)
+    }
   } else {
     ssrLambdas.forEach(configureLambda)
   }

--- a/packages/runtime/src/helpers/config.ts
+++ b/packages/runtime/src/helpers/config.ts
@@ -218,6 +218,19 @@ const buildHeader = (buildHeaderParams: BuildHeaderParams) => {
 const sanitizePath = (path: string) => path.replace(/:[^*/]+\*$/, '*')
 
 /**
+ * Sets Content-type header for static RSC assets (text/x-component), so application/octet-stream is not used when serving them
+ * @param netlifyHeaders - Existing headers that are already configured in the Netlify configuration
+ */
+export const addContentTypeHeaderToStaticRSCAssets = (netlifyHeaders: NetlifyHeaders = []) => {
+  netlifyHeaders.push({
+    for: `*.rsc`,
+    values: {
+      'Content-Type': 'text/x-component',
+    },
+  })
+}
+
+/**
  * Persist Next.js custom headers to the Netlify configuration so the headers work with static files
  * See {@link https://nextjs.org/docs/api-reference/next.config.js/headers} for more information on custom
  * headers in Next.js

--- a/packages/runtime/src/helpers/edge.ts
+++ b/packages/runtime/src/helpers/edge.ts
@@ -290,14 +290,14 @@ export const generateRscDataEdgeManifest = async ({
   const staticAppdirRoutes: Array<string> = []
   for (const [path, route] of Object.entries(prerenderManifest.routes)) {
     if (isAppDirRoute(route.srcRoute, appPathRoutesManifest) && route.dataRoute) {
-      staticAppdirRoutes.push(path, route.dataRoute)
+      staticAppdirRoutes.push(path)
     }
   }
   const dynamicAppDirRoutes: Array<string> = []
 
   for (const [path, route] of Object.entries(prerenderManifest.dynamicRoutes)) {
     if (isAppDirRoute(path, appPathRoutesManifest) && route.dataRouteRegex) {
-      dynamicAppDirRoutes.push(route.routeRegex, route.dataRouteRegex)
+      dynamicAppDirRoutes.push(route.routeRegex)
     }
   }
 

--- a/packages/runtime/src/helpers/flags.ts
+++ b/packages/runtime/src/helpers/flags.ts
@@ -36,3 +36,9 @@ export const bundleBasedOnNftFiles = (featureFlags: Record<string, unknown>): bo
 
   return isEnabled
 }
+
+export const useCDNCacheControlEnabled = (featureFlags: Record<string, unknown>): boolean => {
+  const isEnabled = destr(process.env.NEXT_CDN_CACHE_CONTROL) ?? featureFlags['next-use-cdn-cache-control'] ?? false
+
+  return isEnabled
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -6,7 +6,7 @@ import destr from 'destr'
 import { existsSync, readFileSync } from 'fs-extra'
 import { outdent } from 'outdent'
 
-import { HANDLER_FUNCTION_NAME, ODB_FUNCTION_NAME } from './constants'
+import { HANDLER_FUNCTION_NAME } from './constants'
 import { restoreCache, saveCache } from './helpers/cache'
 import {
   getNextConfig,
@@ -254,7 +254,7 @@ const plugin: NetlifyPlugin = {
     }
 
     await checkForOldFunctions({ functions })
-    await checkZipSize(join(FUNCTIONS_DIST, `${ODB_FUNCTION_NAME}.zip`))
+    await checkZipSize(join(FUNCTIONS_DIST, `${HANDLER_FUNCTION_NAME}.zip`))
     const nextConfig = await getNextConfig({ publish, failBuild })
 
     const { basePath, appDir, experimental } = nextConfig

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -14,6 +14,7 @@ import {
   updateRequiredServerFiles,
   configureHandlerFunctions,
   generateCustomHeaders,
+  addContentTypeHeaderToStaticRSCAssets,
 } from './helpers/config'
 import { onPreDev } from './helpers/dev'
 import { writeEdgeFunctions, loadMiddlewareManifest, cleanupEdgeFunctions } from './helpers/edge'
@@ -250,6 +251,7 @@ const plugin: NetlifyPlugin = {
 
     const { basePath, appDir, experimental } = nextConfig
 
+    addContentTypeHeaderToStaticRSCAssets(headers)
     generateCustomHeaders(nextConfig, headers)
 
     warnForProblematicUserRewrites({ basePath, redirects })

--- a/packages/runtime/src/templates/edge-shared/rsc-data.ts
+++ b/packages/runtime/src/templates/edge-shared/rsc-data.ts
@@ -28,10 +28,9 @@ export declare type PrerenderManifest = {
 
 const noop = () => {}
 
-// Ensure that routes with and without a trailing slash map to different ODB paths
 const rscifyPath = (route: string) => {
   if (route.endsWith('/')) {
-    return route.slice(0, -1) + '.rsc/'
+    return route.slice(0, -1) + '.rsc'
   }
   return route + '.rsc'
 }

--- a/packages/runtime/src/templates/getHandler.ts
+++ b/packages/runtime/src/templates/getHandler.ts
@@ -196,10 +196,14 @@ const makeHandler = ({
     }
 
     // Sending SWR headers causes undefined behaviour with the Netlify CDN
-    const cacheControlHeader = multiValueHeaders['cache-control']?.[0]
+    let cacheControlHeader = multiValueHeaders['cache-control']?.[0]
 
     if (useCDNCacheControl) {
       if (cacheControlHeader?.includes('stale-while-revalidate')) {
+        if (!cacheControlHeader?.includes('stale-while-revalidate=')) {
+          // If no SWR time is set, we'll set it to 86400 seconds
+          cacheControlHeader = cacheControlHeader.replace('stale-while-revalidate', 'stale-while-revalidate=86400')
+        }
         multiValueHeaders[`netlify-cdn-cache-control`] = [cacheControlHeader]
         multiValueHeaders['cache-control'] = ['public, max-age=0, must-revalidate']
 

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -181,115 +181,7 @@ Array [
 ]
 `;
 
-exports[`onBuild() generates a file referencing all API route sources: for _api_hello-background-background 1`] = `
-"// This file is purely to allow nft to know about these pages.
-exports.resolvePages = () => {
-    try {
-        require.resolve('../../../../../node_modules/@swc/helpers/_/_interop_require_default/package.json')
-        require.resolve('../../../../../node_modules/@swc/helpers/_/_interop_require_wildcard/package.json')
-        require.resolve('../../../../../node_modules/@swc/helpers/cjs/_interop_require_default.cjs')
-        require.resolve('../../../../../node_modules/@swc/helpers/cjs/_interop_require_wildcard.cjs')
-        require.resolve('../../../../../node_modules/@swc/helpers/package.json')
-        require.resolve('../../../../../node_modules/next/dist/compiled/react/cjs/react.development.js')
-        require.resolve('../../../../../node_modules/next/dist/compiled/react/cjs/react.production.min.js')
-        require.resolve('../../../../../node_modules/next/dist/compiled/react/index.js')
-        require.resolve('../../../../../node_modules/next/dist/compiled/react/package.json')
-        require.resolve('../../../../../node_modules/next/dist/server/get-page-files.js')
-        require.resolve('../../../../../node_modules/next/dist/server/htmlescape.js')
-        require.resolve('../../../../../node_modules/next/dist/server/utils.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/amp-context.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/amp-mode.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/constants.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/head-manager-context.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/html-context.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/is-plain-object.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/modern-browserslist-target.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/page-path/denormalize-page-path.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/page-path/ensure-leading-slash.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/page-path/normalize-page-path.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/page-path/normalize-path-sep.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/index.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/is-dynamic.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/sorted-routes.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/side-effect.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/utils.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/utils/warn-once.js')
-        require.resolve('../../../../../node_modules/next/package.json')
-        require.resolve('../../../../../node_modules/react/cjs/react.development.js')
-        require.resolve('../../../../../node_modules/react/cjs/react.production.min.js')
-        require.resolve('../../../../../node_modules/react/index.js')
-        require.resolve('../../../../../node_modules/react/package.json')
-        require.resolve('../../../../../package.json')
-        require.resolve('../../../.next/package.json')
-        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
-        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
-        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
-        require.resolve('../../../.next/server/pages/_app.js')
-        require.resolve('../../../.next/server/pages/_document.js')
-        require.resolve('../../../.next/server/pages/_error.js')
-        require.resolve('../../../.next/server/pages/api/hello-background.js')
-        require.resolve('../../../.next/server/webpack-api-runtime.js')
-        require.resolve('../../../.next/server/webpack-runtime.js')
-        require.resolve('../../../package.json')
-    } catch {}
-}"
-`;
-
-exports[`onBuild() generates a file referencing all API route sources: for _api_hello-scheduled-handler 1`] = `
-"// This file is purely to allow nft to know about these pages.
-exports.resolvePages = () => {
-    try {
-        require.resolve('../../../../../node_modules/@swc/helpers/_/_interop_require_default/package.json')
-        require.resolve('../../../../../node_modules/@swc/helpers/_/_interop_require_wildcard/package.json')
-        require.resolve('../../../../../node_modules/@swc/helpers/cjs/_interop_require_default.cjs')
-        require.resolve('../../../../../node_modules/@swc/helpers/cjs/_interop_require_wildcard.cjs')
-        require.resolve('../../../../../node_modules/@swc/helpers/package.json')
-        require.resolve('../../../../../node_modules/next/dist/compiled/react/cjs/react.development.js')
-        require.resolve('../../../../../node_modules/next/dist/compiled/react/cjs/react.production.min.js')
-        require.resolve('../../../../../node_modules/next/dist/compiled/react/index.js')
-        require.resolve('../../../../../node_modules/next/dist/compiled/react/package.json')
-        require.resolve('../../../../../node_modules/next/dist/server/get-page-files.js')
-        require.resolve('../../../../../node_modules/next/dist/server/htmlescape.js')
-        require.resolve('../../../../../node_modules/next/dist/server/utils.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/amp-context.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/amp-mode.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/constants.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/head-manager-context.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/html-context.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/is-plain-object.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/modern-browserslist-target.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/page-path/denormalize-page-path.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/page-path/ensure-leading-slash.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/page-path/normalize-page-path.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/page-path/normalize-path-sep.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/index.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/is-dynamic.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/sorted-routes.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/side-effect.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/utils.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/utils/warn-once.js')
-        require.resolve('../../../../../node_modules/next/package.json')
-        require.resolve('../../../../../node_modules/react/cjs/react.development.js')
-        require.resolve('../../../../../node_modules/react/cjs/react.production.min.js')
-        require.resolve('../../../../../node_modules/react/index.js')
-        require.resolve('../../../../../node_modules/react/package.json')
-        require.resolve('../../../../../package.json')
-        require.resolve('../../../.next/package.json')
-        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
-        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
-        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
-        require.resolve('../../../.next/server/pages/_app.js')
-        require.resolve('../../../.next/server/pages/_document.js')
-        require.resolve('../../../.next/server/pages/_error.js')
-        require.resolve('../../../.next/server/pages/api/hello-scheduled.js')
-        require.resolve('../../../.next/server/webpack-api-runtime.js')
-        require.resolve('../../../.next/server/webpack-runtime.js')
-        require.resolve('../../../package.json')
-    } catch {}
-}"
-`;
-
-exports[`onBuild() generates a file referencing all page sources 1`] = `
+exports[`onBuild() NEXT_CDN_CACHE_CONTROL enabled generates a file referencing all page sources 1`] = `
 "// This file is purely to allow nft to know about these pages.
 exports.resolvePages = () => {
     try {
@@ -473,191 +365,7 @@ exports.resolvePages = () => {
 }"
 `;
 
-exports[`onBuild() generates a file referencing all page sources 2`] = `
-"// This file is purely to allow nft to know about these pages.
-exports.resolvePages = () => {
-    try {
-        require.resolve('../../../../../node_modules/@swc/helpers/_/_interop_require_default/package.json')
-        require.resolve('../../../../../node_modules/@swc/helpers/_/_interop_require_wildcard/package.json')
-        require.resolve('../../../../../node_modules/@swc/helpers/cjs/_interop_require_default.cjs')
-        require.resolve('../../../../../node_modules/@swc/helpers/cjs/_interop_require_wildcard.cjs')
-        require.resolve('../../../../../node_modules/@swc/helpers/package.json')
-        require.resolve('../../../../../node_modules/next/dist/client/add-base-path.js')
-        require.resolve('../../../../../node_modules/next/dist/client/add-locale.js')
-        require.resolve('../../../../../node_modules/next/dist/client/detect-domain-locale.js')
-        require.resolve('../../../../../node_modules/next/dist/client/has-base-path.js')
-        require.resolve('../../../../../node_modules/next/dist/client/head-manager.js')
-        require.resolve('../../../../../node_modules/next/dist/client/normalize-trailing-slash.js')
-        require.resolve('../../../../../node_modules/next/dist/client/remove-base-path.js')
-        require.resolve('../../../../../node_modules/next/dist/client/remove-locale.js')
-        require.resolve('../../../../../node_modules/next/dist/client/request-idle-callback.js')
-        require.resolve('../../../../../node_modules/next/dist/client/route-loader.js')
-        require.resolve('../../../../../node_modules/next/dist/client/router.js')
-        require.resolve('../../../../../node_modules/next/dist/client/script.js')
-        require.resolve('../../../../../node_modules/next/dist/client/trusted-types.js')
-        require.resolve('../../../../../node_modules/next/dist/client/with-router.js')
-        require.resolve('../../../../../node_modules/next/dist/compiled/gzip-size/index.js')
-        require.resolve('../../../../../node_modules/next/dist/compiled/gzip-size/package.json')
-        require.resolve('../../../../../node_modules/next/dist/compiled/path-to-regexp/index.js')
-        require.resolve('../../../../../node_modules/next/dist/compiled/react-dom/cjs/react-dom-server-rendering-stub.development.js')
-        require.resolve('../../../../../node_modules/next/dist/compiled/react-dom/cjs/react-dom-server-rendering-stub.production.min.js')
-        require.resolve('../../../../../node_modules/next/dist/compiled/react-dom/package.json')
-        require.resolve('../../../../../node_modules/next/dist/compiled/react-dom/server-rendering-stub.js')
-        require.resolve('../../../../../node_modules/next/dist/compiled/react-is/cjs/react-is.development.js')
-        require.resolve('../../../../../node_modules/next/dist/compiled/react-is/cjs/react-is.production.min.js')
-        require.resolve('../../../../../node_modules/next/dist/compiled/react-is/index.js')
-        require.resolve('../../../../../node_modules/next/dist/compiled/react-is/package.json')
-        require.resolve('../../../../../node_modules/next/dist/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-client.browser.development.js')
-        require.resolve('../../../../../node_modules/next/dist/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-client.browser.production.min.js')
-        require.resolve('../../../../../node_modules/next/dist/compiled/react-server-dom-webpack/client.browser.js')
-        require.resolve('../../../../../node_modules/next/dist/compiled/react-server-dom-webpack/client.js')
-        require.resolve('../../../../../node_modules/next/dist/compiled/react-server-dom-webpack/package.json')
-        require.resolve('../../../../../node_modules/next/dist/compiled/react/cjs/react-jsx-runtime.development.js')
-        require.resolve('../../../../../node_modules/next/dist/compiled/react/cjs/react-jsx-runtime.production.min.js')
-        require.resolve('../../../../../node_modules/next/dist/compiled/react/cjs/react.development.js')
-        require.resolve('../../../../../node_modules/next/dist/compiled/react/cjs/react.production.min.js')
-        require.resolve('../../../../../node_modules/next/dist/compiled/react/index.js')
-        require.resolve('../../../../../node_modules/next/dist/compiled/react/jsx-runtime.js')
-        require.resolve('../../../../../node_modules/next/dist/compiled/react/package.json')
-        require.resolve('../../../../../node_modules/next/dist/lib/is-api-route.js')
-        require.resolve('../../../../../node_modules/next/dist/lib/is-error.js')
-        require.resolve('../../../../../node_modules/next/dist/pages/_error.js')
-        require.resolve('../../../../../node_modules/next/dist/server/app-render/get-segment-param.js')
-        require.resolve('../../../../../node_modules/next/dist/server/future/helpers/interception-routes.js')
-        require.resolve('../../../../../node_modules/next/dist/server/get-page-files.js')
-        require.resolve('../../../../../node_modules/next/dist/server/htmlescape.js')
-        require.resolve('../../../../../node_modules/next/dist/server/utils.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/amp-context.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/amp-mode.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/app-router-context.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/bloom-filter.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/constants.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/escape-regexp.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/head-manager-context.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/head.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/hooks-client-context.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/html-context.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/i18n/detect-domain-locale.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/i18n/normalize-locale-path.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/is-plain-object.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/loadable-context.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/loadable.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/mitt.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/modern-browserslist-target.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/page-path/denormalize-page-path.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/page-path/ensure-leading-slash.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/page-path/normalize-page-path.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/page-path/normalize-path-sep.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/router-context.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/router.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/add-locale.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/add-path-prefix.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/add-path-suffix.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/app-paths.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/compare-states.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/format-next-pathname-info.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/format-url.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/get-asset-path-from-route.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/get-next-pathname-info.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/handle-smooth-scroll.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/index.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/interpolate-as.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/is-bot.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/is-dynamic.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/is-local-url.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/omit.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/parse-path.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/parse-relative-url.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/parse-url.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/path-has-prefix.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/path-match.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/prepare-destination.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/querystring.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/remove-path-prefix.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/remove-trailing-slash.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/resolve-href.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/resolve-rewrites.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/route-matcher.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/route-regex.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/sorted-routes.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/server-inserted-html.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/side-effect.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/utils.js')
-        require.resolve('../../../../../node_modules/next/dist/shared/lib/utils/warn-once.js')
-        require.resolve('../../../../../node_modules/next/error.js')
-        require.resolve('../../../../../node_modules/next/package.json')
-        require.resolve('../../../../../node_modules/next/router.js')
-        require.resolve('../../../../../node_modules/react-dom/cjs/react-dom.development.js')
-        require.resolve('../../../../../node_modules/react-dom/cjs/react-dom.production.min.js')
-        require.resolve('../../../../../node_modules/react-dom/index.js')
-        require.resolve('../../../../../node_modules/react-dom/node_modules/scheduler/cjs/scheduler.development.js')
-        require.resolve('../../../../../node_modules/react-dom/node_modules/scheduler/cjs/scheduler.production.min.js')
-        require.resolve('../../../../../node_modules/react-dom/node_modules/scheduler/index.js')
-        require.resolve('../../../../../node_modules/react-dom/node_modules/scheduler/package.json')
-        require.resolve('../../../../../node_modules/react-dom/package.json')
-        require.resolve('../../../../../node_modules/react/cjs/react.development.js')
-        require.resolve('../../../../../node_modules/react/cjs/react.production.min.js')
-        require.resolve('../../../../../node_modules/react/index.js')
-        require.resolve('../../../../../node_modules/react/package.json')
-        require.resolve('../../../../../package.json')
-        require.resolve('../../../.next/package.json')
-        require.resolve('../../../.next/server/app/app-edge/page.js')
-        require.resolve('../../../.next/server/app/blog/[author]/[slug]/page.js')
-        require.resolve('../../../.next/server/app/blog/[author]/page.js')
-        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
-        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
-        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
-        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
-        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
-        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
-        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
-        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
-        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
-        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
-        require.resolve('../../../.next/server/chunks/header.js')
-        require.resolve('../../../.next/server/pages/_app.js')
-        require.resolve('../../../.next/server/pages/_document.js')
-        require.resolve('../../../.next/server/pages/_error.js')
-        require.resolve('../../../.next/server/pages/api/enterPreview.js')
-        require.resolve('../../../.next/server/pages/api/exitPreview.js')
-        require.resolve('../../../.next/server/pages/api/hello-background.js')
-        require.resolve('../../../.next/server/pages/api/hello-scheduled.js')
-        require.resolve('../../../.next/server/pages/api/hello.js')
-        require.resolve('../../../.next/server/pages/api/og.js')
-        require.resolve('../../../.next/server/pages/api/revalidate.js')
-        require.resolve('../../../.next/server/pages/api/shows/[...params].js')
-        require.resolve('../../../.next/server/pages/api/shows/[id].js')
-        require.resolve('../../../.next/server/pages/deep/import.js')
-        require.resolve('../../../.next/server/pages/edge/[id].js')
-        require.resolve('../../../.next/server/pages/getServerSideProps/[id].js')
-        require.resolve('../../../.next/server/pages/getServerSideProps/all/[[...slug]].js')
-        require.resolve('../../../.next/server/pages/getServerSideProps/file.js')
-        require.resolve('../../../.next/server/pages/getServerSideProps/static.js')
-        require.resolve('../../../.next/server/pages/getStaticProps/[id].js')
-        require.resolve('../../../.next/server/pages/getStaticProps/env.js')
-        require.resolve('../../../.next/server/pages/getStaticProps/static.js')
-        require.resolve('../../../.next/server/pages/getStaticProps/with-revalidate-404.js')
-        require.resolve('../../../.next/server/pages/getStaticProps/with-revalidate.js')
-        require.resolve('../../../.next/server/pages/getStaticProps/withFallback/[...slug].js')
-        require.resolve('../../../.next/server/pages/getStaticProps/withFallback/[id].js')
-        require.resolve('../../../.next/server/pages/getStaticProps/withFallbackBlocking/[id].js')
-        require.resolve('../../../.next/server/pages/getStaticProps/withRevalidate/[id].js')
-        require.resolve('../../../.next/server/pages/getStaticProps/withRevalidate/withFallback/[id].js')
-        require.resolve('../../../.next/server/pages/getStaticProps/withRevalidate/withFallbackBlocking/[id].js')
-        require.resolve('../../../.next/server/pages/index.js')
-        require.resolve('../../../.next/server/pages/previewTest.js')
-        require.resolve('../../../.next/server/pages/shows/[...params].js')
-        require.resolve('../../../.next/server/pages/shows/[id].js')
-        require.resolve('../../../.next/server/webpack-api-runtime.js')
-        require.resolve('../../../.next/server/webpack-runtime.js')
-        require.resolve('../../../components/Header.js')
-        require.resolve('../../../hello.txt')
-        require.resolve('../../../package.json')
-    } catch {}
-}"
-`;
-
-exports[`onBuild() generates a file referencing all when publish dir is a subdirectory 1`] = `
+exports[`onBuild() NEXT_CDN_CACHE_CONTROL enabled generates a file referencing all when publish dir is a subdirectory 1`] = `
 "// This file is purely to allow nft to know about these pages.
 exports.resolvePages = () => {
     try {
@@ -841,492 +549,2312 @@ exports.resolvePages = () => {
 }"
 `;
 
-exports[`onBuild() generates a file referencing all when publish dir is a subdirectory 2`] = `
-"// This file is purely to allow nft to know about these pages.
-exports.resolvePages = () => {
-    try {
-        require.resolve('../../../../node_modules/@swc/helpers/_/_interop_require_default/package.json')
-        require.resolve('../../../../node_modules/@swc/helpers/_/_interop_require_wildcard/package.json')
-        require.resolve('../../../../node_modules/@swc/helpers/cjs/_interop_require_default.cjs')
-        require.resolve('../../../../node_modules/@swc/helpers/cjs/_interop_require_wildcard.cjs')
-        require.resolve('../../../../node_modules/@swc/helpers/package.json')
-        require.resolve('../../../../node_modules/next/dist/client/add-base-path.js')
-        require.resolve('../../../../node_modules/next/dist/client/add-locale.js')
-        require.resolve('../../../../node_modules/next/dist/client/detect-domain-locale.js')
-        require.resolve('../../../../node_modules/next/dist/client/has-base-path.js')
-        require.resolve('../../../../node_modules/next/dist/client/head-manager.js')
-        require.resolve('../../../../node_modules/next/dist/client/normalize-trailing-slash.js')
-        require.resolve('../../../../node_modules/next/dist/client/remove-base-path.js')
-        require.resolve('../../../../node_modules/next/dist/client/remove-locale.js')
-        require.resolve('../../../../node_modules/next/dist/client/request-idle-callback.js')
-        require.resolve('../../../../node_modules/next/dist/client/route-loader.js')
-        require.resolve('../../../../node_modules/next/dist/client/router.js')
-        require.resolve('../../../../node_modules/next/dist/client/script.js')
-        require.resolve('../../../../node_modules/next/dist/client/trusted-types.js')
-        require.resolve('../../../../node_modules/next/dist/client/with-router.js')
-        require.resolve('../../../../node_modules/next/dist/compiled/gzip-size/index.js')
-        require.resolve('../../../../node_modules/next/dist/compiled/gzip-size/package.json')
-        require.resolve('../../../../node_modules/next/dist/compiled/path-to-regexp/index.js')
-        require.resolve('../../../../node_modules/next/dist/compiled/react-dom/cjs/react-dom-server-rendering-stub.development.js')
-        require.resolve('../../../../node_modules/next/dist/compiled/react-dom/cjs/react-dom-server-rendering-stub.production.min.js')
-        require.resolve('../../../../node_modules/next/dist/compiled/react-dom/package.json')
-        require.resolve('../../../../node_modules/next/dist/compiled/react-dom/server-rendering-stub.js')
-        require.resolve('../../../../node_modules/next/dist/compiled/react-is/cjs/react-is.development.js')
-        require.resolve('../../../../node_modules/next/dist/compiled/react-is/cjs/react-is.production.min.js')
-        require.resolve('../../../../node_modules/next/dist/compiled/react-is/index.js')
-        require.resolve('../../../../node_modules/next/dist/compiled/react-is/package.json')
-        require.resolve('../../../../node_modules/next/dist/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-client.browser.development.js')
-        require.resolve('../../../../node_modules/next/dist/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-client.browser.production.min.js')
-        require.resolve('../../../../node_modules/next/dist/compiled/react-server-dom-webpack/client.browser.js')
-        require.resolve('../../../../node_modules/next/dist/compiled/react-server-dom-webpack/client.js')
-        require.resolve('../../../../node_modules/next/dist/compiled/react-server-dom-webpack/package.json')
-        require.resolve('../../../../node_modules/next/dist/compiled/react/cjs/react-jsx-runtime.development.js')
-        require.resolve('../../../../node_modules/next/dist/compiled/react/cjs/react-jsx-runtime.production.min.js')
-        require.resolve('../../../../node_modules/next/dist/compiled/react/cjs/react.development.js')
-        require.resolve('../../../../node_modules/next/dist/compiled/react/cjs/react.production.min.js')
-        require.resolve('../../../../node_modules/next/dist/compiled/react/index.js')
-        require.resolve('../../../../node_modules/next/dist/compiled/react/jsx-runtime.js')
-        require.resolve('../../../../node_modules/next/dist/compiled/react/package.json')
-        require.resolve('../../../../node_modules/next/dist/lib/is-api-route.js')
-        require.resolve('../../../../node_modules/next/dist/lib/is-error.js')
-        require.resolve('../../../../node_modules/next/dist/pages/_error.js')
-        require.resolve('../../../../node_modules/next/dist/server/app-render/get-segment-param.js')
-        require.resolve('../../../../node_modules/next/dist/server/future/helpers/interception-routes.js')
-        require.resolve('../../../../node_modules/next/dist/server/get-page-files.js')
-        require.resolve('../../../../node_modules/next/dist/server/htmlescape.js')
-        require.resolve('../../../../node_modules/next/dist/server/utils.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/amp-context.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/amp-mode.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/app-router-context.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/bloom-filter.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/constants.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/escape-regexp.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/head-manager-context.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/head.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/hooks-client-context.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/html-context.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/i18n/detect-domain-locale.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/i18n/normalize-locale-path.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/is-plain-object.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/loadable-context.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/loadable.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/mitt.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/modern-browserslist-target.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/page-path/denormalize-page-path.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/page-path/ensure-leading-slash.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/page-path/normalize-page-path.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/page-path/normalize-path-sep.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/router-context.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/router/router.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/add-locale.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/add-path-prefix.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/add-path-suffix.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/app-paths.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/compare-states.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/format-next-pathname-info.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/format-url.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/get-asset-path-from-route.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/get-next-pathname-info.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/handle-smooth-scroll.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/index.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/interpolate-as.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/is-bot.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/is-dynamic.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/is-local-url.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/omit.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/parse-path.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/parse-relative-url.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/parse-url.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/path-has-prefix.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/path-match.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/prepare-destination.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/querystring.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/remove-path-prefix.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/remove-trailing-slash.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/resolve-href.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/resolve-rewrites.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/route-matcher.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/route-regex.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/sorted-routes.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/server-inserted-html.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/side-effect.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/utils.js')
-        require.resolve('../../../../node_modules/next/dist/shared/lib/utils/warn-once.js')
-        require.resolve('../../../../node_modules/next/error.js')
-        require.resolve('../../../../node_modules/next/package.json')
-        require.resolve('../../../../node_modules/next/router.js')
-        require.resolve('../../../../node_modules/react-dom/cjs/react-dom.development.js')
-        require.resolve('../../../../node_modules/react-dom/cjs/react-dom.production.min.js')
-        require.resolve('../../../../node_modules/react-dom/index.js')
-        require.resolve('../../../../node_modules/react-dom/node_modules/scheduler/cjs/scheduler.development.js')
-        require.resolve('../../../../node_modules/react-dom/node_modules/scheduler/cjs/scheduler.production.min.js')
-        require.resolve('../../../../node_modules/react-dom/node_modules/scheduler/index.js')
-        require.resolve('../../../../node_modules/react-dom/node_modules/scheduler/package.json')
-        require.resolve('../../../../node_modules/react-dom/package.json')
-        require.resolve('../../../../node_modules/react/cjs/react.development.js')
-        require.resolve('../../../../node_modules/react/cjs/react.production.min.js')
-        require.resolve('../../../../node_modules/react/index.js')
-        require.resolve('../../../../node_modules/react/package.json')
-        require.resolve('../../../../package.json')
-        require.resolve('../../../web/.next/package.json')
-        require.resolve('../../../web/.next/server/app/app-edge/page.js')
-        require.resolve('../../../web/.next/server/app/blog/[author]/[slug]/page.js')
-        require.resolve('../../../web/.next/server/app/blog/[author]/page.js')
-        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
-        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
-        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
-        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
-        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
-        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
-        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
-        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
-        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
-        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
-        require.resolve('../../../web/.next/server/chunks/header.js')
-        require.resolve('../../../web/.next/server/pages/_app.js')
-        require.resolve('../../../web/.next/server/pages/_document.js')
-        require.resolve('../../../web/.next/server/pages/_error.js')
-        require.resolve('../../../web/.next/server/pages/api/enterPreview.js')
-        require.resolve('../../../web/.next/server/pages/api/exitPreview.js')
-        require.resolve('../../../web/.next/server/pages/api/hello-background.js')
-        require.resolve('../../../web/.next/server/pages/api/hello-scheduled.js')
-        require.resolve('../../../web/.next/server/pages/api/hello.js')
-        require.resolve('../../../web/.next/server/pages/api/og.js')
-        require.resolve('../../../web/.next/server/pages/api/revalidate.js')
-        require.resolve('../../../web/.next/server/pages/api/shows/[...params].js')
-        require.resolve('../../../web/.next/server/pages/api/shows/[id].js')
-        require.resolve('../../../web/.next/server/pages/deep/import.js')
-        require.resolve('../../../web/.next/server/pages/edge/[id].js')
-        require.resolve('../../../web/.next/server/pages/getServerSideProps/[id].js')
-        require.resolve('../../../web/.next/server/pages/getServerSideProps/all/[[...slug]].js')
-        require.resolve('../../../web/.next/server/pages/getServerSideProps/file.js')
-        require.resolve('../../../web/.next/server/pages/getServerSideProps/static.js')
-        require.resolve('../../../web/.next/server/pages/getStaticProps/[id].js')
-        require.resolve('../../../web/.next/server/pages/getStaticProps/env.js')
-        require.resolve('../../../web/.next/server/pages/getStaticProps/static.js')
-        require.resolve('../../../web/.next/server/pages/getStaticProps/with-revalidate-404.js')
-        require.resolve('../../../web/.next/server/pages/getStaticProps/with-revalidate.js')
-        require.resolve('../../../web/.next/server/pages/getStaticProps/withFallback/[...slug].js')
-        require.resolve('../../../web/.next/server/pages/getStaticProps/withFallback/[id].js')
-        require.resolve('../../../web/.next/server/pages/getStaticProps/withFallbackBlocking/[id].js')
-        require.resolve('../../../web/.next/server/pages/getStaticProps/withRevalidate/[id].js')
-        require.resolve('../../../web/.next/server/pages/getStaticProps/withRevalidate/withFallback/[id].js')
-        require.resolve('../../../web/.next/server/pages/getStaticProps/withRevalidate/withFallbackBlocking/[id].js')
-        require.resolve('../../../web/.next/server/pages/index.js')
-        require.resolve('../../../web/.next/server/pages/previewTest.js')
-        require.resolve('../../../web/.next/server/pages/shows/[...params].js')
-        require.resolve('../../../web/.next/server/pages/shows/[id].js')
-        require.resolve('../../../web/.next/server/webpack-api-runtime.js')
-        require.resolve('../../../web/.next/server/webpack-runtime.js')
-        require.resolve('../../../web/components/Header.js')
-        require.resolve('../../../web/hello.txt')
-        require.resolve('../../../web/package.json')
-    } catch {}
-}"
-`;
-
-exports[`onBuild() generates static files manifest 1`] = `
+exports[`onBuild() NEXT_CDN_CACHE_CONTROL enabled when splitting API routes is disabled, it writes correct redirects to netlifyConfig 1`] = `
 Array [
-  Array [
-    "app/blog/erica/first-post.html",
-    "blog/erica/first-post.html",
-  ],
-  Array [
-    "app/blog/erica/first-post.rsc",
-    "blog/erica/first-post.rsc",
-  ],
-  Array [
-    "app/blog/nick/first-post.html",
-    "blog/nick/first-post.html",
-  ],
-  Array [
-    "app/blog/nick/first-post.rsc",
-    "blog/nick/first-post.rsc",
-  ],
-  Array [
-    "app/blog/nick/second-post.html",
-    "blog/nick/second-post.html",
-  ],
-  Array [
-    "app/blog/nick/second-post.rsc",
-    "blog/nick/second-post.rsc",
-  ],
-  Array [
-    "app/blog/rob/second-post.html",
-    "blog/rob/second-post.html",
-  ],
-  Array [
-    "app/blog/rob/second-post.rsc",
-    "blog/rob/second-post.rsc",
-  ],
-  Array [
-    "app/blog/sarah/second-post.html",
-    "blog/sarah/second-post.html",
-  ],
-  Array [
-    "app/blog/sarah/second-post.rsc",
-    "blog/sarah/second-post.rsc",
-  ],
-  Array [
-    "pages/en/404.html",
-    "en/404.html",
-  ],
-  Array [
-    "pages/en/500.html",
-    "en/500.html",
-  ],
-  Array [
-    "pages/en/broken-image.html",
-    "en/broken-image.html",
-  ],
-  Array [
-    "pages/en/css.html",
-    "en/css.html",
-  ],
-  Array [
-    "pages/en/env.html",
-    "en/env.html",
-  ],
-  Array [
-    "pages/en/font.html",
-    "en/font.html",
-  ],
-  Array [
-    "pages/en/getStaticProps/1.html",
-    "en/getStaticProps/1.html",
-  ],
-  Array [
-    "pages/en/getStaticProps/1.json",
-    "_next/data/build-id/en/getStaticProps/1.json",
-  ],
-  Array [
-    "pages/en/getStaticProps/2.html",
-    "en/getStaticProps/2.html",
-  ],
-  Array [
-    "pages/en/getStaticProps/2.json",
-    "_next/data/build-id/en/getStaticProps/2.json",
-  ],
-  Array [
-    "pages/en/getStaticProps/env.html",
-    "en/getStaticProps/env.html",
-  ],
-  Array [
-    "pages/en/getStaticProps/env.json",
-    "_next/data/build-id/en/getStaticProps/env.json",
-  ],
-  Array [
-    "pages/en/getStaticProps/static.html",
-    "en/getStaticProps/static.html",
-  ],
-  Array [
-    "pages/en/getStaticProps/static.json",
-    "_next/data/build-id/en/getStaticProps/static.json",
-  ],
-  Array [
-    "pages/en/getStaticProps/withFallback/1.html",
-    "en/getStaticProps/withFallback/1.html",
-  ],
-  Array [
-    "pages/en/getStaticProps/withFallback/1.json",
-    "_next/data/build-id/en/getStaticProps/withFallback/1.json",
-  ],
-  Array [
-    "pages/en/getStaticProps/withFallback/2.html",
-    "en/getStaticProps/withFallback/2.html",
-  ],
-  Array [
-    "pages/en/getStaticProps/withFallback/2.json",
-    "_next/data/build-id/en/getStaticProps/withFallback/2.json",
-  ],
-  Array [
-    "pages/en/getStaticProps/withFallback/my/path/1.html",
-    "en/getStaticProps/withFallback/my/path/1.html",
-  ],
-  Array [
-    "pages/en/getStaticProps/withFallback/my/path/1.json",
-    "_next/data/build-id/en/getStaticProps/withFallback/my/path/1.json",
-  ],
-  Array [
-    "pages/en/getStaticProps/withFallback/my/path/2.html",
-    "en/getStaticProps/withFallback/my/path/2.html",
-  ],
-  Array [
-    "pages/en/getStaticProps/withFallback/my/path/2.json",
-    "_next/data/build-id/en/getStaticProps/withFallback/my/path/2.json",
-  ],
-  Array [
-    "pages/en/getStaticProps/withFallbackBlocking/1.html",
-    "en/getStaticProps/withFallbackBlocking/1.html",
-  ],
-  Array [
-    "pages/en/getStaticProps/withFallbackBlocking/1.json",
-    "_next/data/build-id/en/getStaticProps/withFallbackBlocking/1.json",
-  ],
-  Array [
-    "pages/en/getStaticProps/withFallbackBlocking/2.html",
-    "en/getStaticProps/withFallbackBlocking/2.html",
-  ],
-  Array [
-    "pages/en/getStaticProps/withFallbackBlocking/2.json",
-    "_next/data/build-id/en/getStaticProps/withFallbackBlocking/2.json",
-  ],
-  Array [
-    "pages/en/image.html",
-    "en/image.html",
-  ],
-  Array [
-    "pages/en/layouts.html",
-    "en/layouts.html",
-  ],
-  Array [
-    "pages/en/previewTest.html",
-    "en/previewTest.html",
-  ],
-  Array [
-    "pages/en/previewTest.json",
-    "_next/data/build-id/en/previewTest.json",
-  ],
-  Array [
-    "pages/en/script.html",
-    "en/script.html",
-  ],
-  Array [
-    "pages/en/static.html",
-    "en/static.html",
-  ],
-  Array [
-    "pages/es/404.html",
-    "es/404.html",
-  ],
-  Array [
-    "pages/es/500.html",
-    "es/500.html",
-  ],
-  Array [
-    "pages/es/broken-image.html",
-    "es/broken-image.html",
-  ],
-  Array [
-    "pages/es/css.html",
-    "es/css.html",
-  ],
-  Array [
-    "pages/es/env.html",
-    "es/env.html",
-  ],
-  Array [
-    "pages/es/font.html",
-    "es/font.html",
-  ],
-  Array [
-    "pages/es/getStaticProps/env.html",
-    "es/getStaticProps/env.html",
-  ],
-  Array [
-    "pages/es/getStaticProps/env.json",
-    "_next/data/build-id/es/getStaticProps/env.json",
-  ],
-  Array [
-    "pages/es/getStaticProps/static.html",
-    "es/getStaticProps/static.html",
-  ],
-  Array [
-    "pages/es/getStaticProps/static.json",
-    "_next/data/build-id/es/getStaticProps/static.json",
-  ],
-  Array [
-    "pages/es/image.html",
-    "es/image.html",
-  ],
-  Array [
-    "pages/es/layouts.html",
-    "es/layouts.html",
-  ],
-  Array [
-    "pages/es/previewTest.html",
-    "es/previewTest.html",
-  ],
-  Array [
-    "pages/es/previewTest.json",
-    "_next/data/build-id/es/previewTest.json",
-  ],
-  Array [
-    "pages/es/script.html",
-    "es/script.html",
-  ],
-  Array [
-    "pages/es/static.html",
-    "es/static.html",
-  ],
-  Array [
-    "pages/fr/404.html",
-    "fr/404.html",
-  ],
-  Array [
-    "pages/fr/500.html",
-    "fr/500.html",
-  ],
-  Array [
-    "pages/fr/broken-image.html",
-    "fr/broken-image.html",
-  ],
-  Array [
-    "pages/fr/css.html",
-    "fr/css.html",
-  ],
-  Array [
-    "pages/fr/env.html",
-    "fr/env.html",
-  ],
-  Array [
-    "pages/fr/font.html",
-    "fr/font.html",
-  ],
-  Array [
-    "pages/fr/getStaticProps/env.html",
-    "fr/getStaticProps/env.html",
-  ],
-  Array [
-    "pages/fr/getStaticProps/env.json",
-    "_next/data/build-id/fr/getStaticProps/env.json",
-  ],
-  Array [
-    "pages/fr/getStaticProps/static.html",
-    "fr/getStaticProps/static.html",
-  ],
-  Array [
-    "pages/fr/getStaticProps/static.json",
-    "_next/data/build-id/fr/getStaticProps/static.json",
-  ],
-  Array [
-    "pages/fr/image.html",
-    "fr/image.html",
-  ],
-  Array [
-    "pages/fr/layouts.html",
-    "fr/layouts.html",
-  ],
-  Array [
-    "pages/fr/previewTest.html",
-    "fr/previewTest.html",
-  ],
-  Array [
-    "pages/fr/previewTest.json",
-    "_next/data/build-id/fr/previewTest.json",
-  ],
-  Array [
-    "pages/fr/script.html",
-    "fr/script.html",
-  ],
-  Array [
-    "pages/fr/static.html",
-    "fr/static.html",
-  ],
+  Object {
+    "conditions": Object {
+      "Cookie": Array [
+        "NEXT_LOCALE",
+      ],
+    },
+    "force": true,
+    "from": "/",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "conditions": Object {
+      "Language": Array [
+        "es",
+      ],
+    },
+    "force": true,
+    "from": "/",
+    "status": 301,
+    "to": "/es/",
+  },
+  Object {
+    "conditions": Object {
+      "Language": Array [
+        "fr",
+      ],
+    },
+    "force": true,
+    "from": "/",
+    "status": 301,
+    "to": "/fr/",
+  },
+  Object {
+    "force": true,
+    "from": "/",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "from": "/_ipx/*",
+    "status": 200,
+    "to": "/.netlify/builders/_ipx",
+  },
+  Object {
+    "force": true,
+    "from": "/_next/data/build-id/en.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/en/500.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/en/app-edge.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/en/broken-image.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/en/css.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/en/deep/import.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/en/edge/:id.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/en/env.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/en/font.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/en/getServerSideProps/:id.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/en/getServerSideProps/all.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/en/getServerSideProps/all/*",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/en/getServerSideProps/file.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/en/getServerSideProps/static.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/en/getStaticProps/:id.json",
+    "status": 404,
+    "to": "/en/404.html",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/en/getStaticProps/env.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/en/getStaticProps/static.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/_next/data/build-id/en/getStaticProps/with-revalidate-404.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/_next/data/build-id/en/getStaticProps/with-revalidate.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/en/getStaticProps/withFallback/:id.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/en/getStaticProps/withFallback/:slug/*",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/en/getStaticProps/withFallbackBlocking/:id.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/en/getStaticProps/withRevalidate/:id.json",
+    "status": 404,
+    "to": "/en/404.html",
+  },
+  Object {
+    "force": true,
+    "from": "/_next/data/build-id/en/getStaticProps/withRevalidate/1.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/_next/data/build-id/en/getStaticProps/withRevalidate/2.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/en/getStaticProps/withRevalidate/withFallback/:id.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/_next/data/build-id/en/getStaticProps/withRevalidate/withFallback/1.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/_next/data/build-id/en/getStaticProps/withRevalidate/withFallback/2.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/en/getStaticProps/withRevalidate/withFallbackBlocking/:id.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/_next/data/build-id/en/getStaticProps/withRevalidate/withFallbackBlocking/1.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/_next/data/build-id/en/getStaticProps/withRevalidate/withFallbackBlocking/2.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/en/image.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/en/layouts.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/en/old/image.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/en/previewTest.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/en/redirectme.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/en/script.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/en/shows/:id.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/en/shows/:params/*",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/en/static.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/en/static/:id.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/_next/data/build-id/es.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/es/500.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/es/app-edge.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/es/broken-image.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/es/css.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/es/deep/import.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/es/edge/:id.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/es/env.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/es/font.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/es/getServerSideProps/:id.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/es/getServerSideProps/all.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/es/getServerSideProps/all/*",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/es/getServerSideProps/file.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/es/getServerSideProps/static.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/es/getStaticProps/:id.json",
+    "status": 404,
+    "to": "/es/404.html",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/es/getStaticProps/env.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/es/getStaticProps/static.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/_next/data/build-id/es/getStaticProps/with-revalidate-404.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/_next/data/build-id/es/getStaticProps/with-revalidate.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/es/getStaticProps/withFallback/:id.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/es/getStaticProps/withFallback/:slug/*",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/es/getStaticProps/withFallbackBlocking/:id.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/es/getStaticProps/withRevalidate/:id.json",
+    "status": 404,
+    "to": "/es/404.html",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/es/getStaticProps/withRevalidate/withFallback/:id.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/es/getStaticProps/withRevalidate/withFallbackBlocking/:id.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/es/image.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/es/layouts.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/es/old/image.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/es/previewTest.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/es/redirectme.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/es/script.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/es/shows/:id.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/es/shows/:params/*",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/es/static.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/es/static/:id.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/_next/data/build-id/fr.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/fr/500.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/fr/app-edge.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/fr/broken-image.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/fr/css.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/fr/deep/import.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/fr/edge/:id.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/fr/env.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/fr/font.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/fr/getServerSideProps/:id.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/fr/getServerSideProps/all.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/fr/getServerSideProps/all/*",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/fr/getServerSideProps/file.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/fr/getServerSideProps/static.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/fr/getStaticProps/:id.json",
+    "status": 404,
+    "to": "/fr/404.html",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/fr/getStaticProps/env.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/fr/getStaticProps/static.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/_next/data/build-id/fr/getStaticProps/with-revalidate-404.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/_next/data/build-id/fr/getStaticProps/with-revalidate.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/fr/getStaticProps/withFallback/:id.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/fr/getStaticProps/withFallback/:slug/*",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/fr/getStaticProps/withFallbackBlocking/:id.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/fr/getStaticProps/withRevalidate/:id.json",
+    "status": 404,
+    "to": "/fr/404.html",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/fr/getStaticProps/withRevalidate/withFallback/:id.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/fr/getStaticProps/withRevalidate/withFallbackBlocking/:id.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/fr/image.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/fr/layouts.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/fr/old/image.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/fr/previewTest.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/fr/redirectme.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/fr/script.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/fr/shows/:id.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/fr/shows/:params/*",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/fr/static.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/fr/static/:id.json",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "from": "/_next/image/*",
+    "query": Object {
+      "q": ":quality",
+      "url": ":url",
+      "w": ":width",
+    },
+    "status": 301,
+    "to": "/_ipx/w_:width,q_:quality/:url",
+  },
+  Object {
+    "from": "/_next/static/*",
+    "status": 200,
+    "to": "/static/:splat",
+  },
+  Object {
+    "from": "/:locale/_next/static/*",
+    "status": 200,
+    "to": "/static/:splat",
+  },
+  Object {
+    "conditions": Object {
+      "Cookie": Array [
+        "__prerender_bypass",
+        "__next_preview_data",
+      ],
+    },
+    "force": true,
+    "from": "/*",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "from": "/*",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/500",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "from": "/api/*",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "from": "/api/hello-background",
+    "status": 200,
+    "to": "/.netlify/functions/_api_hello-background-background",
+  },
+  Object {
+    "from": "/api/hello-scheduled",
+    "status": 404,
+    "to": "/404.html",
+  },
+  Object {
+    "force": false,
+    "from": "/app-edge",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/blog/:author",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/blog/:author.rsc",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/blog/:author/:slug",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/blog/:author/:slug.rsc",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/blog/erica",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/blog/erica.rsc",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/blog/nick",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/blog/nick.rsc",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/blog/rob",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/blog/rob.rsc",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/blog/sarah",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/blog/sarah.rsc",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/broken-image",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/css",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/deep/import",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/edge/:id",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/env",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/es",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/es/500",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/es/app-edge",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/es/blog/:author",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/es/blog/:author.rsc",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/es/blog/:author/:slug",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/es/blog/:author/:slug.rsc",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/es/broken-image",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/es/css",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/es/deep/import",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/es/edge/:id",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/es/env",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/es/font",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/es/getServerSideProps/:id",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/es/getServerSideProps/all",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/es/getServerSideProps/all/*",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/es/getServerSideProps/file",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/es/getServerSideProps/static",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/es/getStaticProps/:id",
+    "status": 404,
+    "to": "/es/404.html",
+  },
+  Object {
+    "force": false,
+    "from": "/es/getStaticProps/env",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/es/getStaticProps/static",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/es/getStaticProps/with-revalidate",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/es/getStaticProps/with-revalidate-404",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/es/getStaticProps/withFallback/:id",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/es/getStaticProps/withFallback/:slug/*",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/es/getStaticProps/withFallbackBlocking/:id",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/es/getStaticProps/withRevalidate/:id",
+    "status": 404,
+    "to": "/es/404.html",
+  },
+  Object {
+    "force": false,
+    "from": "/es/getStaticProps/withRevalidate/withFallback/:id",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/es/getStaticProps/withRevalidate/withFallbackBlocking/:id",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/es/image",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/es/layouts",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/es/old/image",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/es/previewTest",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/es/redirectme",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/es/script",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/es/shows/:id",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/es/shows/:params/*",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/es/static",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/es/static/:id",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/font",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/fr",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/fr/500",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/fr/app-edge",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/fr/blog/:author",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/fr/blog/:author.rsc",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/fr/blog/:author/:slug",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/fr/blog/:author/:slug.rsc",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/fr/broken-image",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/fr/css",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/fr/deep/import",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/fr/edge/:id",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/fr/env",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/fr/font",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/fr/getServerSideProps/:id",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/fr/getServerSideProps/all",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/fr/getServerSideProps/all/*",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/fr/getServerSideProps/file",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/fr/getServerSideProps/static",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/fr/getStaticProps/:id",
+    "status": 404,
+    "to": "/fr/404.html",
+  },
+  Object {
+    "force": false,
+    "from": "/fr/getStaticProps/env",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/fr/getStaticProps/static",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/fr/getStaticProps/with-revalidate",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/fr/getStaticProps/with-revalidate-404",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/fr/getStaticProps/withFallback/:id",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/fr/getStaticProps/withFallback/:slug/*",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/fr/getStaticProps/withFallbackBlocking/:id",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/fr/getStaticProps/withRevalidate/:id",
+    "status": 404,
+    "to": "/fr/404.html",
+  },
+  Object {
+    "force": false,
+    "from": "/fr/getStaticProps/withRevalidate/withFallback/:id",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/fr/getStaticProps/withRevalidate/withFallbackBlocking/:id",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/fr/image",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/fr/layouts",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/fr/old/image",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/fr/previewTest",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/fr/redirectme",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/fr/script",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/fr/shows/:id",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/fr/shows/:params/*",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/fr/static",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/fr/static/:id",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/getServerSideProps/:id",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/getServerSideProps/all",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/getServerSideProps/all/*",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/getServerSideProps/file",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/getServerSideProps/static",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/getStaticProps/:id",
+    "status": 404,
+    "to": "/en/404.html",
+  },
+  Object {
+    "force": false,
+    "from": "/getStaticProps/env",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/getStaticProps/static",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/getStaticProps/with-revalidate",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/getStaticProps/with-revalidate-404",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/getStaticProps/withFallback/:id",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/getStaticProps/withFallback/:slug/*",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/getStaticProps/withFallbackBlocking/:id",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/getStaticProps/withRevalidate/:id",
+    "status": 404,
+    "to": "/en/404.html",
+  },
+  Object {
+    "force": true,
+    "from": "/getStaticProps/withRevalidate/1",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/getStaticProps/withRevalidate/2",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/getStaticProps/withRevalidate/withFallback/:id",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/getStaticProps/withRevalidate/withFallback/1",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/getStaticProps/withRevalidate/withFallback/2",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/getStaticProps/withRevalidate/withFallbackBlocking/:id",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/getStaticProps/withRevalidate/withFallbackBlocking/1",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/getStaticProps/withRevalidate/withFallbackBlocking/2",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/image",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/layouts",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "conditions": Object {
+      "Cookie": Array [
+        "__prerender_bypass",
+        "__next_preview_data",
+      ],
+    },
+    "from": "/next-on-netlify.png",
+    "status": 200,
+    "to": "/next-on-netlify.png",
+  },
+  Object {
+    "force": false,
+    "from": "/old/image",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/previewTest",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/redirectme",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/script",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/shows/:id",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/shows/:params/*",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "conditions": Object {
+      "Cookie": Array [
+        "__prerender_bypass",
+        "__next_preview_data",
+      ],
+    },
+    "from": "/shows1.json",
+    "status": 200,
+    "to": "/shows1.json",
+  },
+  Object {
+    "force": false,
+    "from": "/static",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/static/:id",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
 ]
 `;
 
-exports[`onBuild() when splitting API routes is disabled, it writes correct redirects to netlifyConfig 1`] = `
+exports[`onBuild() NEXT_CDN_CACHE_CONTROL not enabled generates a file referencing all page sources 1`] = `
+"// This file is purely to allow nft to know about these pages.
+exports.resolvePages = () => {
+    try {
+        require.resolve('../../../../../node_modules/@swc/helpers/_/_interop_require_default/package.json')
+        require.resolve('../../../../../node_modules/@swc/helpers/_/_interop_require_wildcard/package.json')
+        require.resolve('../../../../../node_modules/@swc/helpers/cjs/_interop_require_default.cjs')
+        require.resolve('../../../../../node_modules/@swc/helpers/cjs/_interop_require_wildcard.cjs')
+        require.resolve('../../../../../node_modules/@swc/helpers/package.json')
+        require.resolve('../../../../../node_modules/next/dist/client/add-base-path.js')
+        require.resolve('../../../../../node_modules/next/dist/client/add-locale.js')
+        require.resolve('../../../../../node_modules/next/dist/client/detect-domain-locale.js')
+        require.resolve('../../../../../node_modules/next/dist/client/has-base-path.js')
+        require.resolve('../../../../../node_modules/next/dist/client/head-manager.js')
+        require.resolve('../../../../../node_modules/next/dist/client/normalize-trailing-slash.js')
+        require.resolve('../../../../../node_modules/next/dist/client/remove-base-path.js')
+        require.resolve('../../../../../node_modules/next/dist/client/remove-locale.js')
+        require.resolve('../../../../../node_modules/next/dist/client/request-idle-callback.js')
+        require.resolve('../../../../../node_modules/next/dist/client/route-loader.js')
+        require.resolve('../../../../../node_modules/next/dist/client/router.js')
+        require.resolve('../../../../../node_modules/next/dist/client/script.js')
+        require.resolve('../../../../../node_modules/next/dist/client/trusted-types.js')
+        require.resolve('../../../../../node_modules/next/dist/client/with-router.js')
+        require.resolve('../../../../../node_modules/next/dist/compiled/gzip-size/index.js')
+        require.resolve('../../../../../node_modules/next/dist/compiled/gzip-size/package.json')
+        require.resolve('../../../../../node_modules/next/dist/compiled/path-to-regexp/index.js')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react-dom/cjs/react-dom-server-rendering-stub.development.js')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react-dom/cjs/react-dom-server-rendering-stub.production.min.js')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react-dom/package.json')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react-dom/server-rendering-stub.js')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react-is/cjs/react-is.development.js')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react-is/cjs/react-is.production.min.js')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react-is/index.js')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react-is/package.json')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-client.browser.development.js')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-client.browser.production.min.js')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react-server-dom-webpack/client.browser.js')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react-server-dom-webpack/client.js')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react-server-dom-webpack/package.json')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react/cjs/react-jsx-runtime.development.js')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react/cjs/react-jsx-runtime.production.min.js')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react/cjs/react.development.js')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react/cjs/react.production.min.js')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react/index.js')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react/jsx-runtime.js')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react/package.json')
+        require.resolve('../../../../../node_modules/next/dist/lib/is-api-route.js')
+        require.resolve('../../../../../node_modules/next/dist/lib/is-error.js')
+        require.resolve('../../../../../node_modules/next/dist/pages/_error.js')
+        require.resolve('../../../../../node_modules/next/dist/server/app-render/get-segment-param.js')
+        require.resolve('../../../../../node_modules/next/dist/server/future/helpers/interception-routes.js')
+        require.resolve('../../../../../node_modules/next/dist/server/get-page-files.js')
+        require.resolve('../../../../../node_modules/next/dist/server/htmlescape.js')
+        require.resolve('../../../../../node_modules/next/dist/server/utils.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/amp-context.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/amp-mode.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/app-router-context.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/bloom-filter.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/constants.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/escape-regexp.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/head-manager-context.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/head.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/hooks-client-context.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/html-context.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/i18n/detect-domain-locale.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/i18n/normalize-locale-path.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/is-plain-object.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/loadable-context.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/loadable.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/mitt.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/modern-browserslist-target.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/page-path/denormalize-page-path.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/page-path/ensure-leading-slash.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/page-path/normalize-page-path.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/page-path/normalize-path-sep.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router-context.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/router.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/add-locale.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/add-path-prefix.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/add-path-suffix.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/app-paths.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/compare-states.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/format-next-pathname-info.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/format-url.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/get-asset-path-from-route.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/get-next-pathname-info.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/handle-smooth-scroll.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/index.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/interpolate-as.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/is-bot.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/is-dynamic.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/is-local-url.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/omit.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/parse-path.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/parse-relative-url.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/parse-url.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/path-has-prefix.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/path-match.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/prepare-destination.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/querystring.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/remove-path-prefix.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/remove-trailing-slash.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/resolve-href.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/resolve-rewrites.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/route-matcher.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/route-regex.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/sorted-routes.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/server-inserted-html.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/side-effect.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/utils.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/utils/warn-once.js')
+        require.resolve('../../../../../node_modules/next/error.js')
+        require.resolve('../../../../../node_modules/next/package.json')
+        require.resolve('../../../../../node_modules/next/router.js')
+        require.resolve('../../../../../node_modules/react-dom/cjs/react-dom.development.js')
+        require.resolve('../../../../../node_modules/react-dom/cjs/react-dom.production.min.js')
+        require.resolve('../../../../../node_modules/react-dom/index.js')
+        require.resolve('../../../../../node_modules/react-dom/node_modules/scheduler/cjs/scheduler.development.js')
+        require.resolve('../../../../../node_modules/react-dom/node_modules/scheduler/cjs/scheduler.production.min.js')
+        require.resolve('../../../../../node_modules/react-dom/node_modules/scheduler/index.js')
+        require.resolve('../../../../../node_modules/react-dom/node_modules/scheduler/package.json')
+        require.resolve('../../../../../node_modules/react-dom/package.json')
+        require.resolve('../../../../../node_modules/react/cjs/react.development.js')
+        require.resolve('../../../../../node_modules/react/cjs/react.production.min.js')
+        require.resolve('../../../../../node_modules/react/index.js')
+        require.resolve('../../../../../node_modules/react/package.json')
+        require.resolve('../../../../../package.json')
+        require.resolve('../../../.next/package.json')
+        require.resolve('../../../.next/server/app/app-edge/page.js')
+        require.resolve('../../../.next/server/app/blog/[author]/[slug]/page.js')
+        require.resolve('../../../.next/server/app/blog/[author]/page.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/chunks/header.js')
+        require.resolve('../../../.next/server/pages/_app.js')
+        require.resolve('../../../.next/server/pages/_document.js')
+        require.resolve('../../../.next/server/pages/_error.js')
+        require.resolve('../../../.next/server/pages/api/enterPreview.js')
+        require.resolve('../../../.next/server/pages/api/exitPreview.js')
+        require.resolve('../../../.next/server/pages/api/hello-background.js')
+        require.resolve('../../../.next/server/pages/api/hello-scheduled.js')
+        require.resolve('../../../.next/server/pages/api/hello.js')
+        require.resolve('../../../.next/server/pages/api/og.js')
+        require.resolve('../../../.next/server/pages/api/revalidate.js')
+        require.resolve('../../../.next/server/pages/api/shows/[...params].js')
+        require.resolve('../../../.next/server/pages/api/shows/[id].js')
+        require.resolve('../../../.next/server/pages/deep/import.js')
+        require.resolve('../../../.next/server/pages/edge/[id].js')
+        require.resolve('../../../.next/server/pages/getServerSideProps/[id].js')
+        require.resolve('../../../.next/server/pages/getServerSideProps/all/[[...slug]].js')
+        require.resolve('../../../.next/server/pages/getServerSideProps/file.js')
+        require.resolve('../../../.next/server/pages/getServerSideProps/static.js')
+        require.resolve('../../../.next/server/pages/getStaticProps/[id].js')
+        require.resolve('../../../.next/server/pages/getStaticProps/env.js')
+        require.resolve('../../../.next/server/pages/getStaticProps/static.js')
+        require.resolve('../../../.next/server/pages/getStaticProps/with-revalidate-404.js')
+        require.resolve('../../../.next/server/pages/getStaticProps/with-revalidate.js')
+        require.resolve('../../../.next/server/pages/getStaticProps/withFallback/[...slug].js')
+        require.resolve('../../../.next/server/pages/getStaticProps/withFallback/[id].js')
+        require.resolve('../../../.next/server/pages/getStaticProps/withFallbackBlocking/[id].js')
+        require.resolve('../../../.next/server/pages/getStaticProps/withRevalidate/[id].js')
+        require.resolve('../../../.next/server/pages/getStaticProps/withRevalidate/withFallback/[id].js')
+        require.resolve('../../../.next/server/pages/getStaticProps/withRevalidate/withFallbackBlocking/[id].js')
+        require.resolve('../../../.next/server/pages/index.js')
+        require.resolve('../../../.next/server/pages/previewTest.js')
+        require.resolve('../../../.next/server/pages/shows/[...params].js')
+        require.resolve('../../../.next/server/pages/shows/[id].js')
+        require.resolve('../../../.next/server/webpack-api-runtime.js')
+        require.resolve('../../../.next/server/webpack-runtime.js')
+        require.resolve('../../../components/Header.js')
+        require.resolve('../../../hello.txt')
+        require.resolve('../../../package.json')
+    } catch {}
+}"
+`;
+
+exports[`onBuild() NEXT_CDN_CACHE_CONTROL not enabled generates a file referencing all page sources 2`] = `
+"// This file is purely to allow nft to know about these pages.
+exports.resolvePages = () => {
+    try {
+        require.resolve('../../../../../node_modules/@swc/helpers/_/_interop_require_default/package.json')
+        require.resolve('../../../../../node_modules/@swc/helpers/_/_interop_require_wildcard/package.json')
+        require.resolve('../../../../../node_modules/@swc/helpers/cjs/_interop_require_default.cjs')
+        require.resolve('../../../../../node_modules/@swc/helpers/cjs/_interop_require_wildcard.cjs')
+        require.resolve('../../../../../node_modules/@swc/helpers/package.json')
+        require.resolve('../../../../../node_modules/next/dist/client/add-base-path.js')
+        require.resolve('../../../../../node_modules/next/dist/client/add-locale.js')
+        require.resolve('../../../../../node_modules/next/dist/client/detect-domain-locale.js')
+        require.resolve('../../../../../node_modules/next/dist/client/has-base-path.js')
+        require.resolve('../../../../../node_modules/next/dist/client/head-manager.js')
+        require.resolve('../../../../../node_modules/next/dist/client/normalize-trailing-slash.js')
+        require.resolve('../../../../../node_modules/next/dist/client/remove-base-path.js')
+        require.resolve('../../../../../node_modules/next/dist/client/remove-locale.js')
+        require.resolve('../../../../../node_modules/next/dist/client/request-idle-callback.js')
+        require.resolve('../../../../../node_modules/next/dist/client/route-loader.js')
+        require.resolve('../../../../../node_modules/next/dist/client/router.js')
+        require.resolve('../../../../../node_modules/next/dist/client/script.js')
+        require.resolve('../../../../../node_modules/next/dist/client/trusted-types.js')
+        require.resolve('../../../../../node_modules/next/dist/client/with-router.js')
+        require.resolve('../../../../../node_modules/next/dist/compiled/gzip-size/index.js')
+        require.resolve('../../../../../node_modules/next/dist/compiled/gzip-size/package.json')
+        require.resolve('../../../../../node_modules/next/dist/compiled/path-to-regexp/index.js')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react-dom/cjs/react-dom-server-rendering-stub.development.js')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react-dom/cjs/react-dom-server-rendering-stub.production.min.js')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react-dom/package.json')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react-dom/server-rendering-stub.js')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react-is/cjs/react-is.development.js')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react-is/cjs/react-is.production.min.js')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react-is/index.js')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react-is/package.json')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-client.browser.development.js')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-client.browser.production.min.js')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react-server-dom-webpack/client.browser.js')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react-server-dom-webpack/client.js')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react-server-dom-webpack/package.json')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react/cjs/react-jsx-runtime.development.js')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react/cjs/react-jsx-runtime.production.min.js')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react/cjs/react.development.js')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react/cjs/react.production.min.js')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react/index.js')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react/jsx-runtime.js')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react/package.json')
+        require.resolve('../../../../../node_modules/next/dist/lib/is-api-route.js')
+        require.resolve('../../../../../node_modules/next/dist/lib/is-error.js')
+        require.resolve('../../../../../node_modules/next/dist/pages/_error.js')
+        require.resolve('../../../../../node_modules/next/dist/server/app-render/get-segment-param.js')
+        require.resolve('../../../../../node_modules/next/dist/server/future/helpers/interception-routes.js')
+        require.resolve('../../../../../node_modules/next/dist/server/get-page-files.js')
+        require.resolve('../../../../../node_modules/next/dist/server/htmlescape.js')
+        require.resolve('../../../../../node_modules/next/dist/server/utils.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/amp-context.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/amp-mode.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/app-router-context.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/bloom-filter.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/constants.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/escape-regexp.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/head-manager-context.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/head.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/hooks-client-context.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/html-context.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/i18n/detect-domain-locale.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/i18n/normalize-locale-path.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/is-plain-object.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/loadable-context.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/loadable.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/mitt.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/modern-browserslist-target.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/page-path/denormalize-page-path.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/page-path/ensure-leading-slash.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/page-path/normalize-page-path.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/page-path/normalize-path-sep.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router-context.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/router.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/add-locale.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/add-path-prefix.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/add-path-suffix.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/app-paths.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/compare-states.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/format-next-pathname-info.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/format-url.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/get-asset-path-from-route.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/get-next-pathname-info.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/handle-smooth-scroll.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/index.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/interpolate-as.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/is-bot.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/is-dynamic.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/is-local-url.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/omit.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/parse-path.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/parse-relative-url.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/parse-url.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/path-has-prefix.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/path-match.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/prepare-destination.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/querystring.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/remove-path-prefix.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/remove-trailing-slash.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/resolve-href.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/resolve-rewrites.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/route-matcher.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/route-regex.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/sorted-routes.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/server-inserted-html.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/side-effect.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/utils.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/utils/warn-once.js')
+        require.resolve('../../../../../node_modules/next/error.js')
+        require.resolve('../../../../../node_modules/next/package.json')
+        require.resolve('../../../../../node_modules/next/router.js')
+        require.resolve('../../../../../node_modules/react-dom/cjs/react-dom.development.js')
+        require.resolve('../../../../../node_modules/react-dom/cjs/react-dom.production.min.js')
+        require.resolve('../../../../../node_modules/react-dom/index.js')
+        require.resolve('../../../../../node_modules/react-dom/node_modules/scheduler/cjs/scheduler.development.js')
+        require.resolve('../../../../../node_modules/react-dom/node_modules/scheduler/cjs/scheduler.production.min.js')
+        require.resolve('../../../../../node_modules/react-dom/node_modules/scheduler/index.js')
+        require.resolve('../../../../../node_modules/react-dom/node_modules/scheduler/package.json')
+        require.resolve('../../../../../node_modules/react-dom/package.json')
+        require.resolve('../../../../../node_modules/react/cjs/react.development.js')
+        require.resolve('../../../../../node_modules/react/cjs/react.production.min.js')
+        require.resolve('../../../../../node_modules/react/index.js')
+        require.resolve('../../../../../node_modules/react/package.json')
+        require.resolve('../../../../../package.json')
+        require.resolve('../../../.next/package.json')
+        require.resolve('../../../.next/server/app/app-edge/page.js')
+        require.resolve('../../../.next/server/app/blog/[author]/[slug]/page.js')
+        require.resolve('../../../.next/server/app/blog/[author]/page.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/chunks/header.js')
+        require.resolve('../../../.next/server/pages/_app.js')
+        require.resolve('../../../.next/server/pages/_document.js')
+        require.resolve('../../../.next/server/pages/_error.js')
+        require.resolve('../../../.next/server/pages/api/enterPreview.js')
+        require.resolve('../../../.next/server/pages/api/exitPreview.js')
+        require.resolve('../../../.next/server/pages/api/hello-background.js')
+        require.resolve('../../../.next/server/pages/api/hello-scheduled.js')
+        require.resolve('../../../.next/server/pages/api/hello.js')
+        require.resolve('../../../.next/server/pages/api/og.js')
+        require.resolve('../../../.next/server/pages/api/revalidate.js')
+        require.resolve('../../../.next/server/pages/api/shows/[...params].js')
+        require.resolve('../../../.next/server/pages/api/shows/[id].js')
+        require.resolve('../../../.next/server/pages/deep/import.js')
+        require.resolve('../../../.next/server/pages/edge/[id].js')
+        require.resolve('../../../.next/server/pages/getServerSideProps/[id].js')
+        require.resolve('../../../.next/server/pages/getServerSideProps/all/[[...slug]].js')
+        require.resolve('../../../.next/server/pages/getServerSideProps/file.js')
+        require.resolve('../../../.next/server/pages/getServerSideProps/static.js')
+        require.resolve('../../../.next/server/pages/getStaticProps/[id].js')
+        require.resolve('../../../.next/server/pages/getStaticProps/env.js')
+        require.resolve('../../../.next/server/pages/getStaticProps/static.js')
+        require.resolve('../../../.next/server/pages/getStaticProps/with-revalidate-404.js')
+        require.resolve('../../../.next/server/pages/getStaticProps/with-revalidate.js')
+        require.resolve('../../../.next/server/pages/getStaticProps/withFallback/[...slug].js')
+        require.resolve('../../../.next/server/pages/getStaticProps/withFallback/[id].js')
+        require.resolve('../../../.next/server/pages/getStaticProps/withFallbackBlocking/[id].js')
+        require.resolve('../../../.next/server/pages/getStaticProps/withRevalidate/[id].js')
+        require.resolve('../../../.next/server/pages/getStaticProps/withRevalidate/withFallback/[id].js')
+        require.resolve('../../../.next/server/pages/getStaticProps/withRevalidate/withFallbackBlocking/[id].js')
+        require.resolve('../../../.next/server/pages/index.js')
+        require.resolve('../../../.next/server/pages/previewTest.js')
+        require.resolve('../../../.next/server/pages/shows/[...params].js')
+        require.resolve('../../../.next/server/pages/shows/[id].js')
+        require.resolve('../../../.next/server/webpack-api-runtime.js')
+        require.resolve('../../../.next/server/webpack-runtime.js')
+        require.resolve('../../../components/Header.js')
+        require.resolve('../../../hello.txt')
+        require.resolve('../../../package.json')
+    } catch {}
+}"
+`;
+
+exports[`onBuild() NEXT_CDN_CACHE_CONTROL not enabled generates a file referencing all when publish dir is a subdirectory 1`] = `
+"// This file is purely to allow nft to know about these pages.
+exports.resolvePages = () => {
+    try {
+        require.resolve('../../../../node_modules/@swc/helpers/_/_interop_require_default/package.json')
+        require.resolve('../../../../node_modules/@swc/helpers/_/_interop_require_wildcard/package.json')
+        require.resolve('../../../../node_modules/@swc/helpers/cjs/_interop_require_default.cjs')
+        require.resolve('../../../../node_modules/@swc/helpers/cjs/_interop_require_wildcard.cjs')
+        require.resolve('../../../../node_modules/@swc/helpers/package.json')
+        require.resolve('../../../../node_modules/next/dist/client/add-base-path.js')
+        require.resolve('../../../../node_modules/next/dist/client/add-locale.js')
+        require.resolve('../../../../node_modules/next/dist/client/detect-domain-locale.js')
+        require.resolve('../../../../node_modules/next/dist/client/has-base-path.js')
+        require.resolve('../../../../node_modules/next/dist/client/head-manager.js')
+        require.resolve('../../../../node_modules/next/dist/client/normalize-trailing-slash.js')
+        require.resolve('../../../../node_modules/next/dist/client/remove-base-path.js')
+        require.resolve('../../../../node_modules/next/dist/client/remove-locale.js')
+        require.resolve('../../../../node_modules/next/dist/client/request-idle-callback.js')
+        require.resolve('../../../../node_modules/next/dist/client/route-loader.js')
+        require.resolve('../../../../node_modules/next/dist/client/router.js')
+        require.resolve('../../../../node_modules/next/dist/client/script.js')
+        require.resolve('../../../../node_modules/next/dist/client/trusted-types.js')
+        require.resolve('../../../../node_modules/next/dist/client/with-router.js')
+        require.resolve('../../../../node_modules/next/dist/compiled/gzip-size/index.js')
+        require.resolve('../../../../node_modules/next/dist/compiled/gzip-size/package.json')
+        require.resolve('../../../../node_modules/next/dist/compiled/path-to-regexp/index.js')
+        require.resolve('../../../../node_modules/next/dist/compiled/react-dom/cjs/react-dom-server-rendering-stub.development.js')
+        require.resolve('../../../../node_modules/next/dist/compiled/react-dom/cjs/react-dom-server-rendering-stub.production.min.js')
+        require.resolve('../../../../node_modules/next/dist/compiled/react-dom/package.json')
+        require.resolve('../../../../node_modules/next/dist/compiled/react-dom/server-rendering-stub.js')
+        require.resolve('../../../../node_modules/next/dist/compiled/react-is/cjs/react-is.development.js')
+        require.resolve('../../../../node_modules/next/dist/compiled/react-is/cjs/react-is.production.min.js')
+        require.resolve('../../../../node_modules/next/dist/compiled/react-is/index.js')
+        require.resolve('../../../../node_modules/next/dist/compiled/react-is/package.json')
+        require.resolve('../../../../node_modules/next/dist/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-client.browser.development.js')
+        require.resolve('../../../../node_modules/next/dist/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-client.browser.production.min.js')
+        require.resolve('../../../../node_modules/next/dist/compiled/react-server-dom-webpack/client.browser.js')
+        require.resolve('../../../../node_modules/next/dist/compiled/react-server-dom-webpack/client.js')
+        require.resolve('../../../../node_modules/next/dist/compiled/react-server-dom-webpack/package.json')
+        require.resolve('../../../../node_modules/next/dist/compiled/react/cjs/react-jsx-runtime.development.js')
+        require.resolve('../../../../node_modules/next/dist/compiled/react/cjs/react-jsx-runtime.production.min.js')
+        require.resolve('../../../../node_modules/next/dist/compiled/react/cjs/react.development.js')
+        require.resolve('../../../../node_modules/next/dist/compiled/react/cjs/react.production.min.js')
+        require.resolve('../../../../node_modules/next/dist/compiled/react/index.js')
+        require.resolve('../../../../node_modules/next/dist/compiled/react/jsx-runtime.js')
+        require.resolve('../../../../node_modules/next/dist/compiled/react/package.json')
+        require.resolve('../../../../node_modules/next/dist/lib/is-api-route.js')
+        require.resolve('../../../../node_modules/next/dist/lib/is-error.js')
+        require.resolve('../../../../node_modules/next/dist/pages/_error.js')
+        require.resolve('../../../../node_modules/next/dist/server/app-render/get-segment-param.js')
+        require.resolve('../../../../node_modules/next/dist/server/future/helpers/interception-routes.js')
+        require.resolve('../../../../node_modules/next/dist/server/get-page-files.js')
+        require.resolve('../../../../node_modules/next/dist/server/htmlescape.js')
+        require.resolve('../../../../node_modules/next/dist/server/utils.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/amp-context.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/amp-mode.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/app-router-context.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/bloom-filter.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/constants.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/escape-regexp.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/head-manager-context.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/head.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/hooks-client-context.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/html-context.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/i18n/detect-domain-locale.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/i18n/normalize-locale-path.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/is-plain-object.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/loadable-context.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/loadable.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/mitt.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/modern-browserslist-target.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/page-path/denormalize-page-path.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/page-path/ensure-leading-slash.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/page-path/normalize-page-path.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/page-path/normalize-path-sep.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router-context.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/router.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/add-locale.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/add-path-prefix.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/add-path-suffix.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/app-paths.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/compare-states.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/format-next-pathname-info.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/format-url.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/get-asset-path-from-route.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/get-next-pathname-info.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/handle-smooth-scroll.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/index.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/interpolate-as.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/is-bot.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/is-dynamic.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/is-local-url.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/omit.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/parse-path.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/parse-relative-url.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/parse-url.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/path-has-prefix.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/path-match.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/prepare-destination.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/querystring.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/remove-path-prefix.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/remove-trailing-slash.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/resolve-href.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/resolve-rewrites.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/route-matcher.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/route-regex.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/sorted-routes.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/server-inserted-html.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/side-effect.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/utils.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/utils/warn-once.js')
+        require.resolve('../../../../node_modules/next/error.js')
+        require.resolve('../../../../node_modules/next/package.json')
+        require.resolve('../../../../node_modules/next/router.js')
+        require.resolve('../../../../node_modules/react-dom/cjs/react-dom.development.js')
+        require.resolve('../../../../node_modules/react-dom/cjs/react-dom.production.min.js')
+        require.resolve('../../../../node_modules/react-dom/index.js')
+        require.resolve('../../../../node_modules/react-dom/node_modules/scheduler/cjs/scheduler.development.js')
+        require.resolve('../../../../node_modules/react-dom/node_modules/scheduler/cjs/scheduler.production.min.js')
+        require.resolve('../../../../node_modules/react-dom/node_modules/scheduler/index.js')
+        require.resolve('../../../../node_modules/react-dom/node_modules/scheduler/package.json')
+        require.resolve('../../../../node_modules/react-dom/package.json')
+        require.resolve('../../../../node_modules/react/cjs/react.development.js')
+        require.resolve('../../../../node_modules/react/cjs/react.production.min.js')
+        require.resolve('../../../../node_modules/react/index.js')
+        require.resolve('../../../../node_modules/react/package.json')
+        require.resolve('../../../../package.json')
+        require.resolve('../../../web/.next/package.json')
+        require.resolve('../../../web/.next/server/app/app-edge/page.js')
+        require.resolve('../../../web/.next/server/app/blog/[author]/[slug]/page.js')
+        require.resolve('../../../web/.next/server/app/blog/[author]/page.js')
+        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../web/.next/server/chunks/header.js')
+        require.resolve('../../../web/.next/server/pages/_app.js')
+        require.resolve('../../../web/.next/server/pages/_document.js')
+        require.resolve('../../../web/.next/server/pages/_error.js')
+        require.resolve('../../../web/.next/server/pages/api/enterPreview.js')
+        require.resolve('../../../web/.next/server/pages/api/exitPreview.js')
+        require.resolve('../../../web/.next/server/pages/api/hello-background.js')
+        require.resolve('../../../web/.next/server/pages/api/hello-scheduled.js')
+        require.resolve('../../../web/.next/server/pages/api/hello.js')
+        require.resolve('../../../web/.next/server/pages/api/og.js')
+        require.resolve('../../../web/.next/server/pages/api/revalidate.js')
+        require.resolve('../../../web/.next/server/pages/api/shows/[...params].js')
+        require.resolve('../../../web/.next/server/pages/api/shows/[id].js')
+        require.resolve('../../../web/.next/server/pages/deep/import.js')
+        require.resolve('../../../web/.next/server/pages/edge/[id].js')
+        require.resolve('../../../web/.next/server/pages/getServerSideProps/[id].js')
+        require.resolve('../../../web/.next/server/pages/getServerSideProps/all/[[...slug]].js')
+        require.resolve('../../../web/.next/server/pages/getServerSideProps/file.js')
+        require.resolve('../../../web/.next/server/pages/getServerSideProps/static.js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/[id].js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/env.js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/static.js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/with-revalidate-404.js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/with-revalidate.js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/withFallback/[...slug].js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/withFallback/[id].js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/withFallbackBlocking/[id].js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/withRevalidate/[id].js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/withRevalidate/withFallback/[id].js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/withRevalidate/withFallbackBlocking/[id].js')
+        require.resolve('../../../web/.next/server/pages/index.js')
+        require.resolve('../../../web/.next/server/pages/previewTest.js')
+        require.resolve('../../../web/.next/server/pages/shows/[...params].js')
+        require.resolve('../../../web/.next/server/pages/shows/[id].js')
+        require.resolve('../../../web/.next/server/webpack-api-runtime.js')
+        require.resolve('../../../web/.next/server/webpack-runtime.js')
+        require.resolve('../../../web/components/Header.js')
+        require.resolve('../../../web/hello.txt')
+        require.resolve('../../../web/package.json')
+    } catch {}
+}"
+`;
+
+exports[`onBuild() NEXT_CDN_CACHE_CONTROL not enabled generates a file referencing all when publish dir is a subdirectory 2`] = `
+"// This file is purely to allow nft to know about these pages.
+exports.resolvePages = () => {
+    try {
+        require.resolve('../../../../node_modules/@swc/helpers/_/_interop_require_default/package.json')
+        require.resolve('../../../../node_modules/@swc/helpers/_/_interop_require_wildcard/package.json')
+        require.resolve('../../../../node_modules/@swc/helpers/cjs/_interop_require_default.cjs')
+        require.resolve('../../../../node_modules/@swc/helpers/cjs/_interop_require_wildcard.cjs')
+        require.resolve('../../../../node_modules/@swc/helpers/package.json')
+        require.resolve('../../../../node_modules/next/dist/client/add-base-path.js')
+        require.resolve('../../../../node_modules/next/dist/client/add-locale.js')
+        require.resolve('../../../../node_modules/next/dist/client/detect-domain-locale.js')
+        require.resolve('../../../../node_modules/next/dist/client/has-base-path.js')
+        require.resolve('../../../../node_modules/next/dist/client/head-manager.js')
+        require.resolve('../../../../node_modules/next/dist/client/normalize-trailing-slash.js')
+        require.resolve('../../../../node_modules/next/dist/client/remove-base-path.js')
+        require.resolve('../../../../node_modules/next/dist/client/remove-locale.js')
+        require.resolve('../../../../node_modules/next/dist/client/request-idle-callback.js')
+        require.resolve('../../../../node_modules/next/dist/client/route-loader.js')
+        require.resolve('../../../../node_modules/next/dist/client/router.js')
+        require.resolve('../../../../node_modules/next/dist/client/script.js')
+        require.resolve('../../../../node_modules/next/dist/client/trusted-types.js')
+        require.resolve('../../../../node_modules/next/dist/client/with-router.js')
+        require.resolve('../../../../node_modules/next/dist/compiled/gzip-size/index.js')
+        require.resolve('../../../../node_modules/next/dist/compiled/gzip-size/package.json')
+        require.resolve('../../../../node_modules/next/dist/compiled/path-to-regexp/index.js')
+        require.resolve('../../../../node_modules/next/dist/compiled/react-dom/cjs/react-dom-server-rendering-stub.development.js')
+        require.resolve('../../../../node_modules/next/dist/compiled/react-dom/cjs/react-dom-server-rendering-stub.production.min.js')
+        require.resolve('../../../../node_modules/next/dist/compiled/react-dom/package.json')
+        require.resolve('../../../../node_modules/next/dist/compiled/react-dom/server-rendering-stub.js')
+        require.resolve('../../../../node_modules/next/dist/compiled/react-is/cjs/react-is.development.js')
+        require.resolve('../../../../node_modules/next/dist/compiled/react-is/cjs/react-is.production.min.js')
+        require.resolve('../../../../node_modules/next/dist/compiled/react-is/index.js')
+        require.resolve('../../../../node_modules/next/dist/compiled/react-is/package.json')
+        require.resolve('../../../../node_modules/next/dist/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-client.browser.development.js')
+        require.resolve('../../../../node_modules/next/dist/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-client.browser.production.min.js')
+        require.resolve('../../../../node_modules/next/dist/compiled/react-server-dom-webpack/client.browser.js')
+        require.resolve('../../../../node_modules/next/dist/compiled/react-server-dom-webpack/client.js')
+        require.resolve('../../../../node_modules/next/dist/compiled/react-server-dom-webpack/package.json')
+        require.resolve('../../../../node_modules/next/dist/compiled/react/cjs/react-jsx-runtime.development.js')
+        require.resolve('../../../../node_modules/next/dist/compiled/react/cjs/react-jsx-runtime.production.min.js')
+        require.resolve('../../../../node_modules/next/dist/compiled/react/cjs/react.development.js')
+        require.resolve('../../../../node_modules/next/dist/compiled/react/cjs/react.production.min.js')
+        require.resolve('../../../../node_modules/next/dist/compiled/react/index.js')
+        require.resolve('../../../../node_modules/next/dist/compiled/react/jsx-runtime.js')
+        require.resolve('../../../../node_modules/next/dist/compiled/react/package.json')
+        require.resolve('../../../../node_modules/next/dist/lib/is-api-route.js')
+        require.resolve('../../../../node_modules/next/dist/lib/is-error.js')
+        require.resolve('../../../../node_modules/next/dist/pages/_error.js')
+        require.resolve('../../../../node_modules/next/dist/server/app-render/get-segment-param.js')
+        require.resolve('../../../../node_modules/next/dist/server/future/helpers/interception-routes.js')
+        require.resolve('../../../../node_modules/next/dist/server/get-page-files.js')
+        require.resolve('../../../../node_modules/next/dist/server/htmlescape.js')
+        require.resolve('../../../../node_modules/next/dist/server/utils.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/amp-context.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/amp-mode.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/app-router-context.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/bloom-filter.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/constants.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/escape-regexp.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/head-manager-context.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/head.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/hooks-client-context.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/html-context.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/i18n/detect-domain-locale.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/i18n/normalize-locale-path.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/is-plain-object.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/loadable-context.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/loadable.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/mitt.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/modern-browserslist-target.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/page-path/denormalize-page-path.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/page-path/ensure-leading-slash.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/page-path/normalize-page-path.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/page-path/normalize-path-sep.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router-context.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/router.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/add-locale.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/add-path-prefix.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/add-path-suffix.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/app-paths.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/compare-states.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/format-next-pathname-info.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/format-url.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/get-asset-path-from-route.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/get-next-pathname-info.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/handle-smooth-scroll.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/index.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/interpolate-as.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/is-bot.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/is-dynamic.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/is-local-url.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/omit.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/parse-path.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/parse-relative-url.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/parse-url.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/path-has-prefix.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/path-match.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/prepare-destination.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/querystring.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/remove-path-prefix.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/remove-trailing-slash.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/resolve-href.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/resolve-rewrites.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/route-matcher.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/route-regex.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/router/utils/sorted-routes.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/server-inserted-html.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/side-effect.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/utils.js')
+        require.resolve('../../../../node_modules/next/dist/shared/lib/utils/warn-once.js')
+        require.resolve('../../../../node_modules/next/error.js')
+        require.resolve('../../../../node_modules/next/package.json')
+        require.resolve('../../../../node_modules/next/router.js')
+        require.resolve('../../../../node_modules/react-dom/cjs/react-dom.development.js')
+        require.resolve('../../../../node_modules/react-dom/cjs/react-dom.production.min.js')
+        require.resolve('../../../../node_modules/react-dom/index.js')
+        require.resolve('../../../../node_modules/react-dom/node_modules/scheduler/cjs/scheduler.development.js')
+        require.resolve('../../../../node_modules/react-dom/node_modules/scheduler/cjs/scheduler.production.min.js')
+        require.resolve('../../../../node_modules/react-dom/node_modules/scheduler/index.js')
+        require.resolve('../../../../node_modules/react-dom/node_modules/scheduler/package.json')
+        require.resolve('../../../../node_modules/react-dom/package.json')
+        require.resolve('../../../../node_modules/react/cjs/react.development.js')
+        require.resolve('../../../../node_modules/react/cjs/react.production.min.js')
+        require.resolve('../../../../node_modules/react/index.js')
+        require.resolve('../../../../node_modules/react/package.json')
+        require.resolve('../../../../package.json')
+        require.resolve('../../../web/.next/package.json')
+        require.resolve('../../../web/.next/server/app/app-edge/page.js')
+        require.resolve('../../../web/.next/server/app/blog/[author]/[slug]/page.js')
+        require.resolve('../../../web/.next/server/app/blog/[author]/page.js')
+        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../web/.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../web/.next/server/chunks/header.js')
+        require.resolve('../../../web/.next/server/pages/_app.js')
+        require.resolve('../../../web/.next/server/pages/_document.js')
+        require.resolve('../../../web/.next/server/pages/_error.js')
+        require.resolve('../../../web/.next/server/pages/api/enterPreview.js')
+        require.resolve('../../../web/.next/server/pages/api/exitPreview.js')
+        require.resolve('../../../web/.next/server/pages/api/hello-background.js')
+        require.resolve('../../../web/.next/server/pages/api/hello-scheduled.js')
+        require.resolve('../../../web/.next/server/pages/api/hello.js')
+        require.resolve('../../../web/.next/server/pages/api/og.js')
+        require.resolve('../../../web/.next/server/pages/api/revalidate.js')
+        require.resolve('../../../web/.next/server/pages/api/shows/[...params].js')
+        require.resolve('../../../web/.next/server/pages/api/shows/[id].js')
+        require.resolve('../../../web/.next/server/pages/deep/import.js')
+        require.resolve('../../../web/.next/server/pages/edge/[id].js')
+        require.resolve('../../../web/.next/server/pages/getServerSideProps/[id].js')
+        require.resolve('../../../web/.next/server/pages/getServerSideProps/all/[[...slug]].js')
+        require.resolve('../../../web/.next/server/pages/getServerSideProps/file.js')
+        require.resolve('../../../web/.next/server/pages/getServerSideProps/static.js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/[id].js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/env.js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/static.js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/with-revalidate-404.js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/with-revalidate.js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/withFallback/[...slug].js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/withFallback/[id].js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/withFallbackBlocking/[id].js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/withRevalidate/[id].js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/withRevalidate/withFallback/[id].js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/withRevalidate/withFallbackBlocking/[id].js')
+        require.resolve('../../../web/.next/server/pages/index.js')
+        require.resolve('../../../web/.next/server/pages/previewTest.js')
+        require.resolve('../../../web/.next/server/pages/shows/[...params].js')
+        require.resolve('../../../web/.next/server/pages/shows/[id].js')
+        require.resolve('../../../web/.next/server/webpack-api-runtime.js')
+        require.resolve('../../../web/.next/server/webpack-runtime.js')
+        require.resolve('../../../web/components/Header.js')
+        require.resolve('../../../web/hello.txt')
+        require.resolve('../../../web/package.json')
+    } catch {}
+}"
+`;
+
+exports[`onBuild() NEXT_CDN_CACHE_CONTROL not enabled when splitting API routes is disabled, it writes correct redirects to netlifyConfig 1`] = `
 Array [
   Object {
     "conditions": Object {
@@ -2892,6 +4420,415 @@ Array [
     "status": 200,
     "to": "/.netlify/functions/___netlify-handler",
   },
+]
+`;
+
+exports[`onBuild() generates a file referencing all API route sources: for _api_hello-background-background 1`] = `
+"// This file is purely to allow nft to know about these pages.
+exports.resolvePages = () => {
+    try {
+        require.resolve('../../../../../node_modules/@swc/helpers/_/_interop_require_default/package.json')
+        require.resolve('../../../../../node_modules/@swc/helpers/_/_interop_require_wildcard/package.json')
+        require.resolve('../../../../../node_modules/@swc/helpers/cjs/_interop_require_default.cjs')
+        require.resolve('../../../../../node_modules/@swc/helpers/cjs/_interop_require_wildcard.cjs')
+        require.resolve('../../../../../node_modules/@swc/helpers/package.json')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react/cjs/react.development.js')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react/cjs/react.production.min.js')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react/index.js')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react/package.json')
+        require.resolve('../../../../../node_modules/next/dist/server/get-page-files.js')
+        require.resolve('../../../../../node_modules/next/dist/server/htmlescape.js')
+        require.resolve('../../../../../node_modules/next/dist/server/utils.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/amp-context.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/amp-mode.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/constants.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/head-manager-context.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/html-context.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/is-plain-object.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/modern-browserslist-target.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/page-path/denormalize-page-path.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/page-path/ensure-leading-slash.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/page-path/normalize-page-path.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/page-path/normalize-path-sep.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/index.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/is-dynamic.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/sorted-routes.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/side-effect.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/utils.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/utils/warn-once.js')
+        require.resolve('../../../../../node_modules/next/package.json')
+        require.resolve('../../../../../node_modules/react/cjs/react.development.js')
+        require.resolve('../../../../../node_modules/react/cjs/react.production.min.js')
+        require.resolve('../../../../../node_modules/react/index.js')
+        require.resolve('../../../../../node_modules/react/package.json')
+        require.resolve('../../../../../package.json')
+        require.resolve('../../../.next/package.json')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/pages/_app.js')
+        require.resolve('../../../.next/server/pages/_document.js')
+        require.resolve('../../../.next/server/pages/_error.js')
+        require.resolve('../../../.next/server/pages/api/hello-background.js')
+        require.resolve('../../../.next/server/webpack-api-runtime.js')
+        require.resolve('../../../.next/server/webpack-runtime.js')
+        require.resolve('../../../package.json')
+    } catch {}
+}"
+`;
+
+exports[`onBuild() generates a file referencing all API route sources: for _api_hello-scheduled-handler 1`] = `
+"// This file is purely to allow nft to know about these pages.
+exports.resolvePages = () => {
+    try {
+        require.resolve('../../../../../node_modules/@swc/helpers/_/_interop_require_default/package.json')
+        require.resolve('../../../../../node_modules/@swc/helpers/_/_interop_require_wildcard/package.json')
+        require.resolve('../../../../../node_modules/@swc/helpers/cjs/_interop_require_default.cjs')
+        require.resolve('../../../../../node_modules/@swc/helpers/cjs/_interop_require_wildcard.cjs')
+        require.resolve('../../../../../node_modules/@swc/helpers/package.json')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react/cjs/react.development.js')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react/cjs/react.production.min.js')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react/index.js')
+        require.resolve('../../../../../node_modules/next/dist/compiled/react/package.json')
+        require.resolve('../../../../../node_modules/next/dist/server/get-page-files.js')
+        require.resolve('../../../../../node_modules/next/dist/server/htmlescape.js')
+        require.resolve('../../../../../node_modules/next/dist/server/utils.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/amp-context.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/amp-mode.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/constants.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/head-manager-context.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/html-context.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/is-plain-object.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/modern-browserslist-target.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/page-path/denormalize-page-path.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/page-path/ensure-leading-slash.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/page-path/normalize-page-path.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/page-path/normalize-path-sep.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/index.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/is-dynamic.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/router/utils/sorted-routes.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/side-effect.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/utils.js')
+        require.resolve('../../../../../node_modules/next/dist/shared/lib/utils/warn-once.js')
+        require.resolve('../../../../../node_modules/next/package.json')
+        require.resolve('../../../../../node_modules/react/cjs/react.development.js')
+        require.resolve('../../../../../node_modules/react/cjs/react.production.min.js')
+        require.resolve('../../../../../node_modules/react/index.js')
+        require.resolve('../../../../../node_modules/react/package.json')
+        require.resolve('../../../../../package.json')
+        require.resolve('../../../.next/package.json')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/chunks/CHUNK_ID.js')
+        require.resolve('../../../.next/server/pages/_app.js')
+        require.resolve('../../../.next/server/pages/_document.js')
+        require.resolve('../../../.next/server/pages/_error.js')
+        require.resolve('../../../.next/server/pages/api/hello-scheduled.js')
+        require.resolve('../../../.next/server/webpack-api-runtime.js')
+        require.resolve('../../../.next/server/webpack-runtime.js')
+        require.resolve('../../../package.json')
+    } catch {}
+}"
+`;
+
+exports[`onBuild() generates static files manifest 1`] = `
+Array [
+  Array [
+    "app/blog/erica/first-post.html",
+    "blog/erica/first-post.html",
+  ],
+  Array [
+    "app/blog/erica/first-post.rsc",
+    "blog/erica/first-post.rsc",
+  ],
+  Array [
+    "app/blog/nick/first-post.html",
+    "blog/nick/first-post.html",
+  ],
+  Array [
+    "app/blog/nick/first-post.rsc",
+    "blog/nick/first-post.rsc",
+  ],
+  Array [
+    "app/blog/nick/second-post.html",
+    "blog/nick/second-post.html",
+  ],
+  Array [
+    "app/blog/nick/second-post.rsc",
+    "blog/nick/second-post.rsc",
+  ],
+  Array [
+    "app/blog/rob/second-post.html",
+    "blog/rob/second-post.html",
+  ],
+  Array [
+    "app/blog/rob/second-post.rsc",
+    "blog/rob/second-post.rsc",
+  ],
+  Array [
+    "app/blog/sarah/second-post.html",
+    "blog/sarah/second-post.html",
+  ],
+  Array [
+    "app/blog/sarah/second-post.rsc",
+    "blog/sarah/second-post.rsc",
+  ],
+  Array [
+    "pages/en/404.html",
+    "en/404.html",
+  ],
+  Array [
+    "pages/en/500.html",
+    "en/500.html",
+  ],
+  Array [
+    "pages/en/broken-image.html",
+    "en/broken-image.html",
+  ],
+  Array [
+    "pages/en/css.html",
+    "en/css.html",
+  ],
+  Array [
+    "pages/en/env.html",
+    "en/env.html",
+  ],
+  Array [
+    "pages/en/font.html",
+    "en/font.html",
+  ],
+  Array [
+    "pages/en/getStaticProps/1.html",
+    "en/getStaticProps/1.html",
+  ],
+  Array [
+    "pages/en/getStaticProps/1.json",
+    "_next/data/build-id/en/getStaticProps/1.json",
+  ],
+  Array [
+    "pages/en/getStaticProps/2.html",
+    "en/getStaticProps/2.html",
+  ],
+  Array [
+    "pages/en/getStaticProps/2.json",
+    "_next/data/build-id/en/getStaticProps/2.json",
+  ],
+  Array [
+    "pages/en/getStaticProps/env.html",
+    "en/getStaticProps/env.html",
+  ],
+  Array [
+    "pages/en/getStaticProps/env.json",
+    "_next/data/build-id/en/getStaticProps/env.json",
+  ],
+  Array [
+    "pages/en/getStaticProps/static.html",
+    "en/getStaticProps/static.html",
+  ],
+  Array [
+    "pages/en/getStaticProps/static.json",
+    "_next/data/build-id/en/getStaticProps/static.json",
+  ],
+  Array [
+    "pages/en/getStaticProps/withFallback/1.html",
+    "en/getStaticProps/withFallback/1.html",
+  ],
+  Array [
+    "pages/en/getStaticProps/withFallback/1.json",
+    "_next/data/build-id/en/getStaticProps/withFallback/1.json",
+  ],
+  Array [
+    "pages/en/getStaticProps/withFallback/2.html",
+    "en/getStaticProps/withFallback/2.html",
+  ],
+  Array [
+    "pages/en/getStaticProps/withFallback/2.json",
+    "_next/data/build-id/en/getStaticProps/withFallback/2.json",
+  ],
+  Array [
+    "pages/en/getStaticProps/withFallback/my/path/1.html",
+    "en/getStaticProps/withFallback/my/path/1.html",
+  ],
+  Array [
+    "pages/en/getStaticProps/withFallback/my/path/1.json",
+    "_next/data/build-id/en/getStaticProps/withFallback/my/path/1.json",
+  ],
+  Array [
+    "pages/en/getStaticProps/withFallback/my/path/2.html",
+    "en/getStaticProps/withFallback/my/path/2.html",
+  ],
+  Array [
+    "pages/en/getStaticProps/withFallback/my/path/2.json",
+    "_next/data/build-id/en/getStaticProps/withFallback/my/path/2.json",
+  ],
+  Array [
+    "pages/en/getStaticProps/withFallbackBlocking/1.html",
+    "en/getStaticProps/withFallbackBlocking/1.html",
+  ],
+  Array [
+    "pages/en/getStaticProps/withFallbackBlocking/1.json",
+    "_next/data/build-id/en/getStaticProps/withFallbackBlocking/1.json",
+  ],
+  Array [
+    "pages/en/getStaticProps/withFallbackBlocking/2.html",
+    "en/getStaticProps/withFallbackBlocking/2.html",
+  ],
+  Array [
+    "pages/en/getStaticProps/withFallbackBlocking/2.json",
+    "_next/data/build-id/en/getStaticProps/withFallbackBlocking/2.json",
+  ],
+  Array [
+    "pages/en/image.html",
+    "en/image.html",
+  ],
+  Array [
+    "pages/en/layouts.html",
+    "en/layouts.html",
+  ],
+  Array [
+    "pages/en/previewTest.html",
+    "en/previewTest.html",
+  ],
+  Array [
+    "pages/en/previewTest.json",
+    "_next/data/build-id/en/previewTest.json",
+  ],
+  Array [
+    "pages/en/script.html",
+    "en/script.html",
+  ],
+  Array [
+    "pages/en/static.html",
+    "en/static.html",
+  ],
+  Array [
+    "pages/es/404.html",
+    "es/404.html",
+  ],
+  Array [
+    "pages/es/500.html",
+    "es/500.html",
+  ],
+  Array [
+    "pages/es/broken-image.html",
+    "es/broken-image.html",
+  ],
+  Array [
+    "pages/es/css.html",
+    "es/css.html",
+  ],
+  Array [
+    "pages/es/env.html",
+    "es/env.html",
+  ],
+  Array [
+    "pages/es/font.html",
+    "es/font.html",
+  ],
+  Array [
+    "pages/es/getStaticProps/env.html",
+    "es/getStaticProps/env.html",
+  ],
+  Array [
+    "pages/es/getStaticProps/env.json",
+    "_next/data/build-id/es/getStaticProps/env.json",
+  ],
+  Array [
+    "pages/es/getStaticProps/static.html",
+    "es/getStaticProps/static.html",
+  ],
+  Array [
+    "pages/es/getStaticProps/static.json",
+    "_next/data/build-id/es/getStaticProps/static.json",
+  ],
+  Array [
+    "pages/es/image.html",
+    "es/image.html",
+  ],
+  Array [
+    "pages/es/layouts.html",
+    "es/layouts.html",
+  ],
+  Array [
+    "pages/es/previewTest.html",
+    "es/previewTest.html",
+  ],
+  Array [
+    "pages/es/previewTest.json",
+    "_next/data/build-id/es/previewTest.json",
+  ],
+  Array [
+    "pages/es/script.html",
+    "es/script.html",
+  ],
+  Array [
+    "pages/es/static.html",
+    "es/static.html",
+  ],
+  Array [
+    "pages/fr/404.html",
+    "fr/404.html",
+  ],
+  Array [
+    "pages/fr/500.html",
+    "fr/500.html",
+  ],
+  Array [
+    "pages/fr/broken-image.html",
+    "fr/broken-image.html",
+  ],
+  Array [
+    "pages/fr/css.html",
+    "fr/css.html",
+  ],
+  Array [
+    "pages/fr/env.html",
+    "fr/env.html",
+  ],
+  Array [
+    "pages/fr/font.html",
+    "fr/font.html",
+  ],
+  Array [
+    "pages/fr/getStaticProps/env.html",
+    "fr/getStaticProps/env.html",
+  ],
+  Array [
+    "pages/fr/getStaticProps/env.json",
+    "_next/data/build-id/fr/getStaticProps/env.json",
+  ],
+  Array [
+    "pages/fr/getStaticProps/static.html",
+    "fr/getStaticProps/static.html",
+  ],
+  Array [
+    "pages/fr/getStaticProps/static.json",
+    "_next/data/build-id/fr/getStaticProps/static.json",
+  ],
+  Array [
+    "pages/fr/image.html",
+    "fr/image.html",
+  ],
+  Array [
+    "pages/fr/layouts.html",
+    "fr/layouts.html",
+  ],
+  Array [
+    "pages/fr/previewTest.html",
+    "fr/previewTest.html",
+  ],
+  Array [
+    "pages/fr/previewTest.json",
+    "_next/data/build-id/fr/previewTest.json",
+  ],
+  Array [
+    "pages/fr/script.html",
+    "fr/script.html",
+  ],
+  Array [
+    "pages/fr/static.html",
+    "fr/static.html",
+  ],
 ]
 `;
 

--- a/test/helpers/edge.spec.ts
+++ b/test/helpers/edge.spec.ts
@@ -46,12 +46,6 @@ describe('generateRscDataEdgeManifest', () => {
         name: 'RSC data routing',
         path: '/',
       },
-      {
-        function: 'rsc-data',
-        generator: '@netlify/next-runtime@1.0.0',
-        name: 'RSC data routing',
-        path: '/index.rsc',
-      },
     ])
   })
 
@@ -98,12 +92,6 @@ describe('generateRscDataEdgeManifest', () => {
         generator: '@netlify/next-runtime@1.0.0',
         name: 'RSC data routing',
         pattern: '^/blog/([^/]+?)(?:/)?$',
-      },
-      {
-        function: 'rsc-data',
-        generator: '@netlify/next-runtime@1.0.0',
-        name: 'RSC data routing',
-        pattern: '^/blog/([^/]+?)\\.rsc$',
       },
     ])
   })

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -900,6 +900,12 @@ describe('onPostBuild', () => {
 
     expect(netlifyConfig.headers).toEqual([
       {
+        for: `*.rsc`,
+        values: {
+          'Content-Type': 'text/x-component',
+        },
+      },
+      {
         for: '/',
         values: {
           'x-custom-header': 'my custom header value',
@@ -999,6 +1005,12 @@ describe('onPostBuild', () => {
         for: '/',
         values: {
           'x-existing-header-in-configuration': 'existing header in configuration value',
+        },
+      },
+      {
+        for: `*.rsc`,
+        values: {
+          'Content-Type': 'text/x-component',
         },
       },
       {
@@ -1106,6 +1118,12 @@ describe('onPostBuild', () => {
         for: '/',
         values: {
           'x-existing-header-in-configuration': 'existing header in configuration value',
+        },
+      },
+      {
+        for: `*.rsc`,
+        values: {
+          'Content-Type': 'text/x-component',
         },
       },
     ])

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -558,10 +558,10 @@ describe('onBuild()', () => {
     expect(existsSync(odbHandlerFile)).toBeTruthy()
 
     expect(readFileSync(handlerFile, 'utf8')).toMatch(
-      `({ conf: config, app: "../../..", pageRoot, NextServer, staticManifest, mode: 'ssr' })`,
+      `({ conf: config, app: "../../..", pageRoot, NextServer, staticManifest, mode: 'ssr', useCDNCacheControl: false })`,
     )
     expect(readFileSync(odbHandlerFile, 'utf8')).toMatch(
-      `({ conf: config, app: "../../..", pageRoot, NextServer, staticManifest, mode: 'odb' })`,
+      `({ conf: config, app: "../../..", pageRoot, NextServer, staticManifest, mode: 'odb', useCDNCacheControl: false })`,
     )
     expect(readFileSync(handlerFile, 'utf8')).toMatch(`require("../../../.next/required-server-files.json")`)
     expect(readFileSync(odbHandlerFile, 'utf8')).toMatch(`require("../../../.next/required-server-files.json")`)


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/netlify/next-runtime/blob/main/CONTRIBUTING.md. -->

## Description

This explores using CDN Cache Control headers in `next-runtime`. Those are alternative to ODBs. This Pull Request contains changes from following PRs:
 - [fix: add text/x-component header to .rsc assets generated at build time, don't use rsc-data edge function when hitting .rsc path directly](https://github.com/netlify/next-runtime/pull/2290)
 - [test: setup cypress test running for variant of default demo with all flags enabled](https://github.com/netlify/next-runtime/pull/2289)

So it might be worth checking only last commit in this PR for just CDN Cache Control related changes

Things that are done here:
 - introduction of feature flag for cdn cache control
 - if that flag is enabled:
    - don't generate ODB handler at all, and all rewrites that previously would point to odb now point to ssr handler as it handle both SSR and ISR pages in this setup
    - setting up `netlify-cdn-cache-control` header to re-use value of `cache-control` header provided by Next.js, setting `x-nf-vary` from `vary` header provided by Next.js (syntax of value of those headers is different, so there is some manipulation of value going on)
    - `rsc-data` middleware is no longer used for RSC request if it is handled by lambda (we still need it for .rsc files that are produced at build time - we would need header conditions for rewrites to be able to get rid of it completely)

Things not yet done:
 - testing behavior related to i18n
 - implementation of on-demand isr revalidation (required APIs are not yet available)

### Documentation

<!-- Where is this feature or API documented? Did you create an internal and/or external artifact to document this change? -->

## Tests

<!-- Did you add tests? How did you test this change? -->

You can test this change yourself like so:

1. TODO

## Relevant links (GitHub issues, etc.) or a picture of cute animal

<!-- Link to an issue that is fixed by this PR or related to this PR. -->
