### PR TITLE
ci(e2e): run e2e report cron after e2e tests finish

### DIFF
--- a/.github/workflows/e2e-report.yml
+++ b/.github/workflows/e2e-report.yml
@@ -1,7 +1,7 @@
 name: 'Deploy e2e test page'
 on:
   schedule:
-    - cron: '0 3 * * 3' # Run every Wednesday at 3am UTC
+    - cron: '0 6 * * 3' # Run every Wednesday at 6am UTC
   workflow_dispatch:
     inputs:
       use-branch:
@@ -22,9 +22,9 @@ jobs:
         id: get-run-id
         run: |
           if [ "${{ inputs.use-branch }}" == "true" ]; then
-            E2E_RUN_ID=$(gh run list -w test-e2e.yml -e workflow_dispatch -b $GITHUB_REF_NAME --json databaseId --jq ".[0].databaseId" --repo $GITHUB_REPOSITORY)
+            E2E_RUN_ID=$(gh run list -w test-e2e.yml -e workflow_dispatch -s success -b $GITHUB_REF_NAME --json databaseId --jq ".[0].databaseId" --repo $GITHUB_REPOSITORY)
           else
-            E2E_RUN_ID=$(gh run list -w test-e2e.yml -e schedule --json databaseId --jq ".[0].databaseId" --repo $GITHUB_REPOSITORY)
+            E2E_RUN_ID=$(gh run list -w test-e2e.yml -e schedule -s success --json databaseId --jq ".[0].databaseId" --repo $GITHUB_REPOSITORY)
           fi
           echo "runId=$E2E_RUN_ID" >> $GITHUB_OUTPUT
       - name: Download latest e2e results


### PR DESCRIPTION
## Description

We run the next.js repo e2e tests every day at 3am UTC but we were running the e2e report (which pulls the artefacts from the e2e workflow) every Wednesday at 3am UTC. We might as well defer it slightly and pull the data from the freshest run.

In addition, since we weren't filtering on run status, it was almost always failing since the e2e report workflow queried for the most recent e2e test workflow run and, if it had already started, would fail to find its artefacts (because it had started but not completed). Here's an [example failed run](https://github.com/netlify/next-runtime/actions/runs/9672892979/job/26685969360). I fixed this by adding the missing status filter.

### Documentation

N/A

## Tests

I tested the `gh` commands locally.

## Relevant links (GitHub issues, etc.) or a picture of cute animal

