### PR TITLE
fix: handle non ASCII characters in cache-tag headers

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
     extraHTTPHeaders: {
       /* Add debug logging for netlify cache headers */
       'x-nf-debug-logging': '1',
+      'x-next-debug-logging': '1',
     },
   },
   timeout: 10 * 60 * 1000,

--- a/src/run/handlers/cache.cts
+++ b/src/run/handlers/cache.cts
@@ -147,7 +147,9 @@ export class NetlifyCacheHandler implements CacheHandlerForMultipleVersions {
       ) {
         // pages router doesn't have cache tags headers in PAGE cache value
         // so we need to generate appropriate cache tags for it
-        const cacheTags = [`_N_T_${key === '/index' ? '/' : key}`]
+        // encode here to deal with non ASCII characters in the key
+
+        const cacheTags = [`_N_T_${key === '/index' ? '/' : encodeURI(key)}`]
         requestContext.responseCacheTags = cacheTags
       }
     }
@@ -341,7 +343,8 @@ export class NetlifyCacheHandler implements CacheHandlerForMultipleVersions {
       if (data?.kind === 'PAGE' || data?.kind === 'PAGES') {
         const requestContext = getRequestContext()
         if (requestContext?.didPagesRouterOnDemandRevalidate) {
-          const tag = `_N_T_${key === '/index' ? '/' : key}`
+          // encode here to deal with non ASCII characters in the key
+          const tag = `_N_T_${key === '/index' ? '/' : encodeURI(key)}`
           getLogger().debug(`Purging CDN cache for: [${tag}]`)
           requestContext.trackBackgroundWork(
             purgeCache({ tags: [tag] }).catch((error) => {

--- a/tests/e2e/on-demand-app.test.ts
+++ b/tests/e2e/on-demand-app.test.ts
@@ -48,16 +48,16 @@ test.describe('app router on-demand revalidation', () => {
     {
       label: 'revalidatePath (prerendered page with dynamic path) - non-ASCII variant',
       prerendered: true,
-      pagePath: '/product/事前レンダリング',
-      revalidateApiPath: `/api/on-demand-revalidate/path?path=/product/事前レンダリング`,
-      expectedH1Content: 'Product 事前レンダリング',
+      pagePath: '/product/事前レンダリング,test',
+      revalidateApiPath: `/api/on-demand-revalidate/path?path=/product/事前レンダリング,test`,
+      expectedH1Content: 'Product 事前レンダリング,test',
     },
     {
       label: 'revalidatePath (not prerendered page with dynamic path) - non-ASCII variant',
       prerendered: false,
-      pagePath: '/product/事前レンダリングされていない',
-      revalidateApiPath: `/api/on-demand-revalidate/path?path=/product/事前レンダリングされていない`,
-      expectedH1Content: 'Product 事前レンダリングされていない',
+      pagePath: '/product/事前レンダリングされていない,test',
+      revalidateApiPath: `/api/on-demand-revalidate/path?path=/product/事前レンダリングされていない,test`,
+      expectedH1Content: 'Product 事前レンダリングされていない,test',
     },
   ]) {
     test(label, async ({ page, pollUntilHeadersMatch, serverComponents }) => {

--- a/tests/e2e/on-demand-app.test.ts
+++ b/tests/e2e/on-demand-app.test.ts
@@ -45,6 +45,20 @@ test.describe('app router on-demand revalidation', () => {
       revalidateApiPath: '/api/on-demand-revalidate/tag?tag=show-4',
       expectedH1Content: 'Hello, Statically fetched show 4',
     },
+    {
+      label: 'revalidatePath (prerendered page with dynamic path) - non-ASCII variant',
+      prerendered: true,
+      pagePath: '/product/事前レンダリング',
+      revalidateApiPath: `/api/on-demand-revalidate/path?path=/product/事前レンダリング`,
+      expectedH1Content: 'Product 事前レンダリング',
+    },
+    {
+      label: 'revalidatePath (not prerendered page with dynamic path) - non-ASCII variant',
+      prerendered: false,
+      pagePath: '/product/事前レンダリングされていない',
+      revalidateApiPath: `/api/on-demand-revalidate/path?path=/product/事前レンダリングされていない`,
+      expectedH1Content: 'Product 事前レンダリングされていない',
+    },
   ]) {
     test(label, async ({ page, pollUntilHeadersMatch, serverComponents }) => {
       // in case there is retry or some other test did hit that path before

--- a/tests/e2e/page-router.test.ts
+++ b/tests/e2e/page-router.test.ts
@@ -80,12 +80,28 @@ test.describe('Simple Page Router (no basePath, no i18n)', () => {
         revalidateApiBasePath: '/api/revalidate-no-await',
         expectedH1Content: 'Product not-prerendered-and-not-awaited-revalidation',
       },
+      {
+        label:
+          'prerendered page with dynamic path and awaited res.revalidate() - non-ASCII variant',
+        prerendered: true,
+        pagePath: '/products/事前レンダリング',
+        revalidateApiBasePath: '/api/revalidate',
+        expectedH1Content: 'Product 事前レンダリング',
+      },
+      {
+        label:
+          'not prerendered page with dynamic path and awaited res.revalidate() - non-ASCII variant',
+        prerendered: false,
+        pagePath: '/products/事前レンダリングされていない',
+        revalidateApiBasePath: '/api/revalidate',
+        expectedH1Content: 'Product 事前レンダリングされていない',
+      },
     ]) {
       test(label, async ({ page, pollUntilHeadersMatch, pageRouter }) => {
         // in case there is retry or some other test did hit that path before
         // we want to make sure that cdn cache is not warmed up
         const purgeCdnCache = await page.goto(
-          new URL(`/api/purge-cdn?path=${pagePath}`, pageRouter.url).href,
+          new URL(`/api/purge-cdn?path=${encodeURI(pagePath)}`, pageRouter.url).href,
         )
         expect(purgeCdnCache?.status()).toBe(200)
 
@@ -110,7 +126,7 @@ test.describe('Simple Page Router (no basePath, no i18n)', () => {
         const headers1 = response1?.headers() || {}
         expect(response1?.status()).toBe(200)
         expect(headers1['x-nextjs-cache']).toBeUndefined()
-        expect(headers1['netlify-cache-tag']).toBe(`_n_t_${pagePath}`)
+        expect(headers1['netlify-cache-tag']).toBe(`_n_t_${encodeURI(pagePath).toLowerCase()}`)
         expect(headers1['netlify-cdn-cache-control']).toBe(
           's-maxage=31536000, stale-while-revalidate=31536000, durable',
         )
@@ -138,7 +154,7 @@ test.describe('Simple Page Router (no basePath, no i18n)', () => {
         const headers1Json = response1Json?.headers() || {}
         expect(response1Json?.status()).toBe(200)
         expect(headers1Json['x-nextjs-cache']).toBeUndefined()
-        expect(headers1Json['netlify-cache-tag']).toBe(`_n_t_${pagePath}`)
+        expect(headers1Json['netlify-cache-tag']).toBe(`_n_t_${encodeURI(pagePath).toLowerCase()}`)
         expect(headers1Json['netlify-cdn-cache-control']).toBe(
           's-maxage=31536000, stale-while-revalidate=31536000, durable',
         )
@@ -459,14 +475,32 @@ test.describe('Page Router with basePath and i18n', () => {
         revalidateApiBasePath: '/api/revalidate-no-await',
         expectedH1Content: 'Product not-prerendered-and-not-awaited-revalidation',
       },
+      {
+        label:
+          'prerendered page with dynamic path and awaited res.revalidate() - non-ASCII variant',
+        prerendered: true,
+        pagePath: '/products/事前レンダリング',
+        revalidateApiBasePath: '/api/revalidate',
+        expectedH1Content: 'Product 事前レンダリング',
+      },
+      {
+        label:
+          'not prerendered page with dynamic path and awaited res.revalidate() - non-ASCII variant',
+        prerendered: false,
+        pagePath: '/products/事前レンダリングされていない',
+        revalidateApiBasePath: '/api/revalidate',
+        expectedH1Content: 'Product 事前レンダリングされていない',
+      },
     ]) {
       test.describe(label, () => {
         test(`default locale`, async ({ page, pollUntilHeadersMatch, pageRouterBasePathI18n }) => {
           // in case there is retry or some other test did hit that path before
           // we want to make sure that cdn cache is not warmed up
           const purgeCdnCache = await page.goto(
-            new URL(`/base/path/api/purge-cdn?path=/en${pagePath}`, pageRouterBasePathI18n.url)
-              .href,
+            new URL(
+              `/base/path/api/purge-cdn?path=/en${encodeURI(pagePath)}`,
+              pageRouterBasePathI18n.url,
+            ).href,
           )
           expect(purgeCdnCache?.status()).toBe(200)
 
@@ -494,7 +528,9 @@ test.describe('Page Router with basePath and i18n', () => {
           const headers1ImplicitLocale = response1ImplicitLocale?.headers() || {}
           expect(response1ImplicitLocale?.status()).toBe(200)
           expect(headers1ImplicitLocale['x-nextjs-cache']).toBeUndefined()
-          expect(headers1ImplicitLocale['netlify-cache-tag']).toBe(`_n_t_/en${pagePath}`)
+          expect(headers1ImplicitLocale['netlify-cache-tag']).toBe(
+            `_n_t_/en${encodeURI(pagePath).toLowerCase()}`,
+          )
           expect(headers1ImplicitLocale['netlify-cdn-cache-control']).toBe(
             's-maxage=31536000, stale-while-revalidate=31536000, durable',
           )
@@ -520,7 +556,9 @@ test.describe('Page Router with basePath and i18n', () => {
           const headers1ExplicitLocale = response1ExplicitLocale?.headers() || {}
           expect(response1ExplicitLocale?.status()).toBe(200)
           expect(headers1ExplicitLocale['x-nextjs-cache']).toBeUndefined()
-          expect(headers1ExplicitLocale['netlify-cache-tag']).toBe(`_n_t_/en${pagePath}`)
+          expect(headers1ExplicitLocale['netlify-cache-tag']).toBe(
+            `_n_t_/en${encodeURI(pagePath).toLowerCase()}`,
+          )
           expect(headers1ExplicitLocale['netlify-cdn-cache-control']).toBe(
             's-maxage=31536000, stale-while-revalidate=31536000, durable',
           )
@@ -552,7 +590,9 @@ test.describe('Page Router with basePath and i18n', () => {
           const headers1Json = response1Json?.headers() || {}
           expect(response1Json?.status()).toBe(200)
           expect(headers1Json['x-nextjs-cache']).toBeUndefined()
-          expect(headers1Json['netlify-cache-tag']).toBe(`_n_t_/en${pagePath}`)
+          expect(headers1Json['netlify-cache-tag']).toBe(
+            `_n_t_/en${encodeURI(pagePath).toLowerCase()}`,
+          )
           expect(headers1Json['netlify-cdn-cache-control']).toBe(
             's-maxage=31536000, stale-while-revalidate=31536000, durable',
           )
@@ -870,7 +910,7 @@ test.describe('Page Router with basePath and i18n', () => {
           const headers1 = response1?.headers() || {}
           expect(response1?.status()).toBe(200)
           expect(headers1['x-nextjs-cache']).toBeUndefined()
-          expect(headers1['netlify-cache-tag']).toBe(`_n_t_/de${pagePath}`)
+          expect(headers1['netlify-cache-tag']).toBe(`_n_t_/de${encodeURI(pagePath).toLowerCase()}`)
           expect(headers1['netlify-cdn-cache-control']).toBe(
             's-maxage=31536000, stale-while-revalidate=31536000, durable',
           )
@@ -899,7 +939,9 @@ test.describe('Page Router with basePath and i18n', () => {
           const headers1Json = response1Json?.headers() || {}
           expect(response1Json?.status()).toBe(200)
           expect(headers1Json['x-nextjs-cache']).toBeUndefined()
-          expect(headers1Json['netlify-cache-tag']).toBe(`_n_t_/de${pagePath}`)
+          expect(headers1Json['netlify-cache-tag']).toBe(
+            `_n_t_/de${encodeURI(pagePath).toLowerCase()}`,
+          )
           expect(headers1Json['netlify-cdn-cache-control']).toBe(
             's-maxage=31536000, stale-while-revalidate=31536000, durable',
           )

--- a/tests/e2e/page-router.test.ts
+++ b/tests/e2e/page-router.test.ts
@@ -84,17 +84,17 @@ test.describe('Simple Page Router (no basePath, no i18n)', () => {
         label:
           'prerendered page with dynamic path and awaited res.revalidate() - non-ASCII variant',
         prerendered: true,
-        pagePath: '/products/事前レンダリング',
+        pagePath: '/products/事前レンダリング,test',
         revalidateApiBasePath: '/api/revalidate',
-        expectedH1Content: 'Product 事前レンダリング',
+        expectedH1Content: 'Product 事前レンダリング,test',
       },
       {
         label:
           'not prerendered page with dynamic path and awaited res.revalidate() - non-ASCII variant',
         prerendered: false,
-        pagePath: '/products/事前レンダリングされていない',
+        pagePath: '/products/事前レンダリングされていない,test',
         revalidateApiBasePath: '/api/revalidate',
-        expectedH1Content: 'Product 事前レンダリングされていない',
+        expectedH1Content: 'Product 事前レンダリングされていない,test',
       },
     ]) {
       test(label, async ({ page, pollUntilHeadersMatch, pageRouter }) => {
@@ -479,17 +479,17 @@ test.describe('Page Router with basePath and i18n', () => {
         label:
           'prerendered page with dynamic path and awaited res.revalidate() - non-ASCII variant',
         prerendered: true,
-        pagePath: '/products/事前レンダリング',
+        pagePath: '/products/事前レンダリング,test',
         revalidateApiBasePath: '/api/revalidate',
-        expectedH1Content: 'Product 事前レンダリング',
+        expectedH1Content: 'Product 事前レンダリング,test',
       },
       {
         label:
           'not prerendered page with dynamic path and awaited res.revalidate() - non-ASCII variant',
         prerendered: false,
-        pagePath: '/products/事前レンダリングされていない',
+        pagePath: '/products/事前レンダリングされていない,test',
         revalidateApiBasePath: '/api/revalidate',
-        expectedH1Content: 'Product 事前レンダリングされていない',
+        expectedH1Content: 'Product 事前レンダリングされていない,test',
       },
     ]) {
       test.describe(label, () => {

--- a/tests/fixtures/page-router-base-path-i18n/pages/products/[slug].js
+++ b/tests/fixtures/page-router-base-path-i18n/pages/products/[slug].js
@@ -28,8 +28,8 @@ export const getStaticPaths = ({ locales }) => {
       },
       {
         params: {
-          // Japanese prerendered (non-ascii)
-          slug: '事前レンダリング',
+          // Japanese prerendered (non-ascii) and comma
+          slug: '事前レンダリング,test',
         },
       },
     ].flatMap((pathDescription) => locales.map((locale) => ({ ...pathDescription, locale }))),

--- a/tests/fixtures/page-router-base-path-i18n/pages/products/[slug].js
+++ b/tests/fixtures/page-router-base-path-i18n/pages/products/[slug].js
@@ -17,22 +17,22 @@ export async function getStaticProps({ params }) {
   }
 }
 
-export const getStaticPaths = () => {
+/** @type {import('next').GetStaticPaths} */
+export const getStaticPaths = ({ locales }) => {
   return {
     paths: [
       {
         params: {
           slug: 'prerendered',
         },
-        locale: 'en',
       },
       {
         params: {
-          slug: 'prerendered',
+          // Japanese prerendered (non-ascii)
+          slug: '事前レンダリング',
         },
-        locale: 'de',
       },
-    ],
+    ].flatMap((pathDescription) => locales.map((locale) => ({ ...pathDescription, locale }))),
     fallback: 'blocking', // false or "blocking"
   }
 }

--- a/tests/fixtures/page-router/pages/products/[slug].js
+++ b/tests/fixtures/page-router/pages/products/[slug].js
@@ -30,6 +30,12 @@ export const getStaticPaths = () => {
           slug: 'prerendered',
         },
       },
+      {
+        params: {
+          // Japanese prerendered (non-ascii)
+          slug: '事前レンダリング',
+        },
+      },
     ],
     fallback: 'blocking', // false or "blocking"
   }

--- a/tests/fixtures/page-router/pages/products/[slug].js
+++ b/tests/fixtures/page-router/pages/products/[slug].js
@@ -32,8 +32,8 @@ export const getStaticPaths = () => {
       },
       {
         params: {
-          // Japanese prerendered (non-ascii)
-          slug: '事前レンダリング',
+          // Japanese prerendered (non-ascii) and comma
+          slug: '事前レンダリング,test',
         },
       },
     ],

--- a/tests/fixtures/server-components/app/api/on-demand-revalidate/path/route.ts
+++ b/tests/fixtures/server-components/app/api/on-demand-revalidate/path/route.ts
@@ -3,10 +3,19 @@ import { revalidatePath } from 'next/cache'
 
 export async function GET(request: NextRequest) {
   const url = new URL(request.url)
-  const pathToRevalidate = url.searchParams.get('path') ?? '/static-fetch/[id]/page'
+  let pathToRevalidate = url.searchParams.get('path')
+
+  if (pathToRevalidate) {
+    pathToRevalidate = encodeURI(pathToRevalidate)
+  } else {
+    pathToRevalidate = '/static-fetch/[id]/page'
+  }
 
   revalidatePath(pathToRevalidate)
-  return NextResponse.json({ revalidated: true, now: new Date().toISOString() })
+  return NextResponse.json({
+    revalidated: true,
+    now: new Date().toISOString(),
+  })
 }
 
 export const dynamic = 'force-dynamic'

--- a/tests/fixtures/server-components/app/api/on-demand-revalidate/path/route.ts
+++ b/tests/fixtures/server-components/app/api/on-demand-revalidate/path/route.ts
@@ -3,19 +3,10 @@ import { revalidatePath } from 'next/cache'
 
 export async function GET(request: NextRequest) {
   const url = new URL(request.url)
-  let pathToRevalidate = url.searchParams.get('path')
-
-  if (pathToRevalidate) {
-    pathToRevalidate = encodeURI(pathToRevalidate)
-  } else {
-    pathToRevalidate = '/static-fetch/[id]/page'
-  }
+  const pathToRevalidate = url.searchParams.get('path') ?? '/static-fetch/[id]/page'
 
   revalidatePath(pathToRevalidate)
-  return NextResponse.json({
-    revalidated: true,
-    now: new Date().toISOString(),
-  })
+  return NextResponse.json({ revalidated: true, now: new Date().toISOString() })
 }
 
 export const dynamic = 'force-dynamic'

--- a/tests/fixtures/server-components/app/api/purge-cdn/route.ts
+++ b/tests/fixtures/server-components/app/api/purge-cdn/route.ts
@@ -15,7 +15,7 @@ export async function GET(request: NextRequest) {
     )
   }
   try {
-    await purgeCache({ tags: [`_N_T_${pathToPurge}`] })
+    await purgeCache({ tags: [`_N_T_${encodeURI(pathToPurge)}`] })
     return NextResponse.json(
       {
         status: 'ok',

--- a/tests/fixtures/server-components/app/product/[slug]/page.js
+++ b/tests/fixtures/server-components/app/product/[slug]/page.js
@@ -1,6 +1,6 @@
 const Product = ({ params }) => (
   <div>
-    <h1>Product {decodeURI(params.slug)}</h1>
+    <h1>Product {decodeURIComponent(params.slug)}</h1>
     <p>
       This page uses generateStaticParams() to prerender a Product
       <span data-testid="date-now">{new Date().toISOString()}</span>
@@ -11,8 +11,8 @@ const Product = ({ params }) => (
 export async function generateStaticParams() {
   return [
     {
-      // Japanese prerendered (non-ascii)
-      slug: '事前レンダリング',
+      // Japanese prerendered (non-ascii) and comma
+      slug: '事前レンダリング,test',
     },
   ]
 }

--- a/tests/fixtures/server-components/app/product/[slug]/page.js
+++ b/tests/fixtures/server-components/app/product/[slug]/page.js
@@ -1,0 +1,20 @@
+const Product = ({ params }) => (
+  <div>
+    <h1>Product {decodeURI(params.slug)}</h1>
+    <p>
+      This page uses generateStaticParams() to prerender a Product
+      <span data-testid="date-now">{new Date().toISOString()}</span>
+    </p>
+  </div>
+)
+
+export async function generateStaticParams() {
+  return [
+    {
+      // Japanese prerendered (non-ascii)
+      slug: '事前レンダリング',
+    },
+  ]
+}
+
+export default Product

--- a/tests/integration/cache-handler.test.ts
+++ b/tests/integration/cache-handler.test.ts
@@ -46,6 +46,7 @@ describe('page router', () => {
       // the real key is much longer and ends in a hash, but we only assert on the first 50 chars to make it easier
       '/products/an-incredibly-long-product-',
       '/products/prerendered',
+      '/products/事前レンダリング',
       '/static/revalidate-automatic',
       '/static/revalidate-manual',
       '/static/revalidate-slow',

--- a/tests/integration/cache-handler.test.ts
+++ b/tests/integration/cache-handler.test.ts
@@ -360,6 +360,7 @@ describe('plugin', () => {
       '/api/static/first',
       '/api/static/second',
       '/index',
+      '/product/事前レンダリング',
       '/revalidate-fetch',
       '/static-fetch-1',
       '/static-fetch-2',

--- a/tests/integration/cache-handler.test.ts
+++ b/tests/integration/cache-handler.test.ts
@@ -46,7 +46,7 @@ describe('page router', () => {
       // the real key is much longer and ends in a hash, but we only assert on the first 50 chars to make it easier
       '/products/an-incredibly-long-product-',
       '/products/prerendered',
-      '/products/事前レンダリング',
+      '/products/事前レンダリング,te',
       '/static/revalidate-automatic',
       '/static/revalidate-manual',
       '/static/revalidate-slow',
@@ -360,7 +360,7 @@ describe('plugin', () => {
       '/api/static/first',
       '/api/static/second',
       '/index',
-      '/product/事前レンダリング',
+      '/product/事前レンダリング,test',
       '/revalidate-fetch',
       '/static-fetch-1',
       '/static-fetch-2',

--- a/tests/integration/static.test.ts
+++ b/tests/integration/static.test.ts
@@ -37,7 +37,7 @@ test<FixtureTestContext>('requesting a non existing page route that needs to be 
   expect(entries.map(({ key }) => decodeBlobKey(key.substring(0, 50))).sort()).toEqual([
     '/products/an-incredibly-long-product-',
     '/products/prerendered',
-    '/products/事前レンダリング',
+    '/products/事前レンダリング,te',
     '/static/revalidate-automatic',
     '/static/revalidate-manual',
     '/static/revalidate-slow',

--- a/tests/integration/static.test.ts
+++ b/tests/integration/static.test.ts
@@ -37,6 +37,7 @@ test<FixtureTestContext>('requesting a non existing page route that needs to be 
   expect(entries.map(({ key }) => decodeBlobKey(key.substring(0, 50))).sort()).toEqual([
     '/products/an-incredibly-long-product-',
     '/products/prerendered',
+    '/products/事前レンダリング',
     '/static/revalidate-automatic',
     '/static/revalidate-manual',
     '/static/revalidate-slow',


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/netlify/next-runtime/blob/main/CONTRIBUTING.md. -->

## Description

Fixes https://linear.app/netlify/issue/FRB-1352/handle-non-ascii-characters-in-cache-tag-headers

Handles non ASCII characters in cache-tag headers by URI encoding them (does not encode / or valid characters just the non ASCII ones)

### Documentation

<!-- Where is this feature or API documented? Did you create an internal and/or external artifact to document this change? -->

## Tests

Added e2e test case for cacheable page router pages with non-ascii paths

1. TODO

## Relevant links (GitHub issues, etc.) or a picture of cute animal

<!-- Link to an issue that is fixed by this PR or related to this PR. -->
