### PR TITLE
fix: handle cases of chunked middleware

### DIFF
--- a/src/build/functions/edge.ts
+++ b/src/build/functions/edge.ts
@@ -125,7 +125,7 @@ const copyHandlerDependencies = async (
     const entrypoint = await readFile(join(srcDir, file), 'utf8')
     parts.push(`;// Concatenated file: ${file} \n`, entrypoint)
   }
-  const exports = `export default _ENTRIES["middleware_${name}"].default;`
+  const exports = `const middlewareEntryKey = Object.keys(_ENTRIES).find(entryKey => entryKey.startsWith("middleware_${name}")); export default _ENTRIES[middlewareEntryKey].default;`
   await mkdir(dirname(join(destDir, `server/${name}.js`)), { recursive: true })
 
   await writeFile(join(destDir, `server/${name}.js`), [...parts, exports].join('\n'))

--- a/tests/fixtures/middleware/next.config.js
+++ b/tests/fixtures/middleware/next.config.js
@@ -4,6 +4,13 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  webpack: (config) => {
+    // this is a trigger to generate multiple `.next/server/middleware-[hash].js` files instead of
+    // single `.next/server/middleware.js` file
+    config.optimization.splitChunks.maxSize = 100_000
+
+    return config
+  },
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/netlify/next-runtime/blob/main/CONTRIBUTING.md. -->

## Description

Custom user webpack config can result in middleware being chunked. Our middleware wrapper assumes unchunked case and will fail at edge function bundling step if it is chunked and result in user facing error like this:
> Cannot read properties of undefined (reading 'default')

Minified generated code for chunked case looks like this:
```
(_ENTRIES="undefined"==typeof _ENTRIES?{}:_ENTRIES)["middleware_middleware-7410c3f3"]=n}]);
//# sourceMappingURL=middleware-7410c3f3.js.map
export default _ENTRIES["middleware_middleware"].default;
```

And middleware manifest looking like this (relevant subset of it) :

```
"middleware": {
    "/": {
      "files": [
        "prerender-manifest.js",
        "server/edge-runtime-webpack.js",
        "server/middleware-f3956634.js",
        "server/middleware-8bfe7224.js",
        "server/middleware-7410c3f3.js"
      ],
```

Only one of those chunks actually seeds `_ENTRIES`, so the fix here is inspecting `_ENTRIES` object and finding which key starts with `middleware_${name}` instead of just trying to guess exact key. It will still find entry if it's not chunked.

### Documentation

<!-- Where is this feature or API documented? Did you create an internal and/or external artifact to document this change? -->

## Tests

One of middleware related fixtures adjusted to reproduce the issue (force middleware chunking), which result in our tests reproducing reported issue - https://github.com/netlify/next-runtime/actions/runs/10558115993/job/29246960707?pr=2574#step:13:295

## Relevant links (GitHub issues, etc.) or a picture of cute animal

https://linear.app/netlify/issue/FRP-1270/unable-to-bundle-middleware
