### PR TITLE
Fix copying edge image config

### DIFF
--- a/packages/runtime/src/helpers/edge.ts
+++ b/packages/runtime/src/helpers/edge.ts
@@ -493,8 +493,9 @@ export const writeEdgeFunctions = async ({
     const edgeFunctionDir = join(edgeFunctionRoot, 'ipx')
     await ensureDir(edgeFunctionDir)
     await copyEdgeSourceFile({ edgeFunctionDir, file: 'ipx.ts', target: 'index.ts' })
+    const internalFunctionRoot = resolve(PACKAGE_PATH, '.netlify', 'functions-internal')
     await copyFile(
-      join('.netlify', 'functions-internal', IMAGE_FUNCTION_NAME, 'imageconfig.json'),
+      join(internalFunctionRoot, IMAGE_FUNCTION_NAME, 'imageconfig.json'),
       join(edgeFunctionDir, 'imageconfig.json'),
     )
 


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/netlify/next-runtime/blob/main/CONTRIBUTING.md. -->

## Description

The edge image config copy command did not take into consideration of the package path. This PR fixes that.

### Documentation

<!-- Where is this feature or API documented? Did you create an internal and/or external artifact to document this change? -->

## Tests

I have tested this in our project and it solved the build failure issue mentioned in the linked bug report.


## Relevant links (GitHub issues, etc.) or a picture of cute animal

<!-- Link to an issue that is fixed by this PR or related to this PR. -->
Fixes https://github.com/netlify/next-runtime/issues/2418
