### PR TITLE
ci: fix test-e2e workflow

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -183,6 +183,7 @@ jobs:
       - name: Prepare Netlify CLI
         # Control netlify-cli as a regular dev dep but expose it globally for test fixtures to use
         run: npm install -g "netlify-cli@$(npm list --json --depth=0 netlify-cli | jq -r ".dependencies[\"netlify-cli\"].version")"
+        working-directory: ${{ env.runtime-path }}
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps


### PR DESCRIPTION
Since it doesn't run on all PRs, I didn't notice it needed a slightly different config when I changed this in https://github.com/netlify/next-runtime/pull/2673.

This workflow checks out next-runtime in one directory and next.js in another, so we need to specify a working directory.