### PR TITLE
feat: use Netlify Durable Cache

### DIFF
--- a/src/run/handlers/server.ts
+++ b/src/run/handlers/server.ts
@@ -112,7 +112,9 @@ export default async (request: Request, context: FutureContext) => {
 
     await adjustDateHeader({ headers: response.headers, request, span, tracer, requestContext })
 
-    setCacheControlHeaders(response.headers, request, requestContext)
+    const useDurableCache =
+      context.flags.get('serverless_functions_nextjs_durable_cache_disable') !== true
+    setCacheControlHeaders(response.headers, request, requestContext, useDurableCache)
     setCacheTagsHeaders(response.headers, requestContext)
     setVaryHeaders(response.headers, request, nextConfig)
     setCacheStatusHeader(response.headers)

--- a/tests/e2e/durable-cache.test.ts
+++ b/tests/e2e/durable-cache.test.ts
@@ -1,0 +1,19 @@
+import { expect } from '@playwright/test'
+import { test } from '../utils/playwright-helpers.js'
+
+// This fixture is deployed to a separate site with the feature flag enabled
+test('sets cache-control `durable` directive when feature flag is enabled', async ({
+  page,
+  durableCache,
+}) => {
+  const response = await page.goto(durableCache.url)
+  const headers = response?.headers() || {}
+
+  const h1 = page.locator('h1')
+  await expect(h1).toHaveText('Home')
+
+  expect(headers['netlify-cdn-cache-control']).toBe(
+    's-maxage=31536000, stale-while-revalidate=31536000, durable',
+  )
+  expect(headers['cache-control']).toBe('public,max-age=0,must-revalidate')
+})

--- a/tests/integration/run/server-handler.test.ts
+++ b/tests/integration/run/server-handler.test.ts
@@ -1,0 +1,56 @@
+import { getLogger } from 'lambda-local'
+import { v4 } from 'uuid'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { type FixtureTestContext } from '../../utils/contexts.js'
+import { createFixture, invokeFunction, runPlugin } from '../../utils/fixture.js'
+import { generateRandomObjectID, startMockBlobStore } from '../../utils/helpers.js'
+
+// Disable the verbose logging of the lambda-local runtime
+getLogger().level = 'alert'
+
+beforeEach<FixtureTestContext>(async (ctx) => {
+  // set for each test a new deployID and siteID
+  ctx.deployID = generateRandomObjectID()
+  ctx.siteID = v4()
+  vi.stubEnv('SITE_ID', ctx.siteID)
+  vi.stubEnv('DEPLOY_ID', ctx.deployID)
+  // hide debug logs in tests
+  vi.spyOn(console, 'debug').mockImplementation(() => {})
+
+  await startMockBlobStore(ctx)
+})
+
+describe('`serverless_functions_nextjs_durable_cache_disable` feature flag', () => {
+  test<FixtureTestContext>('uses durable cache when flag is nil', async (ctx) => {
+    await createFixture('simple', ctx)
+    await runPlugin(ctx)
+
+    const { headers } = await invokeFunction(ctx, {
+      flags: { serverless_functions_nextjs_durable_cache_disable: undefined },
+    })
+
+    expect(headers['netlify-cdn-cache-control']).toContain('durable')
+  })
+
+  test<FixtureTestContext>('uses durable cache when flag is `false`', async (ctx) => {
+    await createFixture('simple', ctx)
+    await runPlugin(ctx)
+
+    const { headers } = await invokeFunction(ctx, {
+      flags: { serverless_functions_nextjs_durable_cache_disable: false },
+    })
+
+    expect(headers['netlify-cdn-cache-control']).toContain('durable')
+  })
+
+  test<FixtureTestContext>('does not use durable cache when flag is `true`', async (ctx) => {
+    await createFixture('simple', ctx)
+    await runPlugin(ctx)
+
+    const { headers } = await invokeFunction(ctx, {
+      flags: { serverless_functions_nextjs_durable_cache_disable: true },
+    })
+
+    expect(headers['netlify-cdn-cache-control']).not.toContain('durable')
+  })
+})

--- a/tests/utils/create-e2e-fixture.ts
+++ b/tests/utils/create-e2e-fixture.ts
@@ -428,4 +428,10 @@ export const fixtureFactories = {
       publishDirectory: 'apps/site/.next',
       smoke: true,
     }),
+  durableCache: () =>
+    createE2EFixture('simple', {
+      // https://app.netlify.com/sites/next-runtime-testing-durable-cache
+      // This site has all the Durable Cache feature flags enabled.
+      siteId: 'a8ceaa01-86fd-4c9a-8563-3769560d452a',
+    }),
 }

--- a/tests/utils/create-e2e-fixture.ts
+++ b/tests/utils/create-e2e-fixture.ts
@@ -11,8 +11,9 @@ import { cpus } from 'os'
 import pLimit from 'p-limit'
 import { setNextVersionInFixture } from './next-version-helpers.mjs'
 
-// This is the netlify testing application
-export const SITE_ID = process.env.NETLIFY_SITE_ID ?? 'ee859ce9-44a7-46be-830b-ead85e445e53'
+// https://app.netlify.com/sites/next-runtime-testing
+const DEFAULT_SITE_ID = 'ee859ce9-44a7-46be-830b-ead85e445e53'
+export const SITE_ID = process.env.NETLIFY_SITE_ID ?? DEFAULT_SITE_ID
 const NEXT_VERSION = process.env.NEXT_VERSION || 'latest'
 
 export interface DeployResult {
@@ -39,6 +40,10 @@ interface E2EConfig {
    * Some fixtures might pin to non-latest CLI versions. This is used to verify the used CLI version matches expected one
    */
   expectedCliVersion?: string
+  /**
+   * Site ID to deploy to. Defaults to the `NETLIFY_SITE_ID` environment variable or a default site.
+   */
+  siteId?: string
 }
 
 /**
@@ -258,12 +263,12 @@ async function verifyFixture(isolatedFixtureRoot: string, { expectedCliVersion }
 
 async function deploySite(
   isolatedFixtureRoot: string,
-  { packagePath, cwd = '' }: E2EConfig,
+  { packagePath, cwd = '', siteId = SITE_ID }: E2EConfig,
 ): Promise<DeployResult> {
   console.log(`🚀 Building and deploying site...`)
 
   const outputFile = 'deploy-output.txt'
-  let cmd = `npx ntl deploy --build --site ${SITE_ID}`
+  let cmd = `npx ntl deploy --build --site ${siteId}`
 
   if (packagePath) {
     cmd += ` --filter ${packagePath}`
@@ -273,7 +278,7 @@ async function deploySite(
   await execaCommand(cmd, { cwd: siteDir, all: true }).pipeAll?.(join(siteDir, outputFile))
   const output = await readFile(join(siteDir, outputFile), 'utf-8')
 
-  const [url] = new RegExp(/https:.+runtime-testing\.netlify\.app/gm).exec(output) || []
+  const [url] = new RegExp(/https:.+\.netlify\.app/gm).exec(output) || []
   if (!url) {
     throw new Error('Could not extract the URL from the build logs')
   }

--- a/tests/utils/fixture.ts
+++ b/tests/utils/fixture.ts
@@ -322,6 +322,9 @@ export async function uploadBlobs(ctx: FixtureTestContext, blobsDir: string) {
   )
 }
 
+const DEFAULT_FLAGS = {
+  serverless_functions_nextjs_durable_cache_disable: true,
+}
 /**
  * Execute the function with the provided parameters
  * @param ctx
@@ -346,9 +349,11 @@ export async function invokeFunction(
     body?: unknown
     /** Environment variables that should be set during the invocation */
     env?: Record<string, string | number>
+    /** Feature flags that should be set during the invocation */
+    flags?: Record<string, unknown>
   } = {},
 ) {
-  const { httpMethod, headers, body, url, env } = options
+  const { httpMethod, headers, flags, url, env } = options
   // now for the execution set the process working directory to the dist entry point
   const cwdMock = vi
     .spyOn(process, 'cwd')
@@ -381,6 +386,7 @@ export async function invokeFunction(
         headers: headers || {},
         httpMethod: httpMethod || 'GET',
         rawUrl: new URL(url || '/', 'https://example.netlify').href,
+        flags: flags ?? DEFAULT_FLAGS,
       },
       lambdaFunc: { handler },
       timeoutMs: 4_000,


### PR DESCRIPTION
## Description

👁️‍🗨️  **This will be easier to review commit by commit:**

- 287177af194b16003af43df9b309c19d0ea13d76 test: add missing unit test coverage for route handler headers
- a8d8fcaf4bae0b896b0f4e595e95e17b8e897e4c feat: specify `durable` cache-control directive if feature flag is enabled for request
- 4bd24ffe7e2152e29ae7887e21e9385e39ac6c69 feat: specify durable cache-control directive

This is gated behind a feature flag for now.

I can't link to any public docs yet, but by the time you're reading this you should be able to find a section on "Durable caching" at https://docs.netlify.com.

### Documentation

This functionality is now documented at https://docs.netlify.com/platform/caching/#durable-directive.

## Tests

This PR adds exhaustive unit tests and an e2e integration test deployed to a site with the feature flags enabled. I opted not to test through to the platform behavior here since there's no real way to guarantee you're actually hitting separate CDN nodes on subsequent requests and I'd rather not write tests that don't provide confidence in the behavior under test.

You can also manually deploy to that site and manually verify the expected behavior, which I've done.

You can also use this demo site I created: https://github.com/serhalp/next.js-netlify-durable-cache-demo.

## Relevant links (GitHub issues, etc.) or a picture of cute animal

FRP-749

Supersedes https://github.com/netlify/next-runtime/pull/2502.