### PR TITLE
Michalpiechowiak/frp 765 migrate next runtime to use frameworks api

### DIFF
--- a/src/build/content/prerendered.ts
+++ b/src/build/content/prerendered.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 
 import { trace } from '@opentelemetry/api'
 import { wrapTracer } from '@opentelemetry/api/experimental'
@@ -31,12 +31,12 @@ const writeCacheEntry = async (
   lastModified: number,
   ctx: PluginContext,
 ): Promise<void> => {
-  const path = join(ctx.blobDir, await encodeBlobKey(route))
+  const path = join(ctx.blobDir, await encodeBlobKey(route), 'blob')
   const entry = JSON.stringify({
     lastModified,
     value,
   } satisfies NetlifyCacheHandlerValue)
-
+  await mkdir(dirname(path), { recursive: true })
   await writeFile(path, entry, 'utf-8')
 }
 

--- a/src/build/content/prerendered.ts
+++ b/src/build/content/prerendered.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs'
-import { mkdir, readFile, writeFile } from 'node:fs/promises'
-import { dirname, join } from 'node:path'
+import { mkdir, readFile } from 'node:fs/promises'
+import { join } from 'node:path'
 
 import { trace } from '@opentelemetry/api'
 import { wrapTracer } from '@opentelemetry/api/experimental'
@@ -8,7 +8,6 @@ import { glob } from 'fast-glob'
 import pLimit from 'p-limit'
 import { satisfies } from 'semver'
 
-import { encodeBlobKey } from '../../shared/blobkey.js'
 import type {
   CachedFetchValue,
   NetlifyCachedAppPageValue,
@@ -31,13 +30,11 @@ const writeCacheEntry = async (
   lastModified: number,
   ctx: PluginContext,
 ): Promise<void> => {
-  const path = join(ctx.blobDir, await encodeBlobKey(route), 'blob')
   const entry = JSON.stringify({
     lastModified,
     value,
   } satisfies NetlifyCacheHandlerValue)
-  await mkdir(dirname(path), { recursive: true })
-  await writeFile(path, entry, 'utf-8')
+  await ctx.setBlob(route, entry)
 }
 
 /**

--- a/src/build/content/static.ts
+++ b/src/build/content/static.ts
@@ -1,12 +1,11 @@
 import { existsSync } from 'node:fs'
-import { cp, mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises'
-import { basename, dirname, join } from 'node:path'
+import { cp, mkdir, readFile, rename, rm } from 'node:fs/promises'
+import { basename, join } from 'node:path'
 
 import { trace } from '@opentelemetry/api'
 import { wrapTracer } from '@opentelemetry/api/experimental'
 import glob from 'fast-glob'
 
-import { encodeBlobKey } from '../../shared/blobkey.js'
 import { PluginContext } from '../plugin-context.js'
 import { verifyNetlifyForms } from '../verification.js'
 
@@ -33,9 +32,7 @@ export const copyStaticContent = async (ctx: PluginContext): Promise<void> => {
           .map(async (path): Promise<void> => {
             const html = await readFile(join(srcDir, path), 'utf-8')
             verifyNetlifyForms(ctx, html)
-            const blobPath = join(destDir, await encodeBlobKey(path), 'blob')
-            await mkdir(dirname(blobPath), { recursive: true })
-            await writeFile(blobPath, html, 'utf-8')
+            await ctx.setBlob(path, html)
           }),
       )
     } catch (error) {

--- a/src/build/content/static.ts
+++ b/src/build/content/static.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs'
 import { cp, mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises'
-import { basename, join } from 'node:path'
+import { basename, dirname, join } from 'node:path'
 
 import { trace } from '@opentelemetry/api'
 import { wrapTracer } from '@opentelemetry/api/experimental'
@@ -33,7 +33,9 @@ export const copyStaticContent = async (ctx: PluginContext): Promise<void> => {
           .map(async (path): Promise<void> => {
             const html = await readFile(join(srcDir, path), 'utf-8')
             verifyNetlifyForms(ctx, html)
-            await writeFile(join(destDir, await encodeBlobKey(path)), html, 'utf-8')
+            const blobPath = join(destDir, await encodeBlobKey(path), 'blob')
+            await mkdir(dirname(blobPath), { recursive: true })
+            await writeFile(blobPath, html, 'utf-8')
           }),
       )
     } catch (error) {

--- a/src/build/functions/edge.ts
+++ b/src/build/functions/edge.ts
@@ -1,17 +1,17 @@
 import { cp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 
-import type { Manifest, ManifestFunction } from '@netlify/edge-functions'
+import type { IntegrationsConfig } from '@netlify/edge-functions'
 import { glob } from 'fast-glob'
 import type { EdgeFunctionDefinition as NextDefinition } from 'next/dist/build/webpack/plugins/middleware-plugin.js'
 import { pathToRegexp } from 'path-to-regexp'
 
 import { EDGE_HANDLER_NAME, PluginContext } from '../plugin-context.js'
 
-const writeEdgeManifest = async (ctx: PluginContext, manifest: Manifest) => {
-  await mkdir(ctx.edgeFunctionsDir, { recursive: true })
-  await writeFile(join(ctx.edgeFunctionsDir, 'manifest.json'), JSON.stringify(manifest, null, 2))
-}
+// const writeEdgeManifest = async (ctx: PluginContext, manifest: Manifest) => {
+//   await mkdir(ctx.edgeFunctionsDir, { recursive: true })
+//   await writeFile(join(ctx.edgeFunctionsDir, 'manifest.json'), JSON.stringify(manifest, null, 2))
+// }
 
 const copyRuntime = async (ctx: PluginContext, handlerDirectory: string): Promise<void> => {
   const files = await glob('edge-runtime/**/*', {
@@ -53,7 +53,7 @@ const augmentMatchers = (
   })
 }
 
-const writeHandlerFile = async (ctx: PluginContext, { matchers, name }: NextDefinition) => {
+const writeHandlerFile = async (ctx: PluginContext, { matchers, name, page }: NextDefinition) => {
   const nextConfig = ctx.buildConfig
   const handlerName = getHandlerName({ name })
   const handlerDirectory = join(ctx.edgeFunctionsDir, handlerName)
@@ -63,12 +63,11 @@ const writeHandlerFile = async (ctx: PluginContext, { matchers, name }: NextDefi
   // Netlify Edge Functions and the Next.js edge runtime.
   await copyRuntime(ctx, handlerDirectory)
 
+  const augmentedMatchers = augmentMatchers(matchers, ctx)
+
   // Writing a file with the matchers that should trigger this function. We'll
   // read this file from the function at runtime.
-  await writeFile(
-    join(handlerRuntimeDirectory, 'matchers.json'),
-    JSON.stringify(augmentMatchers(matchers, ctx)),
-  )
+  await writeFile(join(handlerRuntimeDirectory, 'matchers.json'), JSON.stringify(augmentedMatchers))
 
   // The config is needed by the edge function to match and normalize URLs. To
   // avoid shipping and parsing a large file at runtime, let's strip it down to
@@ -93,6 +92,15 @@ const writeHandlerFile = async (ctx: PluginContext, { matchers, name }: NextDefi
     import {handleMiddleware} from './edge-runtime/middleware.ts';
     import handler from './server/${name}.js';
     export default (req, context) => handleMiddleware(req, context, handler);
+
+    export const config = ${JSON.stringify({
+      name: name.endsWith('middleware')
+        ? 'Next.js Middleware Handler'
+        : `Next.js Edge Handler: ${page}`,
+      pattern: augmentedMatchers.map((matcher) => matcher.regexp),
+      cache: name.endsWith('middleware') ? undefined : 'manual',
+      generator: `${ctx.pluginName}@${ctx.pluginVersion}`,
+    } satisfies IntegrationsConfig)};
     `,
   )
 }
@@ -142,25 +150,25 @@ const createEdgeHandler = async (ctx: PluginContext, definition: NextDefinition)
 const getHandlerName = ({ name }: Pick<NextDefinition, 'name'>): string =>
   `${EDGE_HANDLER_NAME}-${name.replace(/\W/g, '-')}`
 
-const buildHandlerDefinition = (
-  ctx: PluginContext,
-  { name, matchers, page }: NextDefinition,
-): Array<ManifestFunction> => {
-  const fun = getHandlerName({ name })
-  const funName = name.endsWith('middleware')
-    ? 'Next.js Middleware Handler'
-    : `Next.js Edge Handler: ${page}`
-  const cache = name.endsWith('middleware') ? undefined : ('manual' as const)
-  const generator = `${ctx.pluginName}@${ctx.pluginVersion}`
+// const buildHandlerDefinition = (
+//   ctx: PluginContext,
+//   { name, matchers, page }: NextDefinition,
+// ): Array<ManifestFunction> => {
+//   const fun = getHandlerName({ name })
+//   const funName = name.endsWith('middleware')
+//     ? 'Next.js Middleware Handler'
+//     : `Next.js Edge Handler: ${page}`
+//   const cache = name.endsWith('middleware') ? undefined : ('manual' as const)
+//   const generator = `${ctx.pluginName}@${ctx.pluginVersion}`
 
-  return augmentMatchers(matchers, ctx).map((matcher) => ({
-    function: fun,
-    name: funName,
-    pattern: matcher.regexp,
-    cache,
-    generator,
-  }))
-}
+//   return augmentMatchers(matchers, ctx).map((matcher) => ({
+//     function: fun,
+//     name: funName,
+//     pattern: matcher.regexp,
+//     cache,
+//     generator,
+//   }))
+// }
 
 export const clearStaleEdgeHandlers = async (ctx: PluginContext) => {
   await rm(ctx.edgeFunctionsDir, { recursive: true, force: true })
@@ -174,10 +182,10 @@ export const createEdgeHandlers = async (ctx: PluginContext) => {
   ]
   await Promise.all(nextDefinitions.map((def) => createEdgeHandler(ctx, def)))
 
-  const netlifyDefinitions = nextDefinitions.flatMap((def) => buildHandlerDefinition(ctx, def))
-  const netlifyManifest: Manifest = {
-    version: 1,
-    functions: netlifyDefinitions,
-  }
-  await writeEdgeManifest(ctx, netlifyManifest)
+  // const netlifyDefinitions = nextDefinitions.flatMap((def) => buildHandlerDefinition(ctx, def))
+  // const netlifyManifest: Manifest = {
+  //   version: 1,
+  //   functions: netlifyDefinitions,
+  // }
+  // await writeEdgeManifest(ctx, netlifyManifest)
 }

--- a/src/build/functions/edge.ts
+++ b/src/build/functions/edge.ts
@@ -1,17 +1,17 @@
 import { cp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 
-import type { IntegrationsConfig } from '@netlify/edge-functions'
+import type { IntegrationsConfig, Manifest, ManifestFunction } from '@netlify/edge-functions'
 import { glob } from 'fast-glob'
 import type { EdgeFunctionDefinition as NextDefinition } from 'next/dist/build/webpack/plugins/middleware-plugin.js'
 import { pathToRegexp } from 'path-to-regexp'
 
 import { EDGE_HANDLER_NAME, PluginContext } from '../plugin-context.js'
 
-// const writeEdgeManifest = async (ctx: PluginContext, manifest: Manifest) => {
-//   await mkdir(ctx.edgeFunctionsDir, { recursive: true })
-//   await writeFile(join(ctx.edgeFunctionsDir, 'manifest.json'), JSON.stringify(manifest, null, 2))
-// }
+const writeEdgeManifest = async (ctx: PluginContext, manifest: Manifest) => {
+  await mkdir(ctx.edgeFunctionsDir, { recursive: true })
+  await writeFile(join(ctx.edgeFunctionsDir, 'manifest.json'), JSON.stringify(manifest, null, 2))
+}
 
 const copyRuntime = async (ctx: PluginContext, handlerDirectory: string): Promise<void> => {
   const files = await glob('edge-runtime/**/*', {
@@ -84,6 +84,17 @@ const writeHandlerFile = async (ctx: PluginContext, { matchers, name, page }: Ne
     JSON.stringify(minimalNextConfig),
   )
 
+  const isc = ctx.useFrameworksAPI
+    ? `export const config = ${JSON.stringify({
+        name: name.endsWith('middleware')
+          ? 'Next.js Middleware Handler'
+          : `Next.js Edge Handler: ${page}`,
+        pattern: augmentedMatchers.map((matcher) => matcher.regexp),
+        cache: name.endsWith('middleware') ? undefined : 'manual',
+        generator: `${ctx.pluginName}@${ctx.pluginVersion}`,
+      } satisfies IntegrationsConfig)};`
+    : ``
+
   // Writing the function entry file. It wraps the middleware code with the
   // compatibility layer mentioned above.
   await writeFile(
@@ -92,16 +103,7 @@ const writeHandlerFile = async (ctx: PluginContext, { matchers, name, page }: Ne
     import {handleMiddleware} from './edge-runtime/middleware.ts';
     import handler from './server/${name}.js';
     export default (req, context) => handleMiddleware(req, context, handler);
-
-    export const config = ${JSON.stringify({
-      name: name.endsWith('middleware')
-        ? 'Next.js Middleware Handler'
-        : `Next.js Edge Handler: ${page}`,
-      pattern: augmentedMatchers.map((matcher) => matcher.regexp),
-      cache: name.endsWith('middleware') ? undefined : 'manual',
-      generator: `${ctx.pluginName}@${ctx.pluginVersion}`,
-    } satisfies IntegrationsConfig)};
-    `,
+    ${isc}`,
   )
 }
 
@@ -150,25 +152,25 @@ const createEdgeHandler = async (ctx: PluginContext, definition: NextDefinition)
 const getHandlerName = ({ name }: Pick<NextDefinition, 'name'>): string =>
   `${EDGE_HANDLER_NAME}-${name.replace(/\W/g, '-')}`
 
-// const buildHandlerDefinition = (
-//   ctx: PluginContext,
-//   { name, matchers, page }: NextDefinition,
-// ): Array<ManifestFunction> => {
-//   const fun = getHandlerName({ name })
-//   const funName = name.endsWith('middleware')
-//     ? 'Next.js Middleware Handler'
-//     : `Next.js Edge Handler: ${page}`
-//   const cache = name.endsWith('middleware') ? undefined : ('manual' as const)
-//   const generator = `${ctx.pluginName}@${ctx.pluginVersion}`
+const buildHandlerDefinition = (
+  ctx: PluginContext,
+  { name, matchers, page }: NextDefinition,
+): Array<ManifestFunction> => {
+  const fun = getHandlerName({ name })
+  const funName = name.endsWith('middleware')
+    ? 'Next.js Middleware Handler'
+    : `Next.js Edge Handler: ${page}`
+  const cache = name.endsWith('middleware') ? undefined : ('manual' as const)
+  const generator = `${ctx.pluginName}@${ctx.pluginVersion}`
 
-//   return augmentMatchers(matchers, ctx).map((matcher) => ({
-//     function: fun,
-//     name: funName,
-//     pattern: matcher.regexp,
-//     cache,
-//     generator,
-//   }))
-// }
+  return augmentMatchers(matchers, ctx).map((matcher) => ({
+    function: fun,
+    name: funName,
+    pattern: matcher.regexp,
+    cache,
+    generator,
+  }))
+}
 
 export const clearStaleEdgeHandlers = async (ctx: PluginContext) => {
   await rm(ctx.edgeFunctionsDir, { recursive: true, force: true })
@@ -182,10 +184,12 @@ export const createEdgeHandlers = async (ctx: PluginContext) => {
   ]
   await Promise.all(nextDefinitions.map((def) => createEdgeHandler(ctx, def)))
 
-  // const netlifyDefinitions = nextDefinitions.flatMap((def) => buildHandlerDefinition(ctx, def))
-  // const netlifyManifest: Manifest = {
-  //   version: 1,
-  //   functions: netlifyDefinitions,
-  // }
-  // await writeEdgeManifest(ctx, netlifyManifest)
+  if (!ctx.useFrameworksAPI) {
+    const netlifyDefinitions = nextDefinitions.flatMap((def) => buildHandlerDefinition(ctx, def))
+    const netlifyManifest: Manifest = {
+      version: 1,
+      functions: netlifyDefinitions,
+    }
+    await writeEdgeManifest(ctx, netlifyManifest)
+  }
 }

--- a/src/build/functions/server.ts
+++ b/src/build/functions/server.ts
@@ -67,23 +67,23 @@ const copyHandlerDependencies = async (ctx: PluginContext) => {
   })
 }
 
-const writeHandlerManifest = async (ctx: PluginContext) => {
-  await writeFile(
-    join(ctx.serverHandlerRootDir, `${SERVER_HANDLER_NAME}.json`),
-    JSON.stringify({
-      config: {
-        name: 'Next.js Server Handler',
-        generator: `${ctx.pluginName}@${ctx.pluginVersion}`,
-        nodeBundler: 'none',
-        // the folders can vary in monorepos based on the folder structure of the user so we have to glob all
-        includedFiles: ['**'],
-        includedFilesBasePath: ctx.serverHandlerRootDir,
-      },
-      version: 1,
-    }),
-    'utf-8',
-  )
-}
+// const writeHandlerManifest = async (ctx: PluginContext) => {
+//   await writeFile(
+//     join(ctx.serverHandlerRootDir, `${SERVER_HANDLER_NAME}.json`),
+//     JSON.stringify({
+//       config: {
+//         name: 'Next.js Server Handler',
+//         generator: `${ctx.pluginName}@${ctx.pluginVersion}`,
+//         nodeBundler: 'none',
+//         // the folders can vary in monorepos based on the folder structure of the user so we have to glob all
+//         includedFiles: ['**'],
+//         includedFilesBasePath: ctx.serverHandlerRootDir,
+//       },
+//       version: 1,
+//     }),
+//     'utf-8',
+//   )
+// }
 
 const writePackageMetadata = async (ctx: PluginContext) => {
   await writeFile(
@@ -104,6 +104,8 @@ const getHandlerFile = async (ctx: PluginContext): Promise<string> => {
 
   const templateVariables: Record<string, string> = {
     '{{useRegionalBlobs}}': ctx.useRegionalBlobs.toString(),
+    '{{generator}}': `${ctx.pluginName}@${ctx.pluginVersion}`,
+    '{{serverHandlerRootDir}}': ctx.serverHandlerRootDir,
   }
   // In this case it is a monorepo and we need to use a own template for it
   // as we have to change the process working directory
@@ -141,7 +143,7 @@ export const createServerHandler = async (ctx: PluginContext) => {
     await copyNextServerCode(ctx)
     await copyNextDependencies(ctx)
     await copyHandlerDependencies(ctx)
-    await writeHandlerManifest(ctx)
+    // await writeHandlerManifest(ctx)
     await writePackageMetadata(ctx)
     await writeHandlerFile(ctx)
 

--- a/src/build/functions/server.ts
+++ b/src/build/functions/server.ts
@@ -67,23 +67,23 @@ const copyHandlerDependencies = async (ctx: PluginContext) => {
   })
 }
 
-// const writeHandlerManifest = async (ctx: PluginContext) => {
-//   await writeFile(
-//     join(ctx.serverHandlerRootDir, `${SERVER_HANDLER_NAME}.json`),
-//     JSON.stringify({
-//       config: {
-//         name: 'Next.js Server Handler',
-//         generator: `${ctx.pluginName}@${ctx.pluginVersion}`,
-//         nodeBundler: 'none',
-//         // the folders can vary in monorepos based on the folder structure of the user so we have to glob all
-//         includedFiles: ['**'],
-//         includedFilesBasePath: ctx.serverHandlerRootDir,
-//       },
-//       version: 1,
-//     }),
-//     'utf-8',
-//   )
-// }
+const writeHandlerManifest = async (ctx: PluginContext) => {
+  await writeFile(
+    join(ctx.serverHandlerRootDir, `${SERVER_HANDLER_NAME}.json`),
+    JSON.stringify({
+      config: {
+        name: 'Next.js Server Handler',
+        generator: `${ctx.pluginName}@${ctx.pluginVersion}`,
+        nodeBundler: 'none',
+        // the folders can vary in monorepos based on the folder structure of the user so we have to glob all
+        includedFiles: ['**'],
+        includedFilesBasePath: ctx.serverHandlerRootDir,
+      },
+      version: 1,
+    }),
+    'utf-8',
+  )
+}
 
 const writePackageMetadata = async (ctx: PluginContext) => {
   await writeFile(
@@ -143,7 +143,9 @@ export const createServerHandler = async (ctx: PluginContext) => {
     await copyNextServerCode(ctx)
     await copyNextDependencies(ctx)
     await copyHandlerDependencies(ctx)
-    // await writeHandlerManifest(ctx)
+    if (!ctx.useFrameworksAPI) {
+      await writeHandlerManifest(ctx)
+    }
     await writePackageMetadata(ctx)
     await writeHandlerFile(ctx)
 

--- a/src/build/functions/server.ts
+++ b/src/build/functions/server.ts
@@ -103,7 +103,7 @@ const getHandlerFile = async (ctx: PluginContext): Promise<string> => {
   const templatesDir = join(ctx.pluginDir, 'dist/build/templates')
 
   const templateVariables: Record<string, string> = {
-    '{{useRegionalBlobs}}': ctx.useRegionalBlobs.toString(),
+    '{{useRegionalBlobs}}': (ctx.blobsStrategy !== 'legacy').toString(),
     '{{generator}}': `${ctx.pluginName}@${ctx.pluginVersion}`,
     '{{serverHandlerRootDir}}': ctx.serverHandlerRootDir,
   }

--- a/src/build/plugin-context.ts
+++ b/src/build/plugin-context.ts
@@ -168,7 +168,7 @@ export class PluginContext {
    * `.netlify/functions-internal`
    */
   get serverFunctionsDir(): string {
-    return this.resolveFromPackagePath('.netlify/functions-internal')
+    return this.resolveFromPackagePath('.netlify/v1/functions')
   }
 
   /** Absolute path of the server handler */

--- a/src/build/plugin-context.ts
+++ b/src/build/plugin-context.ts
@@ -177,17 +177,14 @@ export class PluginContext {
   }
 
   get useFrameworksAPI(): boolean {
-    // TODO: make this conditional
-    return true
+    // Defining RegExp pattern in edge function inline config is only supported since 29.50.5
+    const REQUIRED_BUILD_VERSION = '>=29.50.5'
+    return satisfies(this.buildVersion, REQUIRED_BUILD_VERSION, { includePrerelease: true })
   }
 
   get blobsStrategy(): 'legacy' | 'regional' | 'frameworks-api' {
     if (this.useFrameworksAPI) {
       return 'frameworks-api'
-    }
-
-    if (!(this.featureFlags || {})['next-runtime-regional-blobs']) {
-      return 'legacy'
     }
 
     // Region-aware blobs are only available as of CLI v17.23.5 (i.e. Build v29.41.5)
@@ -202,7 +199,11 @@ export class PluginContext {
    * `.netlify/functions-internal`
    */
   get serverFunctionsDir(): string {
-    return this.resolveFromPackagePath('.netlify/v1/functions')
+    if (this.useFrameworksAPI) {
+      return this.resolveFromPackagePath('.netlify/v1/functions')
+    }
+
+    return this.resolveFromPackagePath('.netlify/functions-internal')
   }
 
   /** Absolute path of the server handler */
@@ -229,7 +230,11 @@ export class PluginContext {
    * `.netlify/edge-functions`
    */
   get edgeFunctionsDir(): string {
-    return this.resolveFromPackagePath('.netlify/v1/edge-functions')
+    if (this.useFrameworksAPI) {
+      return this.resolveFromPackagePath('.netlify/v1/edge-functions')
+    }
+
+    return this.resolveFromPackagePath('.netlify/edge-functions')
   }
 
   /** Absolute path of the edge handler */

--- a/src/build/plugin-context.ts
+++ b/src/build/plugin-context.ts
@@ -141,11 +141,12 @@ export class PluginContext {
    * default: `.netlify/blobs/deploy`
    */
   get blobDir(): string {
-    if (this.useRegionalBlobs) {
-      return this.resolveFromPackagePath('.netlify/deploy/v1/blobs/deploy')
-    }
+    return this.resolveFromPackagePath('.netlify/v1/blobs/deploy')
+    // if (this.useRegionalBlobs) {
+    //   return this.resolveFromPackagePath('.netlify/deploy/v1/blobs/deploy')
+    // }
 
-    return this.resolveFromPackagePath('.netlify/blobs/deploy')
+    // return this.resolveFromPackagePath('.netlify/blobs/deploy')
   }
 
   get buildVersion(): string {

--- a/src/build/plugin-context.ts
+++ b/src/build/plugin-context.ts
@@ -195,7 +195,7 @@ export class PluginContext {
    * `.netlify/edge-functions`
    */
   get edgeFunctionsDir(): string {
-    return this.resolveFromPackagePath('.netlify/edge-functions')
+    return this.resolveFromPackagePath('.netlify/v1/edge-functions')
   }
 
   /** Absolute path of the edge handler */

--- a/src/build/plugin-context.ts
+++ b/src/build/plugin-context.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs'
-import { readFile } from 'node:fs/promises'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { createRequire } from 'node:module'
-import { join, relative, resolve } from 'node:path'
+import { dirname, join, relative, resolve } from 'node:path'
 import { join as posixJoin } from 'node:path/posix'
 import { fileURLToPath } from 'node:url'
 
@@ -14,6 +14,8 @@ import type { PrerenderManifest, RoutesManifest } from 'next/dist/build/index.js
 import type { MiddlewareManifest } from 'next/dist/build/webpack/plugins/middleware-plugin.js'
 import type { NextConfigComplete } from 'next/dist/server/config-shared.js'
 import { satisfies } from 'semver'
+
+import { encodeBlobKey } from '../shared/blobkey.js'
 
 const MODULE_DIR = fileURLToPath(new URL('.', import.meta.url))
 const PLUGIN_DIR = join(MODULE_DIR, '../..')
@@ -137,30 +139,62 @@ export class PluginContext {
 
   /**
    * Absolute path of the directory that will be deployed to the blob store
+   * frameworks api: `.netlify/v1/blobs/deploy`
    * region aware: `.netlify/deploy/v1/blobs/deploy`
    * default: `.netlify/blobs/deploy`
    */
   get blobDir(): string {
-    return this.resolveFromPackagePath('.netlify/v1/blobs/deploy')
-    // if (this.useRegionalBlobs) {
-    //   return this.resolveFromPackagePath('.netlify/deploy/v1/blobs/deploy')
-    // }
+    switch (this.blobsStrategy) {
+      case 'frameworks-api':
+        return this.resolveFromPackagePath('.netlify/v1/blobs/deploy')
+      case 'regional':
+        return this.resolveFromPackagePath('.netlify/deploy/v1/blobs/deploy')
+      case 'legacy':
+      default:
+        return this.resolveFromPackagePath('.netlify/blobs/deploy')
+    }
+  }
 
-    // return this.resolveFromPackagePath('.netlify/blobs/deploy')
+  async setBlob(key: string, value: string) {
+    switch (this.blobsStrategy) {
+      case 'frameworks-api': {
+        const path = join(this.blobDir, await encodeBlobKey(key), 'blob')
+        await mkdir(dirname(path), { recursive: true })
+        await writeFile(path, value, 'utf-8')
+        return
+      }
+      case 'regional':
+      case 'legacy':
+      default: {
+        const path = join(this.blobDir, await encodeBlobKey(key))
+        await writeFile(path, value, 'utf-8')
+      }
+    }
   }
 
   get buildVersion(): string {
     return this.constants.NETLIFY_BUILD_VERSION || 'v0.0.0'
   }
 
-  get useRegionalBlobs(): boolean {
+  get useFrameworksAPI(): boolean {
+    // TODO: make this conditional
+    return true
+  }
+
+  get blobsStrategy(): 'legacy' | 'regional' | 'frameworks-api' {
+    if (this.useFrameworksAPI) {
+      return 'frameworks-api'
+    }
+
     if (!(this.featureFlags || {})['next-runtime-regional-blobs']) {
-      return false
+      return 'legacy'
     }
 
     // Region-aware blobs are only available as of CLI v17.23.5 (i.e. Build v29.41.5)
     const REQUIRED_BUILD_VERSION = '>=29.41.5'
     return satisfies(this.buildVersion, REQUIRED_BUILD_VERSION, { includePrerelease: true })
+      ? 'regional'
+      : 'legacy'
   }
 
   /**

--- a/src/build/templates/handler-monorepo.tmpl.js
+++ b/src/build/templates/handler-monorepo.tmpl.js
@@ -53,4 +53,9 @@ export default async function (req, context) {
 export const config = {
   path: '/*',
   preferStatic: true,
+  name: 'Next.js Server Handler',
+  generator: '{{generator}}',
+  nodeBundler: 'none',
+  includedFiles: ['**'],
+  includedFilesBasePath: '{{serverHandlerRootDir}}',
 }

--- a/src/build/templates/handler.tmpl.js
+++ b/src/build/templates/handler.tmpl.js
@@ -46,4 +46,9 @@ export default async function handler(req, context) {
 export const config = {
   path: '/*',
   preferStatic: true,
+  name: 'Next.js Server Handler',
+  generator: '{{generator}}',
+  nodeBundler: 'none',
+  includedFiles: ['**'],
+  includedFilesBasePath: '{{serverHandlerRootDir}}',
 }


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/netlify/next-runtime/blob/main/CONTRIBUTING.md. -->

## Description

work in progress on migrating next runtime to use frameworks API. It still will support older method to support cases of CLI usage (which user might not updated)

### Documentation

<!-- Where is this feature or API documented? Did you create an internal and/or external artifact to document this change? -->

## Tests

<!-- Did you add tests? How did you test this change? -->

You can test this change yourself like so:

1. TODO

## Relevant links (GitHub issues, etc.) or a picture of cute animal

<!-- Link to an issue that is fixed by this PR or related to this PR. -->
