### PR TITLE
fix: copy `vendor` over for local dev

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -55,7 +55,7 @@
     "publish:test": "cd .. && npm ci && npm test",
     "clean": "rimraf lib dist-types",
     "build": "run-s build:*",
-    "build:vendor": "rimraf src/templates/vendor && deno vendor src/templates/vendor.ts --output=src/templates/vendor && patch src/templates/vendor/deno.land/x/html_rewriter@v0.1.0-pre.17/index.ts html_rewriter.patch",
+    "build:vendor": "rimraf src/templates/vendor && deno vendor src/templates/vendor.ts --output=src/templates/vendor && node patch-import-map.mjs && patch src/templates/vendor/deno.land/x/html_rewriter@v0.1.0-pre.17/index.ts html_rewriter.patch",
     "build:tsc": "tsc",
     "watch": "tsc --watch",
     "prepare": "npm run build"

--- a/packages/runtime/patch-import-map.mjs
+++ b/packages/runtime/patch-import-map.mjs
@@ -1,0 +1,13 @@
+import { readFile, writeFile } from "fs/promises"
+
+const importMapPath = new URL("src/templates/vendor/import_map.json", import.meta.url)
+const importMap = JSON.parse(await readFile(importMapPath, "utf8"))
+
+const newMap = {
+  scopes: {
+    "../": importMap.imports,
+    ...importMap.scopes
+  }
+}
+
+await writeFile(importMapPath, JSON.stringify(newMap, null, 2))

--- a/packages/runtime/src/helpers/edge.ts
+++ b/packages/runtime/src/helpers/edge.ts
@@ -260,10 +260,12 @@ export const writeDevEdgeFunction = async ({
       },
     ],
     version: 1,
+    import_map: 'vendor/import_map.json',
   }
   const edgeFunctionRoot = resolve(INTERNAL_EDGE_FUNCTIONS_SRC)
   await emptyDir(edgeFunctionRoot)
   await writeJson(join(edgeFunctionRoot, 'manifest.json'), manifest)
+  await copy(getEdgeTemplatePath('../vendor'), join(edgeFunctionRoot, 'vendor'))
   await copy(getEdgeTemplatePath('../edge-shared'), join(edgeFunctionRoot, 'edge-shared'))
 
   const edgeFunctionDir = join(edgeFunctionRoot, 'next-dev')


### PR DESCRIPTION
Closes https://linear.app/netlify/issue/FRA-53/netlify-dev-fails-to-run-middleware.

In https://github.com/netlify/next-runtime/pull/2302, we started vendoring Deno dependencies, but we forgot about copying them over for local dev. This PR fixes that.

The main change is a one-liner, but there was a problem within the way `esm.sh` bundles these two dependencies, and the way we import them via `../vendor`:

https://github.com/netlify/next-runtime/blob/5d71bfbba214e88cf59ed335a786806c947a2109/packages/runtime/src/templates/edge/next-dev.js#L1-L2

This was fixed by registering the `import_map.json` created by Deno for local dev.  There was a bug in how that works though, that was only fixed in a [recent release](https://github.com/netlify/cli/releases/tag/v16.8.0) of the CLI. This means customers will need to update to that to get local dev working properly.

I've tested this locally with `demos/middleware`, and it's working well!