### PR TITLE
chore: update e2e `cache-status` assertion

### DIFF
--- a/tests/e2e/simple-app.test.ts
+++ b/tests/e2e/simple-app.test.ts
@@ -12,7 +12,9 @@ test('Renders the Home page correctly', async ({ page, simple }) => {
 
   await expect(page).toHaveTitle('Simple Next App')
 
-  expect(headers['cache-status']).toBe('"Next.js"; hit\n"Netlify Edge"; fwd=miss')
+  expect(headers['cache-status']).toBe(
+    '"Next.js"; hit\n"Netlify Durable"; fwd=miss\n"Netlify Edge"; fwd=miss',
+  )
 
   const h1 = page.locator('h1')
   await expect(h1).toHaveText('Home')


### PR DESCRIPTION
## Description

The recent Durable Cache rollout on the platform changed the contents of this header. This test is failing on `main` ([example failure](https://github.com/netlify/next-runtime/actions/runs/9782209033/job/27008026247?pr=2526)).

### Documentation

N/A

## Tests

N/A - test fix

## Relevant links (GitHub issues, etc.) or a picture of cute animal

![image](https://github.com/netlify/next-runtime/assets/1377702/76a804c2-a361-451f-a47a-a18c3c6d1e1a)