### PR TITLE
fix: ensure middleware matchers evaluate default locale

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,8 +93,8 @@ given prefix, run `npm run pretest -- <prefix>`.
 > Needs the `netlify-cli` installed and being logged in having access to Netlify Testing
 > Organization or providing your own site ID with NETLIFY_SITE_ID environment variable.
 
-The e2e tests can be invoked with `npm run e2e` and perform a full e2e test. This means they do the
-following:
+The e2e tests can be invoked with `npm run test:e2e` and perform a full e2e test. This means they do
+the following:
 
 1. Building the next-runtime (just running `npm run build` in the repository)
 2. Creating a temp directory and copying the provided fixture over to the directory.
@@ -113,7 +113,7 @@ following:
    purposes.
 
 > [!TIP] If you'd like to always keep the deployment and the local fixture around for
-> troubleshooting, run `E2E_PERSIST=1 npm run e2e`.
+> troubleshooting, run `E2E_PERSIST=1 npm run test:e2e`.
 
 ### Next.js tests
 

--- a/edge-runtime/lib/next-request.ts
+++ b/edge-runtime/lib/next-request.ts
@@ -13,7 +13,9 @@ import type { NextConfig } from 'next/dist/server/config-shared'
 import type { NextRequest, RequestInit } from 'next/dist/server/web/spec-extension/request.js'
 
 export type NetlifyNextRequest = RequestInit &
-  Pick<NextRequest, 'url' | 'headers' | 'geo' | 'ip' | 'method' | 'body'>
+  Pick<NextRequest, 'url' | 'geo' | 'ip' | 'method' | 'body'> & {
+    headers: HeadersInit
+  }
 
 const normalizeRequest = (url: URL, nextConfig?: NextConfig): URL => {
   url.pathname = removeBasePath(url.pathname, nextConfig?.basePath)
@@ -68,7 +70,7 @@ export const buildNextRequest = (
 
   return {
     url: normalizedUrl.toString(),
-    headers,
+    headers: Object.fromEntries(headers.entries()),
     geo: {
       city,
       country: country?.code,

--- a/edge-runtime/lib/next-request.ts
+++ b/edge-runtime/lib/next-request.ts
@@ -12,8 +12,8 @@ import {
 import type { NextConfig } from 'next/dist/server/config-shared'
 import type { NextRequest, RequestInit } from 'next/dist/server/web/spec-extension/request.js'
 
-export type NetlifyNextRequest = RequestInit &
-  Pick<NextRequest, 'url' | 'geo' | 'ip' | 'method' | 'body'> & {
+export type NetlifyNextRequest = Partial<Omit<NextRequest, 'headers'>> &
+  RequestInit & {
     headers: HeadersInit
   }
 

--- a/edge-runtime/lib/response.ts
+++ b/edge-runtime/lib/response.ts
@@ -20,7 +20,7 @@ export interface FetchEventResult {
 
 interface BuildResponseOptions {
   context: Context
-  config?: NetlifyNextRequest['nextConfig']
+  nextConfig?: NetlifyNextRequest['nextConfig']
   locale?: string
   request: Request
   result: FetchEventResult
@@ -29,7 +29,7 @@ interface BuildResponseOptions {
 
 export const buildResponse = async ({
   context,
-  config,
+  nextConfig,
   locale,
   request,
   result,
@@ -185,9 +185,9 @@ export const buildResponse = async ({
     }
 
     // respect trailing slash rules to prevent 308s
-    rewriteUrl.pathname = normalizeTrailingSlash(rewriteUrl.pathname, config?.trailingSlash)
+    rewriteUrl.pathname = normalizeTrailingSlash(rewriteUrl.pathname, nextConfig?.trailingSlash)
 
-    const target = normalizeLocalizedTarget({ target: rewriteUrl.toString(), request, config })
+    const target = normalizeLocalizedTarget({ target: rewriteUrl.toString(), request, nextConfig })
     if (target === request.url) {
       logger.withFields({ rewrite_url: rewrite }).debug('Rewrite url is same as original url')
       return
@@ -199,7 +199,7 @@ export const buildResponse = async ({
 
   // If we are redirecting a request that had a locale in the URL, we need to add it back in
   if (redirect && locale) {
-    redirect = normalizeLocalizedTarget({ target: redirect, request, config })
+    redirect = normalizeLocalizedTarget({ target: redirect, request, nextConfig })
     if (redirect === request.url) {
       logger.withFields({ rewrite_url: rewrite }).debug('Rewrite url is same as original url')
       return
@@ -233,16 +233,16 @@ export const buildResponse = async ({
 function normalizeLocalizedTarget({
   target,
   request,
-  config,
+  nextConfig,
   locale,
 }: {
   target: string
   request: Request
-  config?: NetlifyNextRequest['nextConfig']
+  nextConfig?: NetlifyNextRequest['nextConfig']
   locale?: string
 }) {
   const targetUrl = new URL(target, request.url)
-  const normalizedTarget = normalizeLocalePath(targetUrl.pathname, config?.i18n?.locales)
+  const normalizedTarget = normalizeLocalePath(targetUrl.pathname, nextConfig?.i18n?.locales)
   const targetPathname = normalizedTarget.pathname
   const targetLocale = normalizedTarget.detectedLocale ?? locale
 
@@ -251,9 +251,10 @@ function normalizeLocalizedTarget({
     !targetPathname.startsWith(`/api/`) &&
     !targetPathname.startsWith(`/_next/static/`)
   ) {
-    targetUrl.pathname = addBasePath(`/${targetLocale}${targetPathname}`, config?.basePath) || `/`
+    targetUrl.pathname =
+      addBasePath(`/${targetLocale}${targetPathname}`, nextConfig?.basePath) || `/`
   } else {
-    targetUrl.pathname = addBasePath(targetPathname, config?.basePath) || `/`
+    targetUrl.pathname = addBasePath(targetPathname, nextConfig?.basePath) || `/`
   }
   return targetUrl.toString()
 }

--- a/edge-runtime/lib/routing.ts
+++ b/edge-runtime/lib/routing.ts
@@ -7,8 +7,8 @@
 
 import type { Key } from '../vendor/deno.land/x/path_to_regexp@v6.2.1/index.ts'
 
-import { compile, pathToRegexp } from '../vendor/deno.land/x/path_to_regexp@v6.2.1/index.ts'
 import { getCookies } from '../vendor/deno.land/std@0.175.0/http/cookie.ts'
+import { compile, pathToRegexp } from '../vendor/deno.land/x/path_to_regexp@v6.2.1/index.ts'
 
 /*
   ┌─────────────────────────────────────────────────────────────────────────┐

--- a/edge-runtime/lib/util.ts
+++ b/edge-runtime/lib/util.ts
@@ -60,27 +60,18 @@ export interface PathLocale {
  */
 export function normalizeLocalePath(pathname: string, locales?: string[]): PathLocale {
   let detectedLocale: string | undefined
+  // first item will be empty string from splitting at first char
+  const pathnameParts = pathname.split('/')
 
-  // normalize the locales to lowercase
-  const normalizedLocales = locales?.map((loc) => loc.toLowerCase())
-
-  // split the pathname into parts, removing the leading slash
-  const pathnameParts = pathname.substring(1).split('/')
-
-  // split the first part of the pathname to check if it's a locale
-  const localeParts = pathnameParts[0].toLowerCase().split('-')
-
-  // check if the first part of the pathname is a locale
-  // by matching the given locales, with decreasing specificity
-  for (let i = localeParts.length; i > 0; i--) {
-    const localePart = localeParts.slice(0, i).join('-')
-    if (normalizedLocales?.includes(localePart)) {
-      detectedLocale = localeParts.join('-')
-      pathname = `/${pathnameParts.slice(1).join('/')}`
-      break
+  ;(locales || []).some((locale) => {
+    if (pathnameParts[1] && pathnameParts[1].toLowerCase() === locale.toLowerCase()) {
+      detectedLocale = locale
+      pathnameParts.splice(1, 1)
+      pathname = pathnameParts.join('/')
+      return true
     }
-  }
-
+    return false
+  })
   return {
     pathname,
     detectedLocale,

--- a/edge-runtime/lib/util.ts
+++ b/edge-runtime/lib/util.ts
@@ -29,6 +29,13 @@ export const addBasePath = (path: string, basePath?: string) => {
   return path
 }
 
+export const addLocale = (path: string, locale?: string) => {
+  if (locale && path !== `/${locale}` && !path.startsWith(`/${locale}/`)) {
+    return `/${locale}${path}`
+  }
+  return path
+}
+
 // https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/i18n/normalize-locale-path.ts
 
 export interface PathLocale {

--- a/edge-runtime/lib/util.ts
+++ b/edge-runtime/lib/util.ts
@@ -29,11 +29,13 @@ export const addBasePath = (path: string, basePath?: string) => {
   return path
 }
 
+// add locale prefix if not present, allowing for locale fallbacks
 export const addLocale = (path: string, locale?: string) => {
   if (
     locale &&
     path.toLowerCase() !== `/${locale.toLowerCase()}` &&
-    !path.toLowerCase().startsWith(`/${locale.toLowerCase()}/`)
+    !path.toLowerCase().startsWith(`/${locale.toLowerCase()}/`) &&
+    !path.toLowerCase().startsWith(`/${locale.toLowerCase()}-`)
   ) {
     return `/${locale}${path}`
   }

--- a/edge-runtime/lib/util.ts
+++ b/edge-runtime/lib/util.ts
@@ -35,7 +35,8 @@ export const addLocale = (path: string, locale?: string) => {
     locale &&
     path.toLowerCase() !== `/${locale.toLowerCase()}` &&
     !path.toLowerCase().startsWith(`/${locale.toLowerCase()}/`) &&
-    !path.toLowerCase().startsWith(`/${locale.toLowerCase()}-`)
+    !path.startsWith(`/api/`) &&
+    !path.startsWith(`/_next/static/`)
   ) {
     return `/${locale}${path}`
   }

--- a/edge-runtime/lib/util.ts
+++ b/edge-runtime/lib/util.ts
@@ -30,7 +30,11 @@ export const addBasePath = (path: string, basePath?: string) => {
 }
 
 export const addLocale = (path: string, locale?: string) => {
-  if (locale && path !== `/${locale}` && !path.startsWith(`/${locale}/`)) {
+  if (
+    locale &&
+    path.toLowerCase() !== `/${locale.toLowerCase()}` &&
+    !path.toLowerCase().startsWith(`/${locale.toLowerCase()}/`)
+  ) {
     return `/${locale}${path}`
   }
   return path
@@ -54,18 +58,27 @@ export interface PathLocale {
  */
 export function normalizeLocalePath(pathname: string, locales?: string[]): PathLocale {
   let detectedLocale: string | undefined
-  // first item will be empty string from splitting at first char
-  const pathnameParts = pathname.split('/')
 
-  ;(locales || []).some((locale) => {
-    if (pathnameParts[1] && pathnameParts[1].toLowerCase() === locale.toLowerCase()) {
-      detectedLocale = locale
-      pathnameParts.splice(1, 1)
-      pathname = pathnameParts.join('/')
-      return true
+  // normalize the locales to lowercase
+  const normalizedLocales = locales?.map((loc) => loc.toLowerCase())
+
+  // split the pathname into parts, removing the leading slash
+  const pathnameParts = pathname.substring(1).split('/')
+
+  // split the first part of the pathname to check if it's a locale
+  const localeParts = pathnameParts[0].toLowerCase().split('-')
+
+  // check if the first part of the pathname is a locale
+  // by matching the given locales, with decreasing specificity
+  for (let i = localeParts.length; i > 0; i--) {
+    const localePart = localeParts.slice(0, i).join('-')
+    if (normalizedLocales?.includes(localePart)) {
+      detectedLocale = localeParts.join('-')
+      pathname = `/${pathnameParts.slice(1).join('/')}`
+      break
     }
-    return false
-  })
+  }
+
   return {
     pathname,
     detectedLocale,

--- a/edge-runtime/middleware.ts
+++ b/edge-runtime/middleware.ts
@@ -40,7 +40,7 @@ export async function handleMiddleware(
     .withRequestID(request.headers.get(InternalHeaders.NFRequestID))
 
   const { nextRequest, nextContext } = buildNextRequest(request, context, nextConfig)
-  const localizedPath = new URL(nextContext.localizedUrl).pathname
+  const { pathname: localizedPath } = new URL(nextContext.localizedUrl)
 
   // While we have already checked the path when mapping to the edge function,
   // Next.js supports extra rules that we need to check here too, because we

--- a/package-lock.json
+++ b/package-lock.json
@@ -7340,9 +7340,9 @@
       "dev": true
     },
     "node_modules/@vercel/nft": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-0.27.2.tgz",
-      "integrity": "sha512-7LeioS1yE5hwPpQfD3DdH04tuugKjo5KrJk3yK5kAI3Lh76iSsK/ezoFQfzuT08X3ZASQOd1y9ePjLNI9+TxTQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-0.27.3.tgz",
+      "integrity": "sha512-oySTdDSzUAFDXpsSLk9Q943o+/Yu/+TCFxnehpFQEf/3khi2stMpTHPVNwFdvZq/Z4Ky93lE+MGHpXCRpMkSCA==",
       "dev": true,
       "dependencies": {
         "@mapbox/node-pre-gyp": "^1.0.5",
@@ -25001,9 +25001,9 @@
       "dev": true
     },
     "@vercel/nft": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-0.27.2.tgz",
-      "integrity": "sha512-7LeioS1yE5hwPpQfD3DdH04tuugKjo5KrJk3yK5kAI3Lh76iSsK/ezoFQfzuT08X3ZASQOd1y9ePjLNI9+TxTQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-0.27.3.tgz",
+      "integrity": "sha512-oySTdDSzUAFDXpsSLk9Q943o+/Yu/+TCFxnehpFQEf/3khi2stMpTHPVNwFdvZq/Z4Ky93lE+MGHpXCRpMkSCA==",
       "dev": true,
       "requires": {
         "@mapbox/node-pre-gyp": "^1.0.5",

--- a/src/build/functions/edge.ts
+++ b/src/build/functions/edge.ts
@@ -65,10 +65,7 @@ const writeHandlerFile = async (ctx: PluginContext, { matchers, name }: NextDefi
 
   // Writing a file with the matchers that should trigger this function. We'll
   // read this file from the function at runtime.
-  await writeFile(
-    join(handlerRuntimeDirectory, 'matchers.json'),
-    JSON.stringify(augmentMatchers(matchers, ctx)),
-  )
+  await writeFile(join(handlerRuntimeDirectory, 'matchers.json'), JSON.stringify(matchers))
 
   // The config is needed by the edge function to match and normalize URLs. To
   // avoid shipping and parsing a large file at runtime, let's strip it down to

--- a/tests/fixtures/middleware-conditions/middleware.ts
+++ b/tests/fixtures/middleware-conditions/middleware.ts
@@ -19,7 +19,7 @@ export const config = {
       source: '/hello',
     },
     {
-      source: '/nl-NL/about',
+      source: '/nl/about',
       locale: false,
     },
   ],

--- a/tests/integration/edge-handler.test.ts
+++ b/tests/integration/edge-handler.test.ts
@@ -248,7 +248,7 @@ describe("aborts middleware execution when the matcher conditions don't match th
     expect(origin.calls).toBe(2)
   })
 
-  test<FixtureTestContext>('should handle locale matching correctly', async (ctx) => {
+  test.only<FixtureTestContext>('should handle locale matching correctly', async (ctx) => {
     await createFixture('middleware-conditions', ctx)
     await runPlugin(ctx)
 
@@ -275,16 +275,13 @@ describe("aborts middleware execution when the matcher conditions don't match th
       expect(response.status).toBe(200)
     }
 
-    for (const path of ['/hello/invalid', '/about', '/en/about']) {
+    for (const path of ['/hello/invalid', '/invalid/hello', '/about', '/en/about']) {
       const response = await invokeEdgeFunction(ctx, {
         functions: ['___netlify-edge-handler-middleware'],
         origin,
         url: path,
       })
-      expect(
-        response.headers.has('x-hello-from-middleware-res'),
-        `does not match ${path}`,
-      ).toBeFalsy()
+      expect(response.headers.has('x-hello-from-middleware-res'), `does match ${path}`).toBeFalsy()
       expect(await response.text()).toBe('Hello from origin!')
       expect(response.status).toBe(200)
     }

--- a/tests/integration/edge-handler.test.ts
+++ b/tests/integration/edge-handler.test.ts
@@ -261,7 +261,7 @@ describe("aborts middleware execution when the matcher conditions don't match th
 
     ctx.cleanup?.push(() => origin.stop())
 
-    for (const path of ['/hello', '/en/hello', '/nl-NL/about']) {
+    for (const path of ['/hello', '/en/hello', '/es/hello', '/nl/about']) {
       const response = await invokeEdgeFunction(ctx, {
         functions: ['___netlify-edge-handler-middleware'],
         origin,
@@ -275,7 +275,7 @@ describe("aborts middleware execution when the matcher conditions don't match th
       expect(response.status).toBe(200)
     }
 
-    for (const path of ['/hello/invalid', '/invalid/hello', '/about', '/en/about']) {
+    for (const path of ['/hello/invalid', '/invalid/hello', '/about', '/en/about', '/es/about']) {
       const response = await invokeEdgeFunction(ctx, {
         functions: ['___netlify-edge-handler-middleware'],
         origin,

--- a/tests/integration/edge-handler.test.ts
+++ b/tests/integration/edge-handler.test.ts
@@ -248,7 +248,7 @@ describe("aborts middleware execution when the matcher conditions don't match th
     expect(origin.calls).toBe(2)
   })
 
-  test.only<FixtureTestContext>('should handle locale matching correctly', async (ctx) => {
+  test<FixtureTestContext>('should handle locale matching correctly', async (ctx) => {
     await createFixture('middleware-conditions', ctx)
     await runPlugin(ctx)
 

--- a/tests/integration/edge-handler.test.ts
+++ b/tests/integration/edge-handler.test.ts
@@ -267,7 +267,10 @@ describe("aborts middleware execution when the matcher conditions don't match th
         origin,
         url: path,
       })
-      expect(response.headers.has('x-hello-from-middleware-res'), `does match ${path}`).toBeTruthy()
+      expect(
+        response.headers.has('x-hello-from-middleware-res'),
+        `does not match ${path}`,
+      ).toBeTruthy()
       expect(await response.text()).toBe('Hello from origin!')
       expect(response.status).toBe(200)
     }

--- a/tests/integration/edge-handler.test.ts
+++ b/tests/integration/edge-handler.test.ts
@@ -269,7 +269,7 @@ describe("aborts middleware execution when the matcher conditions don't match th
       })
       expect(
         response.headers.has('x-hello-from-middleware-res'),
-        `does not match ${path}`,
+        `should match ${path}`,
       ).toBeTruthy()
       expect(await response.text()).toBe('Hello from origin!')
       expect(response.status).toBe(200)
@@ -281,7 +281,10 @@ describe("aborts middleware execution when the matcher conditions don't match th
         origin,
         url: path,
       })
-      expect(response.headers.has('x-hello-from-middleware-res'), `does match ${path}`).toBeFalsy()
+      expect(
+        response.headers.has('x-hello-from-middleware-res'),
+        `should not match ${path}`,
+      ).toBeFalsy()
       expect(await response.text()).toBe('Hello from origin!')
       expect(response.status).toBe(200)
     }

--- a/tests/integration/edge-handler.test.ts
+++ b/tests/integration/edge-handler.test.ts
@@ -261,7 +261,7 @@ describe("aborts middleware execution when the matcher conditions don't match th
 
     ctx.cleanup?.push(() => origin.stop())
 
-    for (const path of ['/hello', '/en/hello', '/nl-NL/hello', '/nl-NL/about']) {
+    for (const path of ['/hello', '/en/hello', '/nl-NL/about']) {
       const response = await invokeEdgeFunction(ctx, {
         functions: ['___netlify-edge-handler-middleware'],
         origin,


### PR DESCRIPTION
## Description

Middleware matching is performed at the edge and also in the edge function because there are some patterns we are unable to evaluate at the edge.

When i18n is enabled, the regex generated by Next matches paths with or without a locale in the first segment of the URL path. However, it does not match the specific list of locales and simply matches _any string_ in the first segment.

This is a problem because `/test` will also match any page at the next level, e.g. `/products/test` because the matcher assumes `products` is a locale.

This PR splits URL normalizing and localizing into separate functions, for clarity and type-safety (`buildNextRequest` now returns a partial `NextRequest` object), and returns a `localizedURL` parameter to the middleware matcher so that the above case is avoided by always evaluating the match using the prefixed locale or the default, e.g. `/en/products/test`.

## Tests

1. Tests have been updated to catch this case

## Relevant links (GitHub issues, etc.) or a picture of cute animal

Fixes FRP-761