### PR TITLE
ci: use includePrerelease flag for version checks

### DIFF
--- a/tests/utils/next-version-helpers.mjs
+++ b/tests/utils/next-version-helpers.mjs
@@ -21,7 +21,7 @@ export function nextVersionSatisfies(condition) {
   const isSemverVersion = valid(version)
   const checkVersion = isSemverVersion ? version : FUTURE_NEXT_PATCH_VERSION
 
-  return satisfies(checkVersion, condition) || version === condition
+  return satisfies(checkVersion, condition, { includePrerelease: true }) || version === condition
 }
 
 /**


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/netlify/next-runtime/blob/main/CONTRIBUTING.md. -->

## Description

New canaries (i.e. `15.0.1-canary.1`) are not matching on our version constraints that use prerelease selector like `nextVersionSatisfies('>=15.0.0-canary.187')` right now - see https://github.com/netlify/next-runtime/actions/runs/11454176059/job/31867886319 - this adjust version constraint check to allow those to match by using `includePrerelease` flag ( see https://www.npmjs.com/package/semver#prerelease-tags )

### Documentation

<!-- Where is this feature or API documented? Did you create an internal and/or external artifact to document this change? -->

## Tests

<!-- Did you add tests? How did you test this change? -->

You can test this change yourself like so:

1. TODO

## Relevant links (GitHub issues, etc.) or a picture of cute animal

<!-- Link to an issue that is fixed by this PR or related to this PR. -->
