### PR TITLE
feat: add waf bypass header to CDN download function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "eslint-plugin-promise": "^6.0.0",
         "eslint-plugin-unicorn": "^43.0.2",
         "execa": "^5.1.1",
+        "follow-redirects": "^1.15.3",
         "fs-extra": "^11.1.1",
         "husky": "^7.0.4",
         "jest": "^27.0.0",
@@ -15984,9 +15985,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
+      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
       "funding": [
         {
           "type": "individual",
@@ -27666,7 +27667,7 @@
     },
     "packages/runtime": {
       "name": "@netlify/plugin-nextjs",
-      "version": "4.41.2",
+      "version": "4.41.3",
       "license": "MIT",
       "dependencies": {
         "@netlify/blobs": "^2.2.0",
@@ -39047,9 +39048,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
+      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q=="
     },
     "for-each": {
       "version": "0.3.3",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "eslint-plugin-promise": "^6.0.0",
     "eslint-plugin-unicorn": "^43.0.2",
     "execa": "^5.1.1",
+    "follow-redirects": "^1.15.3",
     "fs-extra": "^11.1.1",
     "husky": "^7.0.4",
     "jest": "^27.0.0",

--- a/packages/runtime/src/templates/getHandler.ts
+++ b/packages/runtime/src/templates/getHandler.ts
@@ -84,10 +84,10 @@ const makeHandler = ({
   for (const [key, value] of Object.entries(conf.env)) {
     process.env[key] = String(value)
   }
-  // Set during the request as it needs to get it from the request URL. Defaults to the URL env var
-  let base = process.env.URL
+  // Partial event object for context in FS augmentation; set during the request
+  let fsEvent = { rawUrl: process.env.URL, headers: {} }
 
-  augmentFsModule({ promises, staticManifest, blobsManifest, pageRoot, getBase: () => base })
+  augmentFsModule({ promises, staticManifest, blobsManifest, pageRoot, getEvent: () => fsEvent })
 
   // We memoize this because it can be shared between requests, but don't instantiate it until
   // the first request because we need the host and port.
@@ -102,7 +102,7 @@ const makeHandler = ({
     }
     const url = new URL(event.rawUrl)
     const port = Number.parseInt(url.port) || 80
-    base = url.origin
+    fsEvent = { rawUrl: event.rawUrl, headers: event.headers }
 
     const nextServer = new NetlifyNextServer(
       {

--- a/packages/runtime/src/templates/handlerUtils.ts
+++ b/packages/runtime/src/templates/handlerUtils.ts
@@ -32,9 +32,11 @@ export const downloadFileFromCDN = async (
   const options = {
     timeout: 10000,
     maxRedirects: 1,
-    headers: {
-      'X-Nf-Waf-Bypass-Token': event.headers['x-nf-waf-bypass-token'],
-    },
+    headers: {},
+  }
+
+  if (event.headers['x-nf-waf-bypass-token']) {
+    options.headers['x-nf-waf-bypass-token'] = event.headers['x-nf-waf-bypass-token']
   }
 
   await new Promise((resolve, reject) => {


### PR DESCRIPTION
## Description

Pass through the WAF Bypass Token header from the initial request to the fetch call that downloads files from the CDN when not present in the lambda (e.g. static files such as 500.html files).

## Tests

There is currently no easy way to add a test with the current scaffolding. Given the current priorities, I'd be happy to push this through with manual testing for now.

## Relevant links (GitHub issues, etc.) or a picture of cute animal

Main PR to implement the WAF bypass: https://github.com/netlify/pod-adn/issues/82
Prior art: https://github.com/netlify/netlify-ipx/blob/main/src/index.ts#L106-L111
