### PR TITLE
chore(e2e): fix links to test source in new e2e report

### DIFF
--- a/e2e-report/components/table.js
+++ b/e2e-report/components/table.js
@@ -34,7 +34,7 @@ function TestSuiteRow({ suite, idx }) {
     <>
       <tr key={'tr-' + idx} className="text-sm md:text-base">
         <td className="p-2 md:p-4">
-          <Link href={suite.file} className="text-sm md:text-base">
+          <Link href={suite.sourceUrl} className="text-sm md:text-base">
             {suite.name}
           </Link>
         </td>

--- a/e2e-report/utils/data.js
+++ b/e2e-report/utils/data.js
@@ -12,6 +12,7 @@ nonEmptySuites.forEach((suite) => {
 
   suite.failedKnown = actualFailed.filter((t) => !!t.reason).length || 0
   suite.failedUnknown = suite.failed - suite.failedKnown
+  suite.sourceUrl = `https://github.com/vercel/next.js/blob/${fileData.nextVersion}/${suite.file}`
 })
 
 const suitesWithFailures = nonEmptySuites.filter((suite) => suite.failed > 0)


### PR DESCRIPTION
## Description

In https://github.com/netlify/next-runtime/pull/2489 we rewrote the e2e report. This introduced a bug where test suite links lead to a 404.

### Documentation

N/A

## Tests

1. Click on a test suite name [here](https://66799b75b078eb00a9e251cc--runtime-e2e-report.netlify.app/) and get a 404.
2. Click on a test suite name [here](https://6679a428bad5990bfcd13197--runtime-e2e-report.netlify.app/) and see the test suite source. (This one is from this branch.)

## Relevant links (GitHub issues, etc.) or a picture of cute animal

N/A