### PR TITLE
fix: edge-middleware i18n matching

### DIFF
--- a/edge-runtime/lib/next-request.ts
+++ b/edge-runtime/lib/next-request.ts
@@ -2,6 +2,7 @@ import type { Context } from '@netlify/edge-functions'
 
 import {
   addBasePath,
+  addLocale,
   addTrailingSlash,
   normalizeDataUrl,
   normalizeLocalePath,
@@ -70,6 +71,33 @@ const normalizeRequestURL = (
   return {
     url: url.toString(),
     detectedLocale,
+  }
+}
+
+export const localizeRequest = (
+  url: URL,
+  nextConfig?: {
+    basePath?: string
+    i18n?: I18NConfig | null
+  },
+): { localizedUrl: URL; locale?: string } => {
+  const localizedUrl = new URL(url)
+  localizedUrl.pathname = removeBasePath(localizedUrl.pathname, nextConfig?.basePath)
+
+  // Detect the locale from the URL
+  const { detectedLocale } = normalizeLocalePath(localizedUrl.pathname, nextConfig?.i18n?.locales)
+
+  // Add the locale to the URL if not already present
+  localizedUrl.pathname = addLocale(
+    localizedUrl.pathname,
+    detectedLocale ?? nextConfig?.i18n?.defaultLocale,
+  )
+
+  localizedUrl.pathname = addBasePath(localizedUrl.pathname, nextConfig?.basePath)
+
+  return {
+    localizedUrl,
+    locale: detectedLocale,
   }
 }
 

--- a/edge-runtime/lib/util.ts
+++ b/edge-runtime/lib/util.ts
@@ -36,7 +36,7 @@ export const addLocale = (path: string, locale?: string) => {
     path.toLowerCase() !== `/${locale.toLowerCase()}` &&
     !path.toLowerCase().startsWith(`/${locale.toLowerCase()}/`) &&
     !path.startsWith(`/api/`) &&
-    !path.startsWith(`/_next/static/`)
+    !path.startsWith(`/_next/`)
   ) {
     return `/${locale}${path}`
   }

--- a/edge-runtime/lib/util.ts
+++ b/edge-runtime/lib/util.ts
@@ -29,6 +29,20 @@ export const addBasePath = (path: string, basePath?: string) => {
   return path
 }
 
+// add locale prefix if not present, allowing for locale fallbacks
+export const addLocale = (path: string, locale?: string) => {
+  if (
+    locale &&
+    path.toLowerCase() !== `/${locale.toLowerCase()}` &&
+    !path.toLowerCase().startsWith(`/${locale.toLowerCase()}/`) &&
+    !path.startsWith(`/api/`) &&
+    !path.startsWith(`/_next/static/`)
+  ) {
+    return `/${locale}${path}`
+  }
+  return path
+}
+
 // https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/i18n/normalize-locale-path.ts
 
 export interface PathLocale {

--- a/src/build/functions/edge.ts
+++ b/src/build/functions/edge.ts
@@ -65,10 +65,7 @@ const writeHandlerFile = async (ctx: PluginContext, { matchers, name }: NextDefi
 
   // Writing a file with the matchers that should trigger this function. We'll
   // read this file from the function at runtime.
-  await writeFile(
-    join(handlerRuntimeDirectory, 'matchers.json'),
-    JSON.stringify(augmentMatchers(matchers, ctx)),
-  )
+  await writeFile(join(handlerRuntimeDirectory, 'matchers.json'), JSON.stringify(matchers))
 
   // The config is needed by the edge function to match and normalize URLs. To
   // avoid shipping and parsing a large file at runtime, let's strip it down to

--- a/tests/fixtures/middleware-conditions/middleware.ts
+++ b/tests/fixtures/middleware-conditions/middleware.ts
@@ -19,7 +19,7 @@ export const config = {
       source: '/hello',
     },
     {
-      source: '/nl-NL/about',
+      source: '/nl/about',
       locale: false,
     },
   ],

--- a/tests/integration/edge-handler.test.ts
+++ b/tests/integration/edge-handler.test.ts
@@ -261,18 +261,7 @@ describe("aborts middleware execution when the matcher conditions don't match th
 
     ctx.cleanup?.push(() => origin.stop())
 
-    for (const path of ['/hello', '/en/hello', '/nl-NL/hello', '/nl-NL/about']) {
-      const response = await invokeEdgeFunction(ctx, {
-        functions: ['___netlify-edge-handler-middleware'],
-        origin,
-        url: path,
-      })
-      expect(response.headers.has('x-hello-from-middleware-res'), `does match ${path}`).toBeTruthy()
-      expect(await response.text()).toBe('Hello from origin!')
-      expect(response.status).toBe(200)
-    }
-
-    for (const path of ['/hello/invalid', '/about', '/en/about']) {
+    for (const path of ['/hello', '/en/hello', '/nl/hello', '/nl/about']) {
       const response = await invokeEdgeFunction(ctx, {
         functions: ['___netlify-edge-handler-middleware'],
         origin,
@@ -280,7 +269,21 @@ describe("aborts middleware execution when the matcher conditions don't match th
       })
       expect(
         response.headers.has('x-hello-from-middleware-res'),
-        `does not match ${path}`,
+        `should match ${path}`,
+      ).toBeTruthy()
+      expect(await response.text()).toBe('Hello from origin!')
+      expect(response.status).toBe(200)
+    }
+
+    for (const path of ['/invalid/hello', '/hello/invalid', '/about', '/en/about']) {
+      const response = await invokeEdgeFunction(ctx, {
+        functions: ['___netlify-edge-handler-middleware'],
+        origin,
+        url: path,
+      })
+      expect(
+        response.headers.has('x-hello-from-middleware-res'),
+        `should not match ${path}`,
       ).toBeFalsy()
       expect(await response.text()).toBe('Hello from origin!')
       expect(response.status).toBe(200)


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/netlify/next-runtime/blob/main/CONTRIBUTING.md. -->

## Description

Scaled down version of https://github.com/netlify/next-runtime/pull/2548 which just adjusts what is being passed to matcher leaving everything else as-is

### Documentation

<!-- Where is this feature or API documented? Did you create an internal and/or external artifact to document this change? -->

## Tests

<!-- Did you add tests? How did you test this change? -->

You can test this change yourself like so:

1. TODO

## Relevant links (GitHub issues, etc.) or a picture of cute animal

<!-- Link to an issue that is fixed by this PR or related to this PR. -->
