### PR TITLE
chore: output playwright report in readable form in github actions output

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -254,6 +254,7 @@ jobs:
       run: |
         npx playwright merge-reports --reporter html ./all-blob-reports
         npx playwright merge-reports --reporter json ./all-blob-reports > merged_reports.json
+        npx playwright merge-reports --reporter list ./all-blob-reports
 
     # FIXME(serhalp) Once we recover access to the SquidlifyBot Slack App, reenable this.
     # - name: Notify Slack


### PR DESCRIPTION
## Description

This is optimistic addition so we can have easy way to lookup complete report with status of tests on github action run page without having to download html or json artifacts or going through each shard results

### Documentation

<!-- Where is this feature or API documented? Did you create an internal and/or external artifact to document this change? -->

## Tests

<!-- Did you add tests? How did you test this change? -->

You can test this change yourself like so:

1. TODO

## Relevant links (GitHub issues, etc.) or a picture of cute animal

<!-- Link to an issue that is fixed by this PR or related to this PR. -->
