### PR TITLE
docs: mention next.js build in e2e testing instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,9 +117,10 @@ following:
 
 ### Next.js tests
 
-There is a script `run-local-test.sh` and GitHub workflow that runs the e2e tests from the Next.js
-repo against this repo. It requires that `next.js` is checked out in the same parent directory as
-this repo, and is run from this repo with `./run-local-test.sh your-test-pattern-here`.
+There is a GitHub workflow that runs the e2e tests from the Next.js repo against this repo. There is
+also a script to run these tests locally that is run from this repo with
+`./run-local-test.sh your-test-pattern-here`. It requires that `next.js` is checked out in the same
+parent directory as this repo and built with `pnpm run build`.
 
 #### cleanup old deploys
 


### PR DESCRIPTION
## Description

Mention the need for locally building Next.js before running the next.js repo e2e tests locally.

### Documentation

N/A - this is documentation

## Tests

N/A

## Relevant links (GitHub issues, etc.) or a picture of cute animal

<!-- Link to an issue that is fixed by this PR or related to this PR. -->