### PR TITLE
test(e2e): fix failures due to latest and canary releases

### DIFF
--- a/tests/e2e/cli-before-regional-blobs-support.test.ts
+++ b/tests/e2e/cli-before-regional-blobs-support.test.ts
@@ -22,12 +22,10 @@ test('should serve 404 page when requesting non existing page (no matching route
   // https://github.com/vercel/next.js/pull/69802 made changes to returned cache-control header,
   // after that (14.2.10 and canary.147) 404 pages would have `private` directive, before that it
   // would not
-  const shouldHavePrivateDirective = nextVersionSatisfies(
-    '>=14.2.10 <15.0.0 || >=15.0.0-canary.147',
-  )
+  const shouldHavePrivateDirective = nextVersionSatisfies('^14.2.10 || >=15.0.0-canary.147')
   expect(headers['netlify-cdn-cache-control']).toBe(
     (shouldHavePrivateDirective ? 'private, ' : '') +
-      'private, no-cache, no-store, max-age=0, must-revalidate, durable',
+      'no-cache, no-store, max-age=0, must-revalidate, durable',
   )
   expect(headers['cache-control']).toBe(
     (shouldHavePrivateDirective ? 'private,' : '') + 'no-cache,no-store,max-age=0,must-revalidate',

--- a/tests/e2e/cli-before-regional-blobs-support.test.ts
+++ b/tests/e2e/cli-before-regional-blobs-support.test.ts
@@ -1,5 +1,6 @@
 import { expect } from '@playwright/test'
 import { test } from '../utils/playwright-helpers.js'
+import { nextVersionSatisfies } from '../utils/next-version-helpers.mjs'
 
 test('should serve 404 page when requesting non existing page (no matching route) if site is deployed with CLI not supporting regional blobs', async ({
   page,
@@ -18,8 +19,17 @@ test('should serve 404 page when requesting non existing page (no matching route
 
   expect(await page.textContent('h1')).toBe('404')
 
-  expect(headers['netlify-cdn-cache-control']).toBe(
-    'no-cache, no-store, max-age=0, must-revalidate, durable',
+  // https://github.com/vercel/next.js/pull/69802 made changes to returned cache-control header,
+  // after that (14.2.10 and canary.147) 404 pages would have `private` directive, before that it
+  // would not
+  const shouldHavePrivateDirective = nextVersionSatisfies(
+    '>=14.2.10 <15.0.0 || >=15.0.0-canary.147',
   )
-  expect(headers['cache-control']).toBe('no-cache,no-store,max-age=0,must-revalidate')
+  expect(headers['netlify-cdn-cache-control']).toBe(
+    (shouldHavePrivateDirective ? 'private, ' : '') +
+      'private, no-cache, no-store, max-age=0, must-revalidate, durable',
+  )
+  expect(headers['cache-control']).toBe(
+    (shouldHavePrivateDirective ? 'private,' : '') + 'no-cache,no-store,max-age=0,must-revalidate',
+  )
 })

--- a/tests/e2e/page-router.test.ts
+++ b/tests/e2e/page-router.test.ts
@@ -1,5 +1,6 @@
 import { expect } from '@playwright/test'
 import { test } from '../utils/playwright-helpers.js'
+import { nextVersionSatisfies } from '../utils/next-version-helpers.mjs'
 
 export function waitFor(millis: number) {
   return new Promise((resolve) => setTimeout(resolve, millis))
@@ -340,10 +341,20 @@ test.describe('Simple Page Router (no basePath, no i18n)', () => {
 
     expect(await page.textContent('h1')).toBe('404')
 
-    expect(headers['netlify-cdn-cache-control']).toBe(
-      'no-cache, no-store, max-age=0, must-revalidate, durable',
+    // https://github.com/vercel/next.js/pull/69802 made changes to returned cache-control header,
+    // after that (14.2.10 and canary.147) 404 pages would have `private` directive, before that
+    // it would not
+    const shouldHavePrivateDirective = nextVersionSatisfies(
+      '>=14.2.10 <15.0.0 || >=15.0.0-canary.147',
     )
-    expect(headers['cache-control']).toBe('no-cache,no-store,max-age=0,must-revalidate')
+    expect(headers['netlify-cdn-cache-control']).toBe(
+      (shouldHavePrivateDirective ? 'private, ' : '') +
+        'no-cache, no-store, max-age=0, must-revalidate, durable',
+    )
+    expect(headers['cache-control']).toBe(
+      (shouldHavePrivateDirective ? 'private,' : '') +
+        'no-cache,no-store,max-age=0,must-revalidate',
+    )
   })
 
   test('should serve 404 page when requesting non existing page (marked with notFound: true in getStaticProps)', async ({
@@ -1039,10 +1050,19 @@ test.describe('Page Router with basePath and i18n', () => {
 
     expect(await page.textContent('h1')).toBe('404')
 
-    expect(headers['netlify-cdn-cache-control']).toBe(
-      'no-cache, no-store, max-age=0, must-revalidate, durable',
+    // https://github.com/vercel/next.js/pull/69802 made changes to returned cache-control header,
+    // after that 404 pages would have `private` directive, before that it would not
+    const shouldHavePrivateDirective = nextVersionSatisfies(
+      '>=14.2.10 <15.0.0 || >=15.0.0-canary.147',
     )
-    expect(headers['cache-control']).toBe('no-cache,no-store,max-age=0,must-revalidate')
+    expect(headers['netlify-cdn-cache-control']).toBe(
+      (shouldHavePrivateDirective ? 'private, ' : '') +
+        'no-cache, no-store, max-age=0, must-revalidate, durable',
+    )
+    expect(headers['cache-control']).toBe(
+      (shouldHavePrivateDirective ? 'private,' : '') +
+        'no-cache,no-store,max-age=0,must-revalidate',
+    )
   })
 
   test('requesting a non existing page route that needs to be fetched from the blob store like 404.html (notFound: true)', async ({

--- a/tests/e2e/page-router.test.ts
+++ b/tests/e2e/page-router.test.ts
@@ -344,9 +344,7 @@ test.describe('Simple Page Router (no basePath, no i18n)', () => {
     // https://github.com/vercel/next.js/pull/69802 made changes to returned cache-control header,
     // after that (14.2.10 and canary.147) 404 pages would have `private` directive, before that
     // it would not
-    const shouldHavePrivateDirective = nextVersionSatisfies(
-      '>=14.2.10 <15.0.0 || >=15.0.0-canary.147',
-    )
+    const shouldHavePrivateDirective = nextVersionSatisfies('^14.2.10 || >=15.0.0-canary.147')
     expect(headers['netlify-cdn-cache-control']).toBe(
       (shouldHavePrivateDirective ? 'private, ' : '') +
         'no-cache, no-store, max-age=0, must-revalidate, durable',
@@ -1052,9 +1050,7 @@ test.describe('Page Router with basePath and i18n', () => {
 
     // https://github.com/vercel/next.js/pull/69802 made changes to returned cache-control header,
     // after that 404 pages would have `private` directive, before that it would not
-    const shouldHavePrivateDirective = nextVersionSatisfies(
-      '>=14.2.10 <15.0.0 || >=15.0.0-canary.147',
-    )
+    const shouldHavePrivateDirective = nextVersionSatisfies('^14.2.10 || >=15.0.0-canary.147')
     expect(headers['netlify-cdn-cache-control']).toBe(
       (shouldHavePrivateDirective ? 'private, ' : '') +
         'no-cache, no-store, max-age=0, must-revalidate, durable',

--- a/tests/e2e/simple-app.test.ts
+++ b/tests/e2e/simple-app.test.ts
@@ -224,7 +224,7 @@ test('requesting a non existing page route that needs to be fetched from the blo
   // would not ... and then https://github.com/vercel/next.js/pull/69802 changed it back again
   // (14.2.10 and canary.147)
   const shouldHavePrivateDirective = nextVersionSatisfies(
-    '<14.2.4 || >=14.2.10 < 15 || <15.0.0-canary.24 || >= 15.0.0-canary.147',
+    '<14.2.4 || >=14.2.10 <15.0.0-canary.24 || ^15.0.0-canary.147',
   )
 
   expect(headers['netlify-cdn-cache-control']).toBe(

--- a/tests/e2e/simple-app.test.ts
+++ b/tests/e2e/simple-app.test.ts
@@ -220,8 +220,12 @@ test('requesting a non existing page route that needs to be fetched from the blo
   expect(await page.textContent('h1')).toBe('404 Not Found')
 
   // https://github.com/vercel/next.js/pull/66674 made changes to returned cache-control header,
-  // before that 404 page would have `private` directive, after that it would not
-  const shouldHavePrivateDirective = !nextVersionSatisfies('>=14.2.4 <15.0.0 || >=15.0.0-canary.24')
+  // before that 404 page would have `private` directive, after that (14.2.4 and canary.24) it
+  // would not ... and then https://github.com/vercel/next.js/pull/69802 changed it back again
+  // (14.2.10 and canary.147)
+  const shouldHavePrivateDirective = nextVersionSatisfies(
+    '<14.2.4 || >=14.2.10 < 15 || <15.0.0-canary.24 || >= 15.0.0-canary.147',
+  )
 
   expect(headers['netlify-cdn-cache-control']).toBe(
     (shouldHavePrivateDirective ? 'private, ' : '') +


### PR DESCRIPTION
## Description

[v14.2.10](https://github.com/vercel/next.js/releases/tag/v14.2.10) and [v15.0.0-canary.147](https://github.com/vercel/next.js/releases/tag/v15.0.0-canary.147) included https://github.com/vercel/next.js/pull/69802 which added `private` back into `no-cache,no-store` `cache-control` headers in some cases.

There are still failures after this fix but they are caused by two (three?) additional unrelated issues.

<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/netlify/next-runtime/blob/main/CONTRIBUTING.md. -->

### Documentation

N/A

## Tests

N/A

## Relevant links (GitHub issues, etc.) or a picture of cute animal

N/A
