### PR TITLE
fix: apply type: module only to runtime modules

### DIFF
--- a/src/build/content/server.ts
+++ b/src/build/content/server.ts
@@ -260,9 +260,9 @@ export const copyNextDependencies = async (ctx: PluginContext): Promise<void> =>
   await tracer.withActiveSpan('copyNextDependencies', async () => {
     const entries = await readdir(ctx.standaloneDir)
     const promises: Promise<void>[] = entries.map(async (entry) => {
-      // copy all except the package.json and distDir (.next) folder as this is handled in a separate function
+      // copy all except the distDir (.next) folder as this is handled in a separate function
       // this will include the node_modules folder as well
-      if (entry === 'package.json' || entry === ctx.nextDistDir) {
+      if (entry === ctx.nextDistDir) {
         return
       }
       const src = join(ctx.standaloneDir, entry)

--- a/src/build/plugin-context.ts
+++ b/src/build/plugin-context.ts
@@ -182,6 +182,10 @@ export class PluginContext {
     return join(this.serverHandlerRootDir, this.distDirParent)
   }
 
+  get serverHandlerRuntimeModulesDir(): string {
+    return join(this.serverHandlerDir, '.netlify')
+  }
+
   get nextServerHandler(): string {
     if (this.relativeAppDir.length !== 0) {
       return join(this.lambdaWorkingDirectory, '.netlify/dist/run/handlers/server.js')

--- a/tests/e2e/simple-app.test.ts
+++ b/tests/e2e/simple-app.test.ts
@@ -252,3 +252,14 @@ test('Compressed rewrites are readable', async ({ simple }) => {
   expect(resp.headers.get('content-encoding')).toEqual('br')
   expect(await resp.text()).toContain('<title>Example Domain</title>')
 })
+
+test('can require CJS module that is not bundled', async ({ simple }) => {
+  const resp = await fetch(`${simple.url}/api/cjs-file-with-js-extension`)
+
+  expect(resp.status).toBe(200)
+
+  const parsedBody = await resp.json()
+
+  expect(parsedBody.notBundledCJSModule.isBundled).toEqual(false)
+  expect(parsedBody.bundledCJSModule.isBundled).toEqual(true)
+})

--- a/tests/fixtures/simple/app/api/cjs-file-with-js-extension/bundled.cjs
+++ b/tests/fixtures/simple/app/api/cjs-file-with-js-extension/bundled.cjs
@@ -1,0 +1,9 @@
+const { parse: pathParse } = require('node:path')
+
+const fileBase = pathParse(__filename).base
+
+module.exports = {
+  fileBase,
+  // if fileBase is not the same as this module name, it was bundled
+  isBundled: fileBase !== 'bundled.cjs',
+}

--- a/tests/fixtures/simple/app/api/cjs-file-with-js-extension/route.js
+++ b/tests/fixtures/simple/app/api/cjs-file-with-js-extension/route.js
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server'
+import { resolve } from 'node:path'
+
+export async function GET() {
+  return NextResponse.json({
+    notBundledCJSModule: __non_webpack_require__(resolve('./cjs-file-with-js-extension.js')),
+    bundledCJSModule: require('./bundled.cjs'),
+  })
+}
+
+export const dynamic = 'force-dynamic'

--- a/tests/fixtures/simple/cjs-file-with-js-extension.js
+++ b/tests/fixtures/simple/cjs-file-with-js-extension.js
@@ -1,0 +1,9 @@
+const { parse: pathParse } = require('node:path')
+
+const fileBase = pathParse(__filename).base
+
+module.exports = {
+  fileBase,
+  // if fileBase is not the same as this module name, it was bundled
+  isBundled: fileBase !== 'cjs-file-with-js-extension.js',
+}

--- a/tests/integration/simple-app.test.ts
+++ b/tests/integration/simple-app.test.ts
@@ -245,6 +245,20 @@ test.skipIf(process.env.NEXT_VERSION !== 'canary')<FixtureTestContext>(
   },
 )
 
+test<FixtureTestContext>('can require CJS module that is not bundled', async (ctx) => {
+  await createFixture('simple', ctx)
+  await runPlugin(ctx)
+
+  const response = await invokeFunction(ctx, { url: '/api/cjs-file-with-js-extension' })
+
+  expect(response.statusCode).toBe(200)
+
+  const parsedBody = JSON.parse(response.body)
+
+  expect(parsedBody.notBundledCJSModule.isBundled).toEqual(false)
+  expect(parsedBody.bundledCJSModule.isBundled).toEqual(true)
+})
+
 describe('next patching', async () => {
   const { cp: originalCp, appendFile } = (await vi.importActual(
     'node:fs/promises',


### PR DESCRIPTION

## Description

We are setting entire request handler function dir as `type: 'module'` right now, which result in `ERR_REQUIRE_ESM` kind of errors when `.js` file which is actually CJS is being required.

### Documentation

<!-- Where is this feature or API documented? Did you create an internal and/or external artifact to document this change? -->

## Tests

Integration and e2e test added using same fixture - both fail. Integration test output https://github.com/netlify/next-runtime/actions/runs/9992611474/job/27618021931?pr=2549#step:12:151 showing `ERR_REQUIRE_ESM` error (e2e only see 500 status, as error is hidden in function logs).

Second commit makes them pass.

## Relevant links (GitHub issues, etc.) or a picture of cute animal

<!-- Link to an issue that is fixed by this PR or related to this PR. -->
