### PR TITLE
fix: use durable cache for stale responses

### DIFF
--- a/src/run/headers.test.ts
+++ b/src/run/headers.test.ts
@@ -238,7 +238,7 @@ describe('headers', () => {
         expect(headers.set).toHaveBeenNthCalledWith(
           1,
           'netlify-cdn-cache-control',
-          'public, max-age=0, must-revalidate',
+          'public, max-age=0, must-revalidate, durable',
         )
       })
 
@@ -257,7 +257,7 @@ describe('headers', () => {
         expect(headers.set).toHaveBeenNthCalledWith(
           1,
           'netlify-cdn-cache-control',
-          'public, max-age=0, must-revalidate',
+          'public, max-age=0, must-revalidate, durable',
         )
       })
 

--- a/src/run/headers.ts
+++ b/src/run/headers.ts
@@ -224,7 +224,7 @@ export const setCacheControlHeaders = (
     const cdnCacheControl =
       // if we are serving already stale response, instruct edge to not attempt to cache that response
       headers.get('x-nextjs-cache') === 'STALE'
-        ? 'public, max-age=0, must-revalidate'
+        ? 'public, max-age=0, must-revalidate, durable'
         : `s-maxage=${requestContext.routeHandlerRevalidate === false ? 31536000 : requestContext.routeHandlerRevalidate}, stale-while-revalidate=31536000, durable`
 
     headers.set('netlify-cdn-cache-control', cdnCacheControl)
@@ -246,7 +246,7 @@ export const setCacheControlHeaders = (
     const cdnCacheControl =
       // if we are serving already stale response, instruct edge to not attempt to cache that response
       headers.get('x-nextjs-cache') === 'STALE'
-        ? 'public, max-age=0, must-revalidate'
+        ? 'public, max-age=0, must-revalidate, durable'
         : [
             ...getHeaderValueArray(cacheControl).map((value) =>
               value === 'stale-while-revalidate' ? 'stale-while-revalidate=31536000' : value,

--- a/tests/integration/cache-handler.test.ts
+++ b/tests/integration/cache-handler.test.ts
@@ -65,7 +65,7 @@ describe('page router', () => {
     expect(call1.headers, 'a stale page served with swr').toEqual(
       expect.objectContaining({
         'cache-status': '"Next.js"; hit; fwd=stale',
-        'netlify-cdn-cache-control': 'public, max-age=0, must-revalidate',
+        'netlify-cdn-cache-control': 'public, max-age=0, must-revalidate, durable',
       }),
     )
 
@@ -223,7 +223,7 @@ describe('app router', () => {
       // It will be stale instead of hit
       expect.objectContaining({
         'cache-status': '"Next.js"; hit; fwd=stale',
-        'netlify-cdn-cache-control': 'public, max-age=0, must-revalidate',
+        'netlify-cdn-cache-control': 'public, max-age=0, must-revalidate, durable',
       }),
     )
     expect(

--- a/tests/integration/fetch-handler.test.ts
+++ b/tests/integration/fetch-handler.test.ts
@@ -195,7 +195,7 @@ test<FixtureTestContext>('if the fetch call is cached correctly (cached page res
   expect(post1.headers, 'a stale page served with swr').toEqual(
     expect.objectContaining({
       'cache-status': '"Next.js"; hit; fwd=stale',
-      'netlify-cdn-cache-control': 'public, max-age=0, must-revalidate',
+      'netlify-cdn-cache-control': 'public, max-age=0, must-revalidate, durable',
     }),
   )
 
@@ -264,7 +264,7 @@ test<FixtureTestContext>('if the fetch call is cached correctly (cached page res
   expect(post3.headers, 'a stale page served with swr').toEqual(
     expect.objectContaining({
       'cache-status': '"Next.js"; hit; fwd=stale',
-      'netlify-cdn-cache-control': 'public, max-age=0, must-revalidate',
+      'netlify-cdn-cache-control': 'public, max-age=0, must-revalidate, durable',
     }),
   )
 

--- a/tests/integration/simple-app.test.ts
+++ b/tests/integration/simple-app.test.ts
@@ -198,7 +198,7 @@ test<FixtureTestContext>('cacheable route handler is cached on cdn (revalidate=1
   const firstTimeCachedResponse = await invokeFunction(ctx, { url: '/api/cached-revalidate' })
   // this will be "stale" response from build
   expect(firstTimeCachedResponse.headers['netlify-cdn-cache-control']).toBe(
-    'public, max-age=0, must-revalidate',
+    'public, max-age=0, must-revalidate, durable',
   )
 
   // allow server to regenerate fresh response in background


### PR DESCRIPTION
## Description

We are currently not applying `durable` directive when serving stale responses which cause issues with updating durable cache

## Tests

Updated test assertions

## Relevant links (GitHub issues, etc.) or a picture of cute animal

Fixes https://linear.app/netlify/issue/FRP-1320/add-missing-durable-directive-for-stale-responses
