### PR TITLE
test: fix next.js repo e2e tests for canary.56

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NODE_VERSION: 18.17.1
+  NODE_VERSION: 18.18.0
   PNPM_VERSION: 8.9.0
   NEXT_REPO: vercel/next.js
   NEXT_TEST_MODE: deploy


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/netlify/next-runtime/blob/main/CONTRIBUTING.md. -->

## Description

The minimum supported version for canary got bumped recently: https://github.com/vercel/next.js/pull/67274.

We could set different versions per next.js version but it probably isn't worth it here.

### Documentation

N/A

## Tests

Here's a manual run that proves this fixes it: https://github.com/netlify/next-runtime/actions/runs/9898568341. (You have to inspect the results to see we're back closer to ~99% than to 7%...)

## Relevant links (GitHub issues, etc.) or a picture of cute animal

N/A