### PR TITLE
fix: track revalidate / cdn purge to ensure it finishes execution and is not suspended mid-execution

### DIFF
--- a/src/run/handlers/cache.cts
+++ b/src/run/handlers/cache.cts
@@ -244,12 +244,14 @@ export class NetlifyCacheHandler implements CacheHandler {
         if (requestContext?.didPagesRouterOnDemandRevalidate) {
           const tag = `_N_T_${key === '/index' ? '/' : key}`
           getLogger().debug(`Purging CDN cache for: [${tag}]`)
-          purgeCache({ tags: [tag] }).catch((error) => {
-            // TODO: add reporting here
-            getLogger()
-              .withError(error)
-              .error(`[NetlifyCacheHandler]: Purging the cache for tag ${tag} failed`)
-          })
+          requestContext.trackBackgroundWork(
+            purgeCache({ tags: [tag] }).catch((error) => {
+              // TODO: add reporting here
+              getLogger()
+                .withError(error)
+                .error(`[NetlifyCacheHandler]: Purging the cache for tag ${tag} failed`)
+            }),
+          )
         }
       }
     })
@@ -257,6 +259,18 @@ export class NetlifyCacheHandler implements CacheHandler {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async revalidateTag(tagOrTags: string | string[], ...args: any) {
+    const revalidateTagPromise = this.doRevalidateTag(tagOrTags, ...args)
+
+    const requestContext = getRequestContext()
+    if (requestContext) {
+      requestContext.trackBackgroundWork(revalidateTagPromise)
+    }
+
+    return revalidateTagPromise
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private async doRevalidateTag(tagOrTags: string | string[], ...args: any) {
     getLogger().withFields({ tagOrTags, args }).debug('NetlifyCacheHandler.revalidateTag')
 
     const tags = Array.isArray(tagOrTags) ? tagOrTags : [tagOrTags]
@@ -275,7 +289,7 @@ export class NetlifyCacheHandler implements CacheHandler {
       }),
     )
 
-    purgeCache({ tags }).catch((error) => {
+    await purgeCache({ tags }).catch((error) => {
       // TODO: add reporting here
       getLogger()
         .withError(error)

--- a/tests/fixtures/page-router/pages/api/revalidate.js
+++ b/tests/fixtures/page-router/pages/api/revalidate.js
@@ -1,6 +1,9 @@
 export default async function handler(req, res) {
   try {
-    await res.revalidate('/static/revalidate-manual')
+    // res.revalidate returns a promise that can be awaited to wait for the revalidation to complete
+    // if user doesn't await it, we still want to ensure the revalidation is completed, so we internally track
+    // this as "background work" to ensure it completes before function suspends execution
+    res.revalidate('/static/revalidate-manual')
     return res.json({ code: 200, message: 'success' })
   } catch (err) {
     return res.status(500).send({ code: 500, message: err.message })


### PR DESCRIPTION
## Description

With the changes some time ago to streaming functions to not await untracked background work we might have not handled all cases of background work we should be tracking. We do track background regeneration (~SWR), but on-demand revalidation code paths were not tracked possibly resulting in flaky on-demand revalidate behaviors

### Documentation

<!-- Where is this feature or API documented? Did you create an internal and/or external artifact to document this change? -->

## Tests

Not clear how to exactly test this without adding some TEST specific timeous to runtime, if anyone has ideas on what kind of tests could assert that we indeed are awaiting/tracking relevant on-demand revalidation work, happy to add or modify tests.

We do have tests for on-demand revalidation which are a bit flaky. Maybe this will un-flake them (or at least decrease flakiness)?

## Relevant links (GitHub issues, etc.) or a picture of cute animal

- https://linear.app/netlify/issue/FRA-566/nextjs-routes-revalidating-when-not-required#comment-1bf42469 (+ my next comment)
   // notes:
   my hunch in here it looks like Next cache is being correctly invalidated, but then CDN purge is not going through resulting in CDN nodes still serving whatever it had cached prior to purge - optionally CDN nodes that didn't have response cached would serve fresh leading to undeterministic response (depending on CDN node that handled request)
   
 - https://linear.app/netlify/issue/FRA-568/help-understanding-cache-tag-usage#comment-169cc400
   // notes:
   App Router `revalidateTag` (or `revalidatePath` for that matter) don't return promises that user can await on, so execution can be suspended without going through <- I'm not exactly the most confident that changes here will fully resolve what this comment talks about, but from my own testing those changes seem required



 
