### PR TITLE
fix: only clear stale functions with build through CLI

### DIFF
--- a/src/build/functions/edge.ts
+++ b/src/build/functions/edge.ts
@@ -162,9 +162,11 @@ const buildHandlerDefinition = (
   }))
 }
 
-export const createEdgeHandlers = async (ctx: PluginContext) => {
+export const clearStaleEdgeHandlers = async (ctx: PluginContext) => {
   await rm(ctx.edgeFunctionsDir, { recursive: true, force: true })
+}
 
+export const createEdgeHandlers = async (ctx: PluginContext) => {
   const nextManifest = await ctx.getMiddlewareManifest()
   const nextDefinitions = [
     ...Object.values(nextManifest.middleware),

--- a/src/build/functions/server.ts
+++ b/src/build/functions/server.ts
@@ -127,12 +127,15 @@ const writeHandlerFile = async (ctx: PluginContext) => {
   await writeFile(join(ctx.serverHandlerRootDir, `${SERVER_HANDLER_NAME}.mjs`), handler)
 }
 
+export const clearStaleServerHandlers = async (ctx: PluginContext) => {
+  await rm(ctx.serverFunctionsDir, { recursive: true, force: true })
+}
+
 /**
  * Create a Netlify function to run the Next.js server
  */
 export const createServerHandler = async (ctx: PluginContext) => {
   await tracer.withActiveSpan('createServerHandler', async () => {
-    await rm(ctx.serverFunctionsDir, { recursive: true, force: true })
     await mkdir(join(ctx.serverHandlerDir, '.netlify'), { recursive: true })
 
     await copyNextServerCode(ctx)


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/netlify/next-runtime/blob/main/CONTRIBUTING.md. -->

## Description

Alternative to https://github.com/netlify/next-runtime/pull/2511

This doesn't fully solve the problem as it can still happen with CLI (it does reduce reach of the problem), but feels much safer than previous PR. This relies on fact that builds on platform don't restore functions generated by previous builds therefore there is no need to clear those dirs. It also moves dir clearing to earlier stage so it's less likely that other integrations produced any functions yet (in case of using CLI)

### Documentation

<!-- Where is this feature or API documented? Did you create an internal and/or external artifact to document this change? -->

## Tests

<!-- Did you add tests? How did you test this change? -->

You can test this change yourself like so:

1. TODO

## Relevant links (GitHub issues, etc.) or a picture of cute animal

<!-- Link to an issue that is fixed by this PR or related to this PR. -->
