### PR TITLE
ci: fix next.js repo tests workflow for 13.5.1

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -93,7 +93,8 @@ jobs:
 
   e2e:
     needs: setup
-    runs-on: ubuntu-latest
+    # `playwright install` fails on Ubuntu 24.04+ with older versions of playwright (which 13.5.1 has)
+    runs-on: "${{ matrix.version_spec.selector == '13.5.1' && 'ubuntu-22.04' || 'ubuntu-latest' }}"
     name: Test next@${{ matrix.version_spec.selector }} group ${{ matrix.group }}/${{ needs.setup.outputs.total }}
     timeout-minutes: 120
     strategy:


### PR DESCRIPTION
The latest Ubuntu (24.04) doesn't work out of the box with older versions of playwright.

next@latest and next@canary have been updated: https://github.com/vercel/next.js/pull/71312.

13.5.1 has not been, so let's keep using 22.04 just for that