### PR TITLE
test: setup cypress test running for variant of default demo with all flags enabled

### DIFF
--- a/.github/workflows/cypress-demo-all-flags.yml
+++ b/.github/workflows/cypress-demo-all-flags.yml
@@ -1,0 +1,73 @@
+name: Run e2e (default demo with all feature flags enabled)
+on:
+  pull_request:
+    types: [opened, synchronize]
+  push:
+    branches:
+      - main
+    paths:
+      - 'demos/default/**/*.{js,jsx,ts,tsx}'
+      - 'cypress/e2e/default/**/*.{ts,js}'
+      - 'packages/*/src/**/*.{ts,js}'
+jobs:
+  cypress:
+    name: Cypress
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        containers: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Generate Github token
+        uses: navikt/github-app-token-generator@v1
+        id: get-token
+        with:
+          private-key: ${{ secrets.TOKENS_PRIVATE_KEY }}
+          app-id: ${{ secrets.TOKENS_APP_ID }}
+
+      - name: Checkout @netlify/wait-for-deploy-action
+        uses: actions/checkout@v3
+        with:
+          repository: netlify/wait-for-deploy-action
+          token: ${{ steps.get-token.outputs.token }}
+          path: ./.github/actions/wait-for-netlify-deploy
+
+      - name: Wait for Netlify Deploy
+        id: deploy
+        uses: ./.github/actions/wait-for-netlify-deploy
+        with:
+          site-name: netlify-plugin-nextjs-demo-all-flags
+          timeout: 300
+
+      - name: Deploy successful
+        if: ${{ steps.deploy.outputs.origin-url }}
+        run: echo ${{ steps.deploy.outputs.origin-url }}
+
+      - name: Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+
+      - run: npm install
+
+      - name: Cypress run
+        if: ${{ steps.deploy.outputs.origin-url }}
+        id: cypress
+        uses: cypress-io/github-action@v5
+        with:
+          browser: chrome
+          record: true
+          parallel: true
+          config-file: cypress/config/ci.config.ts
+          group: 'Next Runtime - Demo'
+          spec: cypress/e2e/default/*
+        env:
+          DEBUG: '@cypress/github-action'
+          CYPRESS_baseUrl: ${{ steps.deploy.outputs.origin-url }}
+          CYPRESS_NETLIFY_CONTEXT: ${{ steps.deploy.outputs.context }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CYPRESS_RECORD_KEY: ${{ secrets.DEFAULT_CYPRESS_RECORD_KEY }}
+          CYPRESS_PLUGIN_ALL_FEATURE_FLAGS: 'enabled'

--- a/cypress/utils/flags.ts
+++ b/cypress/utils/flags.ts
@@ -1,0 +1,25 @@
+export const allFlagsEnabled = Cypress.env('PLUGIN_ALL_FEATURE_FLAGS') === `enabled`
+
+/**
+ * @param shouldExecute {boolean} - if truthy, `describe` will be executed, otherwise skipped
+ * @returns {function} - describe or describe.skip
+ * @example
+ * // this will execute the describe block only if CDNCacheControlEnabled variable is falsy
+ * describeConditional(!CDNCacheControlEnabled)('describe block name', () => {
+ * }
+ */
+export const describeConditional = function describeConditional(shouldExecute: boolean) {
+  return shouldExecute ? describe : describe.skip
+}
+
+/**
+ * @param shouldExecute {boolean} - if truthy, `it` will be executed, otherwise skipped
+ * @returns {function} - it or it.skip
+ * @example
+ * // this will execute the test only if CDNCacheControlEnabled variable is falsy
+ * itConditional(!CDNCacheControlEnabled)('test name', () => {
+ * }
+ */
+export const itConditional = function itConditional(shouldExecute: boolean) {
+  return shouldExecute ? it : it.skip
+}


### PR DESCRIPTION
## Description

This is extracted from https://github.com/netlify/next-runtime/pull/2286 to standalone PR to prepare setup in repo to run cypress default demo tests with all upcoming feature flags enabled (as there will be some assertions that need to be conditional or potentially tests / entire describe blocks skipped). As-is it will just do same thing as current default demo and extracting it to separate PR just limits to diff on my PR + make the setup available for blobs store related work (if needed).

New Netlify site was created ( https://app.netlify.com/sites/netlify-plugin-nextjs-demo-all-flags/overview ) that is build from same directory as current default demo site demo. As new feature flags are added - we should be adding those via Environment Variables to new test site in Netlify UI (`netlify.toml` is shared so we can't add them there without making default demo also using all the new feature flags)

### Documentation

<!-- Where is this feature or API documented? Did you create an internal and/or external artifact to document this change? -->

## Tests

<!-- Did you add tests? How did you test this change? -->

You can test this change yourself like so:

1. TODO

## Relevant links (GitHub issues, etc.) or a picture of cute animal

<!-- Link to an issue that is fixed by this PR or related to this PR. -->
