### PR TITLE
fix: add text/x-component header to .rsc assets generated at build time, don't use rsc-data edge function when hitting .rsc path directly

### DIFF
--- a/packages/runtime/src/helpers/config.ts
+++ b/packages/runtime/src/helpers/config.ts
@@ -218,6 +218,19 @@ const buildHeader = (buildHeaderParams: BuildHeaderParams) => {
 const sanitizePath = (path: string) => path.replace(/:[^*/]+\*$/, '*')
 
 /**
+ * Sets Content-type header for static RSC assets (text/x-component), so application/octet-stream is not used when serving them
+ * @param netlifyHeaders - Existing headers that are already configured in the Netlify configuration
+ */
+export const addContentTypeHeaderToStaticRSCAssets = (netlifyHeaders: NetlifyHeaders = []) => {
+  netlifyHeaders.push({
+    for: `*.rsc`,
+    values: {
+      'Content-Type': 'text/x-component',
+    },
+  })
+}
+
+/**
  * Persist Next.js custom headers to the Netlify configuration so the headers work with static files
  * See {@link https://nextjs.org/docs/api-reference/next.config.js/headers} for more information on custom
  * headers in Next.js

--- a/packages/runtime/src/helpers/edge.ts
+++ b/packages/runtime/src/helpers/edge.ts
@@ -290,14 +290,14 @@ export const generateRscDataEdgeManifest = async ({
   const staticAppdirRoutes: Array<string> = []
   for (const [path, route] of Object.entries(prerenderManifest.routes)) {
     if (isAppDirRoute(route.srcRoute, appPathRoutesManifest) && route.dataRoute) {
-      staticAppdirRoutes.push(path, route.dataRoute)
+      staticAppdirRoutes.push(path)
     }
   }
   const dynamicAppDirRoutes: Array<string> = []
 
   for (const [path, route] of Object.entries(prerenderManifest.dynamicRoutes)) {
     if (isAppDirRoute(path, appPathRoutesManifest) && route.dataRouteRegex) {
-      dynamicAppDirRoutes.push(route.routeRegex, route.dataRouteRegex)
+      dynamicAppDirRoutes.push(route.routeRegex)
     }
   }
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -14,6 +14,7 @@ import {
   updateRequiredServerFiles,
   configureHandlerFunctions,
   generateCustomHeaders,
+  addContentTypeHeaderToStaticRSCAssets,
 } from './helpers/config'
 import { onPreDev } from './helpers/dev'
 import { writeEdgeFunctions, loadMiddlewareManifest, cleanupEdgeFunctions } from './helpers/edge'
@@ -250,6 +251,7 @@ const plugin: NetlifyPlugin = {
 
     const { basePath, appDir, experimental } = nextConfig
 
+    addContentTypeHeaderToStaticRSCAssets(headers)
     generateCustomHeaders(nextConfig, headers)
 
     warnForProblematicUserRewrites({ basePath, redirects })

--- a/packages/runtime/src/templates/edge-shared/rsc-data.ts
+++ b/packages/runtime/src/templates/edge-shared/rsc-data.ts
@@ -28,10 +28,9 @@ export declare type PrerenderManifest = {
 
 const noop = () => {}
 
-// Ensure that routes with and without a trailing slash map to different ODB paths
 const rscifyPath = (route: string) => {
   if (route.endsWith('/')) {
-    return route.slice(0, -1) + '.rsc/'
+    return route.slice(0, -1) + '.rsc'
   }
   return route + '.rsc'
 }

--- a/test/helpers/edge.spec.ts
+++ b/test/helpers/edge.spec.ts
@@ -46,12 +46,6 @@ describe('generateRscDataEdgeManifest', () => {
         name: 'RSC data routing',
         path: '/',
       },
-      {
-        function: 'rsc-data',
-        generator: '@netlify/next-runtime@1.0.0',
-        name: 'RSC data routing',
-        path: '/index.rsc',
-      },
     ])
   })
 
@@ -98,12 +92,6 @@ describe('generateRscDataEdgeManifest', () => {
         generator: '@netlify/next-runtime@1.0.0',
         name: 'RSC data routing',
         pattern: '^/blog/([^/]+?)(?:/)?$',
-      },
-      {
-        function: 'rsc-data',
-        generator: '@netlify/next-runtime@1.0.0',
-        name: 'RSC data routing',
-        pattern: '^/blog/([^/]+?)\\.rsc$',
       },
     ])
   })

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -900,6 +900,12 @@ describe('onPostBuild', () => {
 
     expect(netlifyConfig.headers).toEqual([
       {
+        for: `*.rsc`,
+        values: {
+          'Content-Type': 'text/x-component',
+        },
+      },
+      {
         for: '/',
         values: {
           'x-custom-header': 'my custom header value',
@@ -999,6 +1005,12 @@ describe('onPostBuild', () => {
         for: '/',
         values: {
           'x-existing-header-in-configuration': 'existing header in configuration value',
+        },
+      },
+      {
+        for: `*.rsc`,
+        values: {
+          'Content-Type': 'text/x-component',
         },
       },
       {
@@ -1106,6 +1118,12 @@ describe('onPostBuild', () => {
         for: '/',
         values: {
           'x-existing-header-in-configuration': 'existing header in configuration value',
+        },
+      },
+      {
+        for: `*.rsc`,
+        values: {
+          'Content-Type': 'text/x-component',
         },
       },
     ])


### PR DESCRIPTION
## Description

When working on something else I noticed quite the weirdness with how `rsc-data` middleware behaves when it comes to routing:

```
# hitting /blog/erica/first-post
Aug 31, 06:02:32 PM: 01H9659Z info   Is rsc request
Aug 31, 06:02:32 PM: 01H9659Z info   Rewriting to /blog/erica/first-post.rsc
# hitting /blog/erica/first-post/
Aug 31, 06:06:23 PM: 01H965H0 info   Is rsc request
Aug 31, 06:06:23 PM: 01H965H0 info   Rewriting to /blog/erica/first-post.rsc/
# hitting /blog/erica/first-post.rsc
Aug 31, 06:07:18 PM: 01H965JP info   Is rsc request
Aug 31, 06:07:18 PM: 01H965JP info   Rewriting to /blog/erica/first-post.rsc.rsc
```

as `/blog/erica/first-post.rsc` is actually asset produced at build time:
![image](https://github.com/netlify/next-runtime/assets/419821/5b213f02-4101-498b-9dbc-48cc410a8808)
so only the first request from logs above one worked correctly. Second one did seem to work, but instead of using static asset on CDN it wen't to lambda to generate it and third one I don't even remember but it definitely seems wrong.

I'm not exactly sure why we make edge middleware to handle requests for `.rsc` paths - when trying that path we should just use path as-is - it will either use static asset from CDN or go to lambda to generate it (and possibly cache with with ODB). I did remove that from this PR as it didn't make sense to me, especially as it was redirecting to `/blog/erica/first-post.rsc.rsc` which seems all kind of wrong thing to do.

The statically produced .rsc files also didn't get expected `text/x-component` header (we only get this header right now when request is handled by lambda), so I also added header rule to ensure those get expected headers.

And finally I'm not sure why the rsc-data would want to rewrite to paths that end with trailing slash (`.rsc/`) - the comment say to differentiate those for ODB, but with no clarity why you want to do that? It also meant that if user hit path with trailing slash it would never use static assets on CDN and would always need to go through lambda

### Documentation

<!-- Where is this feature or API documented? Did you create an internal and/or external artifact to document this change? -->

## Tests

<!-- Did you add tests? How did you test this change? -->

You can test this change yourself like so:

1. TODO

## Relevant links (GitHub issues, etc.) or a picture of cute animal

<!-- Link to an issue that is fixed by this PR or related to this PR. -->
