### PR TITLE
ci: don't use next's github releases as source of most recent stable/canary versions

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -74,19 +74,11 @@ jobs:
             if [ "${VERSION_SPEC}" != "[" ]; then
               VERSION_SPEC+=","
             fi
-            VERSION_SPEC+="{\"selector\":\"$SELECTOR\""
 
-            if [ "$SELECTOR" == "latest" ]; then
-              VERSION_SPEC+=",\"tag\":\"$(curl -s https://api.github.com/repos/vercel/next.js/releases/latest | jq -r .tag_name)\""
-            elif [ "$SELECTOR" == "canary" ]; then
-              VERSION_SPEC+=",\"tag\":\"$(curl -s https://api.github.com/repos/vercel/next.js/releases | jq -r '.[] | select(.prerelease == true) | .tag_name' | head -n 1)\""
-            else
-              VERSION_SPEC+=",\"tag\":\"v$SELECTOR\""
-            fi
+            VERSION=$(npm view next@$SELECTOR version)
+            TAG="v$VERSION"
 
-            VERSION_SPEC+=",\"version\":\"$(npm view next@$SELECTOR version)\""
-
-            VERSION_SPEC+="}"
+            VERSION_SPEC+="{\"selector\":\"$SELECTOR\",\"tag\":\"$TAG\",\"version\":\"$VERSION\"}"
           done
           VERSION_SPEC+="]"
           echo "version_spec=$VERSION_SPEC" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Description

Our setup to run Vercel's tests seems to no longer work as expected now that `rc` version is not marked as "prerelease" in Github Releases (we are relying on `prerelease` status of Github release to select git tag for `latest` and `canary` right now).

See https://github.com/netlify/next-runtime/actions/runs/11432475420/job/31803013304 which is supposed to run against `latest` but it checks out following git tag `note: switching to 'refs/tags/v15.0.0-rc.1'.` and later tries to install swc binaries for actual stable ( `pnpm add --workspace-root @next/swc-linux-x64-gnu@14.2.15`) so we might have some problems caused by version mismatch that our current setup is producing.

This changes so we use `npm` as sole source of truth and construct git tag from it instead (basically now git tag is `v$(npm info next@<version_selector>)`) and we don't check github releases at all now.

I triggered workflow manually from my branch - https://github.com/netlify/next-runtime/actions/runs/11437943131 and it seems to work correctly there (also added `rc` selector for this manual run - we might want to add it to our daily runs?)