### PR TITLE
ci(e2e-report): support generating report site for version other than latest

### DIFF
--- a/.github/workflows/e2e-report.yml
+++ b/.github/workflows/e2e-report.yml
@@ -7,6 +7,14 @@ on:
       use-branch:
         description: 'Enable if you want to test data from your selected branch instead of the scheduled test runs from Main'
         type: boolean
+      version:
+        description: 'Version of Next.js (most recent test run must have included this version)'
+        type: choice
+        options:
+          - 'latest'
+          - 'canary'
+          - '13.5.1'
+        default: 'latest'
 
 env:
   NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
@@ -27,12 +35,19 @@ jobs:
             E2E_RUN_ID=$(gh run list -w test-e2e.yml -e schedule -s success --json databaseId --jq ".[0].databaseId" --repo $GITHUB_REPOSITORY)
           fi
           echo "runId=$E2E_RUN_ID" >> $GITHUB_OUTPUT
-      - name: Download latest e2e results
+      - name: Download e2e results
         if: ${{ steps.get-run-id.outputs.runId }}
         run: |
-          echo "Downloading latest test results from run https://github.com/netlify/next-runtime/actions/runs/${{ steps.get-run-id.outputs.runId }}"
-          rm e2e-report/data/test-results.json
-          gh run download ${{ steps.get-run-id.outputs.runId }} -n "latest-test-results.json" -D e2e-report/data/ --repo $GITHUB_REPOSITORY
+          version="${{ inputs.version }}"
+          version=${version:-latest}
+          OUTPUT_DIR="e2e-report/data"
+          OUTPUT_FILENAME="test-results.json"
+          echo "Downloading ${version} test results from run https://github.com/netlify/next-runtime/actions/runs/${{ steps.get-run-id.outputs.runId }}"
+          rm "${OUTPUT_DIR}/${OUTPUT_FILENAME}"
+          artifact_name="${version}-test-results.json"
+          # NOTE: The artifact name is not necessarily the artifact *file* name. The file name here
+          # must be `test-results.json`, but this is defined at the artifact upload step.
+          gh run download ${{ steps.get-run-id.outputs.runId }} -n "${artifact_name}" -D "${OUTPUT_DIR}" --repo $GITHUB_REPOSITORY
       - name: Install site dependencies
         if: success()
         run: |

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -259,6 +259,9 @@ jobs:
       - name: Upload Test JSON
         uses: actions/upload-artifact@v4
         with:
+          # TODO(serhalp) Consider renaming this. It's misleading, since it's just an identifier,
+          # but it's formatted like a filename, and happens to be almost - but not quite - the
+          # actual filename.
           name: ${{matrix.version_spec.selector}}-test-results.json
           path: report/test-results.json
 


### PR DESCRIPTION
## Description

This replaces the hardcoded Next.js "latest" version with an optional selector input.

While I was at it, I clarified some confusing aspects of this setup. It's tripped up multiple people already.

### Documentation

N/A

## Tests

When you make changes to a manual workflow setup, you can't see it reflected in the UI until you merge. However, I was able to use the GitHub CLI to manually trigger workflows against this branch's version of the workflow and it worked:

```sh
# run against default (latest)
gh workflow run -r ci/read-correct-e2e-results-file e2e-report.yml
# run against specific version (canary)
gh workflow run -r ci/read-correct-e2e-results-file e2e-report.yml -f version=canary
```

This resulted in these runs, respectively:
- https://github.com/netlify/next-runtime/actions/runs/9895424607
- https://github.com/netlify/next-runtime/actions/runs/9895445211

## Relevant links (GitHub issues, etc.) or a picture of cute animal

N/A